### PR TITLE
Serve Discord avatars and emojis from the CDN directly

### DIFF
--- a/src/app-routes.ts
+++ b/src/app-routes.ts
@@ -40,8 +40,6 @@ export const routes = [
 	defRoute('/layer-data.json', [], 'custom'),
 	defRoute('/check-auth', [], 'custom'),
 
-	defRoute('/discord-cdn/*', ['*'], 'custom'),
-
 	defRoute('/orpc', [], 'custom', { websocket: true }),
 	// server agents authenticate with a per-server token, not a session cookie, so this route is unauthed and
 	// validates the token itself (see server-agent.server.ts)

--- a/src/models/discord.models.ts
+++ b/src/models/discord.models.ts
@@ -2,6 +2,8 @@ import * as EMO from '@/models/emoji.models'
 import type * as D from 'discord.js'
 import { z } from 'zod'
 
+export const CDN_BASE = 'https://cdn.discordapp.com'
+
 export function toNormalizedEmoji(emoji: D.GuildEmoji): EMO.DiscordEmoji {
 	return {
 		id: EMO.createDiscordEmojiId(emoji.id),

--- a/src/models/users.models.ts
+++ b/src/models/users.models.ts
@@ -1,5 +1,5 @@
 import type * as SchemaModels from '$root/drizzle/schema.models'
-import * as AR from '@/app-routes'
+import * as DM from '@/models/discord.models'
 import { z } from 'zod'
 
 export const GuiUserIdSchema = z.object({
@@ -61,9 +61,9 @@ export const UserIdSchema = z.bigint().positive()
 export type UserId = z.infer<typeof UserIdSchema>
 
 export const getAvatarUrl = (user: User) => {
-	if (user.avatar) return AR.link('/discord-cdn/*', `avatars/${user.discordId}/${user.avatar}.png`)
+	if (user.avatar) return `${DM.CDN_BASE}/avatars/${user.discordId}/${user.avatar}.png`
 	const id = ((user.discordId >> 22n) % 6n).toString()
-	return AR.link('/discord-cdn/*', `embed/avatars/${id}.png`)
+	return `${DM.CDN_BASE}/embed/avatars/${id}.png`
 }
 
 export const getUserInitials = (user: User) => {

--- a/src/systems/discord.client.ts
+++ b/src/systems/discord.client.ts
@@ -1,4 +1,4 @@
-import * as AR from '@/app-routes'
+import * as DM from '@/models/discord.models'
 import * as EMO from '@/models/emoji.models'
 import * as RPC from '@/orpc.client'
 import { useQuery } from '@tanstack/react-query'
@@ -26,5 +26,5 @@ export function useEmoji(id: string | undefined, opts?: { enabled?: boolean }) {
 }
 
 export function getEmojiUrl(emoji: Extract<EMO.Emoji, { type: 'discord' }>, size: number = 32): string {
-	return AR.link('/discord-cdn/*', `emojis/${EMO.parseDiscordEmojiId(emoji.id)}.webp?size=${size}`)
+	return `${DM.CDN_BASE}/emojis/${EMO.parseDiscordEmojiId(emoji.id)}.webp?size=${size}`
 }

--- a/src/systems/fastify.server.ts
+++ b/src/systems/fastify.server.ts
@@ -31,7 +31,6 @@ import fastifyWebsocket from '@fastify/websocket'
 import * as Otel from '@opentelemetry/api'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import fastify from 'fastify'
-import { Readable } from 'node:stream'
 import type { WebSocket } from 'ws'
 
 const BASE_HEADERS = {
@@ -193,59 +192,6 @@ export const setup = C.spanOp('setup', { module }, async () => {
 			return ctx.res.status(401).send({ error: 'Unauthorized' })
 		}
 		return res.status(200).send({ status: 'ok' })
-	})
-
-	// Discord CDN proxy - streams responses without buffering
-	instance.get(AR.route('/discord-cdn/*'), async (req, res) => {
-		try {
-			// Extract the path after /cdn-proxy/
-			const url = req.url.replace(/^\/discord-cdn\//, '')
-			const cdnUrl = `https://cdn.discordapp.com/${url}`
-
-			log.trace('Proxying request to Discord CDN: %s', cdnUrl)
-
-			// Fetch from Discord CDN
-			const cdnResponse = await fetch(cdnUrl, { signal: getPatchedCtx(req).signal })
-
-			if (!cdnResponse.ok) {
-				log.warn('Discord CDN returned error: %d for %s', cdnResponse.status, cdnUrl)
-				return res.status(cdnResponse.status).send({ error: 'CDN request failed' })
-			}
-
-			// Forward relevant headers from Discord CDN response
-			const headersToForward = [
-				'content-type',
-				'content-length',
-				'cache-control',
-				'etag',
-				'last-modified',
-				'expires',
-				'content-disposition',
-				'content-encoding',
-			]
-
-			for (const header of headersToForward) {
-				const value = cdnResponse.headers.get(header)
-				if (value) {
-					res.header(header, value)
-				}
-			}
-
-			// Add CORS headers
-			res.header('Access-Control-Allow-Origin', '*')
-			res.header('Access-Control-Allow-Methods', 'GET')
-
-			// Stream the response using Node.js stream from Web Stream
-			if (cdnResponse.body) {
-				const nodeStream = Readable.fromWeb(cdnResponse.body as any)
-				return res.send(nodeStream)
-			}
-
-			return res.send('')
-		} catch (err) {
-			log.error('Error proxying to Discord CDN: %s', err)
-			return res.status(500).send({ error: 'Failed to proxy request' })
-		}
 	})
 
 	const authedCtxCreatedAt = new Map<FastifyRequest['id'], number>()


### PR DESCRIPTION
Removes the `/discord-cdn/*` proxy route so avatar and emoji URLs point at `cdn.discordapp.com` directly.

## Why

The proxy was unconditional and unauthenticated. The route was registered above the auth wall in `fastify.server.ts` (before `getAuthedCtx`), and its handler pasted any request path onto `https://cdn.discordapp.com/`, so it also worked as an open relay for arbitrary Discord CDN paths rather than just the avatars it existed to serve.

## COEP interaction (the reason the proxy may have existed)

The app sets `Cross-Origin-Embedder-Policy: credentialless` in `BASE_HEADERS` (`fastify.server.ts`) and in the vite dev server config, to get cross-origin isolation for `SharedArrayBuffer` (sqlocal + the layer query worker, which asserts on it). Routing avatars through a same-origin proxy makes them immune to COEP entirely, which is a plausible original motivation.

Discord's CDN sends **no `Cross-Origin-Resource-Policy` header** (only `access-control-allow-origin: *`). Verified in-browser against the live CDN, serving the app's exact policy:

| App COEP | Discord avatar | `crossOriginIsolated` |
|---|---|---|
| `credentialless` (current) | loads (256x256) | `true` |
| `require-corp` | blocked | `true` |

Under `credentialless`, `<img>` loads are no-cors, sent without credentials, and exempt from the CORP requirement, so they pass. Cross-origin isolation and `SharedArrayBuffer` are unaffected either way, so the wasm engine keeps working.

**Tradeoff this commits us to:** because Discord sends no CORP, dropping the proxy pins the app to `credentialless`. Tightening COEP to `require-corp` later would silently break every avatar and emoji. `credentialless` already provides the isolation sqlocal needs, so there is no current reason to tighten it, but it is now a real constraint.

Also note user browsers now contact Discord directly when loading avatars, where previously the server fronted those requests.

## Changes

- `discord.models.ts` — new `CDN_BASE` constant, shared by both callers
- `users.models.ts` — `getAvatarUrl` builds direct URLs
- `discord.client.ts` — `getEmojiUrl` builds direct URLs (this caller was easy to miss; the route was not avatars-only)
- `app-routes.ts` / `fastify.server.ts` — route definition and proxy handler removed, along with the now-unused `Readable` import

## Verification

`tsc -b --force` and `oxlint --type-aware` both clean. Discord CDN image load confirmed in a real browser under `COEP: credentialless` (see table above). The dropped CORS headers on the old proxy are not needed, since these load via `<img>` tags.

## Note for review

`/discord-cdn/*` was a public URL surface. Nothing in this repo still references it, but if anything outside the repo links to it, those links now 404 — a 302 redirect shim would be the compatible alternative if that is a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)