### PR TITLE
Rework the permissions dialog's simulation controls

### DIFF
--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -43,7 +43,7 @@ const EXPLORE_LAYERS_FRAME_INSTANCE_ID = 'explore-layers'
 export default function NavBar() {
 	const flags = FeatureFlags.useFeatureFlags()
 	const wsStatus = RPC.useConnectStatus()
-	const { simulateRoles, setSimulateRoles } = ZusUtils.useStore(RbacClient.RbacStore)
+	const { simulate, setSimulate } = ZusUtils.useStore(RbacClient.RbacStore)
 	const user = useLoggedInUser()
 
 	const avatarUrl = user && USR.getAvatarUrl(user)
@@ -114,10 +114,10 @@ export default function NavBar() {
 	const userMenuContent = user && (
 		<>
 			<DropdownMenuLabel className="truncate max-w-50">{user.displayName}</DropdownMenuLabel>
-			{simulateRoles && (
-				<DropdownMenuItem onClick={() => setSimulateRoles(false)} className="sm:hidden text-sm">
+			{simulate && (
+				<DropdownMenuItem onClick={() => setSimulate(false)} className="sm:hidden text-sm">
 					<Icons.X className="mr-2 h-4 w-4" />
-					Stop Simulating Roles
+					Stop Simulating
 				</DropdownMenuItem>
 			)}
 			{wsStatus === 'closed' && (
@@ -239,10 +239,10 @@ export default function NavBar() {
 			</div>
 			<ExploreLayersDialog open={exploreLayersOpen} onOpenChange={setExploreLayersOpen} />
 			<div className="flex h-max min-h-0 flex-row items-center space-x-1 sm:space-x-3 overflow-hidden">
-				{simulateRoles && (
+				{simulate && (
 					<div className="hidden sm:flex items-center space-x-1 shrink-0">
-						<span className="text-sm font-medium">Simulating Roles</span>{' '}
-						<Button size="icon" variant="ghost" onClick={() => setSimulateRoles(false)}>
+						<span className="text-sm font-medium">Simulating</span>{' '}
+						<Button size="icon" variant="ghost" onClick={() => setSimulate(false)}>
 							<Icons.X className="h-4 w-4" />
 						</Button>
 					</div>

--- a/src/components/user-permissions-dialog.tsx
+++ b/src/components/user-permissions-dialog.tsx
@@ -148,6 +148,7 @@ export default function UserPermissionsDialog(
 		enablePerm,
 	} = ZusUtils.useStore(RbacClient.RbacStore)
 	const allRoles = RbacClient.useUserDefinedRoles().data
+	const myRoles = RbacClient.useMyRoles().data
 	const simulatableRoles = RbacClient.useSimulatableRoles().data
 
 	const basePerms = userBase?.perms
@@ -161,12 +162,23 @@ export default function UserPermissionsDialog(
 				: [],
 		[basePerms, simulate, addedRoles],
 	)
-	const permissionsByRole = React.useMemo(() => basePerms ? RBAC.getPermissionsByRole(basePerms) : [], [basePerms])
+	// the roles the user holds, each with the permissions it grants them. Roles come from myRoles rather than from the
+	// permission traces, so that a role granting nothing still shows up as one they hold. The inferred roles
+	// (filter-owner and friends) exist only in the traces, so both sources are merged
+	const heldRoles = React.useMemo(() => {
+		if (!basePerms) return []
+		const byRole = new Map(RBAC.getPermissionsByRole(basePerms).map(([role, perms]) => [JSON.stringify(role), { role, perms }]))
+		for (const role of myRoles ?? []) {
+			const key = JSON.stringify(role)
+			if (!byRole.has(key)) byRole.set(key, { role, perms: [] })
+		}
+		return [...byRole.values()]
+	}, [basePerms, myRoles])
 	const unheldRoles = React.useMemo(() => {
-		if (!allRoles || !basePerms) return []
-		const held = new Set(basePerms.flatMap(p => p.allowedByRoles.map(r => r.type)))
+		if (!allRoles || !myRoles) return []
+		const held = new Set(myRoles.map(r => r.type))
 		return allRoles.filter(role => !held.has(role.type))
-	}, [allRoles, basePerms])
+	}, [allRoles, myRoles])
 	const unheldPermTypes = React.useMemo(() => {
 		if (!basePerms) return []
 		const held = new Set(basePerms.map(p => p.type))
@@ -314,7 +326,7 @@ export default function UserPermissionsDialog(
 
 					<TabsContent value="roles" className="flex-1 overflow-auto">
 						<div className="space-y-6">
-							{permissionsByRole.map(([role, perms]) => (
+							{heldRoles.map(({ role, perms }) => (
 								<RoleSection
 									key={JSON.stringify(role)}
 									role={role}

--- a/src/components/user-permissions-dialog.tsx
+++ b/src/components/user-permissions-dialog.tsx
@@ -8,6 +8,7 @@ import * as RbacClient from '@/systems/rbac.client'
 import * as UsersClient from '@/systems/users.client'
 import React from 'react'
 import { Badge } from './ui/badge'
+import { Button } from './ui/button'
 import { Checkbox } from './ui/checkbox'
 import { Label } from './ui/label'
 import { Switch } from './ui/switch'
@@ -73,6 +74,8 @@ function RoleBadge(props: { role: RBAC.Role; simulate: boolean; enabled: boolean
 	)
 }
 
+const PERMS_SHOWN_COLLAPSED = 5
+
 function RoleSection(props: {
 	role: RBAC.Role
 	perms: RBAC.TracedPermission[]
@@ -82,6 +85,10 @@ function RoleSection(props: {
 	onToggle: (enabled: boolean) => void
 	isPermActive: (perm: RBAC.Permission) => boolean
 }) {
+	const [showAll, setShowAll] = React.useState(false)
+	const shownPerms = showAll ? props.perms : props.perms.slice(0, PERMS_SHOWN_COLLAPSED)
+	const hiddenCount = props.perms.length - shownPerms.length
+
 	return (
 		<div className={cn('border rounded-lg p-4 space-y-3', !props.enabled && 'opacity-50 bg-muted/30')}>
 			<div className="flex items-center justify-between">
@@ -105,7 +112,7 @@ function RoleSection(props: {
 
 			{props.enabled && (
 				<div className="space-y-2">
-					{props.perms.map((perm) => (
+					{shownPerms.map((perm) => (
 						<div
 							key={permKey(perm)}
 							className={cn(
@@ -123,6 +130,16 @@ function RoleSection(props: {
 							<Badge variant="outline" className="text-xs">{formatPermissionScope(perm)}</Badge>
 						</div>
 					))}
+					{(hiddenCount > 0 || showAll) && (
+						<Button
+							variant="link"
+							size="sm"
+							className="h-auto p-0 text-xs"
+							onClick={() => setShowAll(!showAll)}
+						>
+							{showAll ? 'Show fewer' : `...see all ${props.perms.length}`}
+						</Button>
+					)}
 				</div>
 			)}
 		</div>
@@ -228,10 +245,10 @@ export default function UserPermissionsDialog(
 					<DialogDescription>View your current permissions and roles</DialogDescription>
 				</DialogHeader>
 
-				<div className="flex items-center space-x-2 p-4 border rounded-lg bg-muted/50">
+				<div className="flex items-center space-x-3 p-4 border rounded-lg bg-muted/50">
 					<Switch checked={simulate} onCheckedChange={setSimulate} id={simulateId} />
-					<Label htmlFor={simulateId} className="text-sm font-medium">Simulate</Label>
-					<span className="text-xs text-muted-foreground">
+					<Label htmlFor={simulateId} className="text-sm font-medium shrink-0">Simulate</Label>
+					<span className="text-xs text-muted-foreground text-balance leading-relaxed">
 						Toggle roles and permissions to see how the site behaves without them. You can only simulate losing access, never gaining it.
 					</span>
 				</div>

--- a/src/components/user-permissions-dialog.tsx
+++ b/src/components/user-permissions-dialog.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils'
 import * as ZusUtils from '@/lib/zustand'
 import * as RBAC from '@/rbac.models'
 import * as RbacClient from '@/systems/rbac.client'
-import { useLoggedInUser, useLoggedInUserBase } from '@/systems/users.client'
+import * as UsersClient from '@/systems/users.client'
 import React from 'react'
 import { Badge } from './ui/badge'
 import { Checkbox } from './ui/checkbox'
@@ -14,18 +14,168 @@ import { Switch } from './ui/switch'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs'
 
+function formatPermissionScope(perm: RBAC.Permission) {
+	if (perm.scope === 'global') return 'Global'
+	if (perm.scope === 'filter' && perm.args && 'filterId' in perm.args) {
+		return `Filter: ${perm.args.filterId}`
+	}
+	return perm.scope
+}
+
+function formatRoleName(role: RBAC.Role) {
+	if (!RBAC.isInferredRoleType(role)) return role.type
+
+	if (role.type === 'filter-role-contributor') {
+		return `${role.type}: (${role.filterId}, ${role.roleId})`
+	}
+	if (role.type === 'filter-user-contributor') {
+		return `${role.type}: (${role.filterId})`
+	}
+	if (role.type === 'filter-owner') {
+		return `${role.type}: (${role.filterId})`
+	}
+
+	assertNever(role)
+}
+
+function getPermissionDescription(permType: string) {
+	return RBAC.PERMISSION_DEFINITION[permType as keyof typeof RBAC.PERMISSION_DEFINITION]?.description || permType
+}
+
+function permKey(perm: RBAC.Permission & Partial<RBAC.PermissionTrace>) {
+	return `${perm.type}:${perm.scope}:${JSON.stringify(perm.args ?? null)}:${perm.negating ? 'negating' : ''}`
+}
+
+function NegationBadges(props: { perm: RBAC.TracedPermission }) {
+	return (
+		<>
+			{props.perm.negated && <Badge variant="destructive" className="text-xs">negated</Badge>}
+			{props.perm.negating && <Badge variant="outline" className="text-xs border-orange-500 text-orange-700">negating</Badge>}
+		</>
+	)
+}
+
+// the role a permission is attributed to. Deselectable while simulating, which drops every permission this role is the
+// last enabled grantor of
+function RoleBadge(props: { role: RBAC.Role; simulate: boolean; enabled: boolean; onToggle: (enabled: boolean) => void }) {
+	if (!props.simulate) {
+		return <Badge variant="secondary" className="text-xs">{formatRoleName(props.role)}</Badge>
+	}
+	return (
+		<button type="button" onClick={() => props.onToggle(!props.enabled)}>
+			<Badge
+				variant={props.enabled ? 'secondary' : 'outline'}
+				className={cn('text-xs cursor-pointer hover:opacity-80', !props.enabled && 'line-through text-muted-foreground')}
+			>
+				{formatRoleName(props.role)}
+			</Badge>
+		</button>
+	)
+}
+
+function RoleSection(props: {
+	role: RBAC.Role
+	perms: RBAC.TracedPermission[]
+	enabled: boolean
+	simulate: boolean
+	checkboxId: string
+	onToggle: (enabled: boolean) => void
+	isPermActive: (perm: RBAC.Permission) => boolean
+}) {
+	return (
+		<div className={cn('border rounded-lg p-4 space-y-3', !props.enabled && 'opacity-50 bg-muted/30')}>
+			<div className="flex items-center justify-between">
+				<div className="flex items-center space-x-3">
+					{props.simulate && (
+						<Checkbox
+							id={props.checkboxId}
+							checked={props.enabled}
+							onCheckedChange={(checked) => props.onToggle(checked === true)}
+						/>
+					)}
+					<div>
+						<Label htmlFor={props.checkboxId} className="font-semibold">{formatRoleName(props.role)}</Label>
+						<p className="text-sm text-muted-foreground">
+							{props.perms.length} permission{props.perms.length !== 1 ? 's' : ''}
+						</p>
+					</div>
+				</div>
+				{props.simulate && !props.enabled && <Badge variant="secondary">Disabled</Badge>}
+			</div>
+
+			{props.enabled && (
+				<div className="space-y-2">
+					{props.perms.map((perm) => (
+						<div
+							key={permKey(perm)}
+							className={cn(
+								'flex items-start justify-between p-2 bg-muted/50 rounded text-sm',
+								props.simulate && !perm.negating && !props.isPermActive(perm) && 'opacity-50',
+							)}
+						>
+							<div className="space-y-1">
+								<div className="flex items-center gap-2">
+									<NegationBadges perm={perm} />
+									<div className="font-mono">{perm.type}</div>
+								</div>
+								<div className="text-muted-foreground">{getPermissionDescription(perm.type)}</div>
+							</div>
+							<Badge variant="outline" className="text-xs">{formatPermissionScope(perm)}</Badge>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	)
+}
+
 export default function UserPermissionsDialog(
 	props: { children: React.ReactNode; open?: boolean; onOpenChange?: (newState: boolean) => void },
 ) {
-	const userBase = useLoggedInUserBase()
-	const user = useLoggedInUser()
-	const { simulateRoles, disabledRoles, enableRole, disableRole, setSimulateRoles } = ZusUtils.useStore(RbacClient.RbacStore)
+	const userBase = UsersClient.useLoggedInUserBase()
+	const user = UsersClient.useLoggedInUser()
+	const {
+		simulate,
+		setSimulate,
+		disabledRoles,
+		enableRole,
+		disableRole,
+		addedRoles,
+		addRole,
+		removeRole,
+		disabledPerms,
+		disablePerm,
+		enablePerm,
+	} = ZusUtils.useStore(RbacClient.RbacStore)
+	const allRoles = RbacClient.useUserDefinedRoles().data
+	const simulatableRoles = RbacClient.useSimulatableRoles().data
 
-	// Group permissions by role
-	const permissionsByRole = React.useMemo(() => user?.perms ? RBAC.getPermissionsByRole(user.perms) : undefined, [user?.perms])
-	const setSimulateRoleId = React.useId()
+	const basePerms = userBase?.perms
+	// every permission on offer: the user's own, plus the ones roles they've opted into would attribute to those roles.
+	// Built from the base perms so that switching something off never removes the row carrying the control that switches
+	// it back on
+	const shownPerms = React.useMemo(
+		() =>
+			basePerms
+				? UsersClient.simulatePerms(basePerms, { disabledRoles: [], addedRoles: simulate ? addedRoles : [], disabledPerms: [] })
+				: [],
+		[basePerms, simulate, addedRoles],
+	)
+	const permissionsByRole = React.useMemo(() => basePerms ? RBAC.getPermissionsByRole(basePerms) : [], [basePerms])
+	const unheldRoles = React.useMemo(() => {
+		if (!allRoles || !basePerms) return []
+		const held = new Set(basePerms.flatMap(p => p.allowedByRoles.map(r => r.type)))
+		return allRoles.filter(role => !held.has(role.type))
+	}, [allRoles, basePerms])
+	const unheldPermTypes = React.useMemo(() => {
+		if (!basePerms) return []
+		const held = new Set(basePerms.map(p => p.type))
+		return RBAC.PERMISSION_TYPE.options.filter(type => !held.has(type))
+	}, [basePerms])
 
-	if (!userBase || !user || !permissionsByRole) {
+	const simulateId = React.useId()
+
+	if (!userBase || !user) {
 		return (
 			<Dialog open={props.open} onOpenChange={props.onOpenChange}>
 				<DialogTrigger asChild>
@@ -44,33 +194,18 @@ export default function UserPermissionsDialog(
 		)
 	}
 
-	const formatPermissionScope = (perm: RBAC.TracedPermission) => {
-		if (perm.scope === 'global') return 'Global'
-		if (perm.scope === 'filter' && perm.args && 'filterId' in perm.args) {
-			return `Filter: ${perm.args.filterId}`
-		}
-		return perm.scope
+	const isRoleEnabled = (role: RBAC.Role) => !simulate || !disabledRoles.some(r => Obj.deepEqual(r, role))
+	const isPermDisabled = (perm: RBAC.Permission) => disabledPerms.some(p => RBAC.isSamePerm(p, perm))
+	const getSimulatableRole = (role: RBAC.Role) => simulatableRoles?.find(r => Obj.deepEqual(r.role, role))
+	// granted under whatever simulation is currently in effect
+	const isPermActive = (perm: RBAC.Permission) => user.perms.some(p => RBAC.isSamePerm(p, perm) && !p.negated)
+
+	const toggleRole = (role: RBAC.Role, enabled: boolean) => {
+		if (enabled) enableRole(role)
+		else disableRole(role)
 	}
 
-	const formatRoleName = (role: RBAC.Role) => {
-		if (!RBAC.isInferredRoleType(role)) return role.type
-
-		if (role.type === 'filter-role-contributor') {
-			return `${role.type}: (${role.filterId}, ${role.roleId})`
-		}
-		if (role.type === 'filter-user-contributor') {
-			return `${role.type}: (${role.filterId})`
-		}
-		if (role.type === 'filter-owner') {
-			return `${role.type}: (${role.filterId})`
-		}
-
-		assertNever(role)
-	}
-
-	const getPermissionDescription = (permType: string) => {
-		return RBAC.PERMISSION_DEFINITION[permType as keyof typeof RBAC.PERMISSION_DEFINITION]?.description || permType
-	}
+	const activePermCount = user.perms.filter(p => !p.negated && !p.negating).length
 
 	return (
 		<Dialog modal open={props.open} onOpenChange={props.onOpenChange}>
@@ -81,6 +216,14 @@ export default function UserPermissionsDialog(
 					<DialogDescription>View your current permissions and roles</DialogDescription>
 				</DialogHeader>
 
+				<div className="flex items-center space-x-2 p-4 border rounded-lg bg-muted/50">
+					<Switch checked={simulate} onCheckedChange={setSimulate} id={simulateId} />
+					<Label htmlFor={simulateId} className="text-sm font-medium">Simulate</Label>
+					<span className="text-xs text-muted-foreground">
+						Toggle roles and permissions to see how the site behaves without them. You can only simulate losing access, never gaining it.
+					</span>
+				</div>
+
 				<Tabs defaultValue="roles" className="flex-1 overflow-hidden flex flex-col">
 					<TabsList className="grid w-full grid-cols-2">
 						<TabsTrigger value="roles">By Role</TabsTrigger>
@@ -90,12 +233,13 @@ export default function UserPermissionsDialog(
 					<TabsContent value="permissions" className="flex-1 overflow-auto">
 						<div className="space-y-4">
 							<div className="text-sm text-muted-foreground">
-								You have {userBase.perms.length} permission{userBase.perms.length !== 1 ? 's' : ''}
+								You have {activePermCount} permission{activePermCount !== 1 ? 's' : ''}
 							</div>
 
 							<Table>
 								<TableHeader>
 									<TableRow>
+										{simulate && <TableHead className="w-8" />}
 										<TableHead>Permission</TableHead>
 										<TableHead>Description</TableHead>
 										<TableHead>Scope</TableHead>
@@ -103,35 +247,41 @@ export default function UserPermissionsDialog(
 									</TableRow>
 								</TableHeader>
 								<TableBody>
-									{user.perms.map((perm) => {
-										const permKey = `${perm.type}:${perm.scope}:${perm.negated ? 'neg' : ''}`
+									{shownPerms.map((perm) => {
+										// a negating permission is what takes access away, so switching it off could only grant access
+										const canToggle = simulate && !perm.negating
+										const checkboxId = 'simulate-perm-checkbox-' + permKey(perm)
 										return (
-											<TableRow key={permKey}>
+											<TableRow key={permKey(perm)} className={cn(simulate && !perm.negating && !isPermActive(perm) && 'opacity-50')}>
+												{simulate && (
+													<TableCell>
+														{canToggle && (
+															<Checkbox
+																id={checkboxId}
+																checked={!isPermDisabled(perm)}
+																onCheckedChange={(checked) => checked ? enablePerm(perm) : disablePerm(perm)}
+															/>
+														)}
+													</TableCell>
+												)}
 												<TableCell className="font-mono text-sm">
 													<div className="flex items-center gap-2">
-														{perm.negated && (
-															<Badge variant="destructive" className="text-xs">
-																Negated
-															</Badge>
-														)}
-														{perm.negating && (
-															<Badge variant="outline" className="text-xs border-orange-500 text-orange-700">
-																Negating
-															</Badge>
-														)}
-														{perm.type}
+														<NegationBadges perm={perm} />
+														<Label htmlFor={checkboxId}>{perm.type}</Label>
 													</div>
 												</TableCell>
-												<TableCell>
-													{getPermissionDescription(perm.type)}
-												</TableCell>
+												<TableCell>{getPermissionDescription(perm.type)}</TableCell>
 												<TableCell>{formatPermissionScope(perm)}</TableCell>
 												<TableCell>
 													<div className="flex flex-wrap gap-1">
 														{perm.allowedByRoles.map((role) => (
-															<Badge key={JSON.stringify(role)} variant="secondary" className="text-xs">
-																{formatRoleName(role)}
-															</Badge>
+															<RoleBadge
+																key={JSON.stringify(role)}
+																role={role}
+																simulate={simulate}
+																enabled={isRoleEnabled(role)}
+																onToggle={(enabled) => toggleRole(role, enabled)}
+															/>
 														))}
 													</div>
 												</TableCell>
@@ -140,100 +290,88 @@ export default function UserPermissionsDialog(
 									})}
 								</TableBody>
 							</Table>
+
+							<section className="space-y-2">
+								<h3 className="text-sm font-semibold">Permissions you don't have</h3>
+								{unheldPermTypes.length === 0
+									? <p className="text-sm text-muted-foreground">You have every permission.</p>
+									: (
+										<div className="space-y-1">
+											{unheldPermTypes.map((permType) => (
+												<div key={permType} className="flex items-start justify-between p-2 rounded text-sm opacity-60 bg-muted/30">
+													<div className="space-y-1">
+														<div className="font-mono">{permType}</div>
+														<div className="text-muted-foreground">{getPermissionDescription(permType)}</div>
+													</div>
+													<Badge variant="outline" className="text-xs">{RBAC.PERMISSION_DEFINITION[permType].scope}</Badge>
+												</div>
+											))}
+										</div>
+									)}
+							</section>
 						</div>
 					</TabsContent>
 
 					<TabsContent value="roles" className="flex-1 overflow-auto">
-						<div className="space-y-4">
-							<div className="flex items-center space-x-2 p-4 border rounded-lg bg-muted/50">
-								<Switch
-									checked={simulateRoles}
-									onCheckedChange={setSimulateRoles}
-									id={setSimulateRoleId}
+						<div className="space-y-6">
+							{permissionsByRole.map(([role, perms]) => (
+								<RoleSection
+									key={JSON.stringify(role)}
+									role={role}
+									perms={perms}
+									enabled={isRoleEnabled(role)}
+									simulate={simulate}
+									checkboxId={'simulate-role-checkbox-' + JSON.stringify(role)}
+									onToggle={(enabled) => toggleRole(role, enabled)}
+									isPermActive={isPermActive}
 								/>
-								<label htmlFor={setSimulateRoleId} className="text-sm font-medium">
-									Simulate roles
-								</label>
-								<span className="text-xs text-muted-foreground">
-									Toggle roles to see how your permissions would change. You can only simulate losing roles, not gaining roles that you
-									don't already have.
-								</span>
-							</div>
+							))}
 
-							<div className="space-y-6">
-								{permissionsByRole.map(([role, perms]) => {
-									const isRoleEnabled = !simulateRoles || !disabledRoles.some(r => Obj.deepEqual(r, role))
-
-									const checkboxId = 'simulate-role-checkbox-' + JSON.stringify(role)
+							<section className="space-y-3">
+								<div>
+									<h3 className="text-sm font-semibold">Roles you don't have</h3>
+									<p className="text-xs text-muted-foreground">
+										A role can be simulated when everything it grants is already covered by your own permissions.
+									</p>
+								</div>
+								{unheldRoles.length === 0 && <p className="text-sm text-muted-foreground">You have every role.</p>}
+								{unheldRoles.map((role) => {
+									const simulatable = getSimulatableRole(role)
+									const added = !!simulatable && addedRoles.some(a => Obj.deepEqual(a.role, role))
+									const checkboxId = 'add-role-checkbox-' + JSON.stringify(role)
+									if (simulatable && added) {
+										return (
+											<RoleSection
+												key={JSON.stringify(role)}
+												role={role}
+												perms={simulatable.perms}
+												enabled={isRoleEnabled(role)}
+												simulate={simulate}
+												checkboxId={checkboxId}
+												onToggle={() => removeRole(role)}
+												isPermActive={isPermActive}
+											/>
+										)
+									}
 									return (
-										<div
-											key={JSON.stringify(role)}
-											className={cn(
-												'border rounded-lg p-4 space-y-3',
-												!isRoleEnabled && simulateRoles && 'opacity-50 bg-muted/30',
-											)}
-										>
-											<div className="flex items-center justify-between">
-												<div className="flex items-center space-x-3">
-													{simulateRoles && (
-														<Checkbox
-															id={checkboxId}
-															checked={isRoleEnabled}
-															onCheckedChange={(checked) => checked ? enableRole(role) : disableRole(role)}
-														/>
-													)}
-													<div>
-														<Label htmlFor={checkboxId} className="font-semibold">{formatRoleName(role)}</Label>
-														<p className="text-sm text-muted-foreground">
-															{perms.length} permission{perms.length !== 1 ? 's' : ''}
-														</p>
-													</div>
-												</div>
-												{simulateRoles && !isRoleEnabled && (
-													<Badge variant="secondary">
-														Disabled
-													</Badge>
+										<div key={JSON.stringify(role)} className="flex items-center justify-between border rounded-lg p-4 bg-muted/30">
+											<div className="flex items-center space-x-3">
+												{simulate && simulatable && (
+													<Checkbox
+														id={checkboxId}
+														checked={false}
+														onCheckedChange={() => addRole(simulatable)}
+													/>
 												)}
+												<Label htmlFor={checkboxId} className={cn('font-semibold', !simulatable && 'text-muted-foreground')}>
+													{formatRoleName(role)}
+												</Label>
 											</div>
-
-											{isRoleEnabled && (
-												<div className="space-y-2">
-													{perms.map((perm) => {
-														const permKey = `${perm.type}:${perm.scope}:${perm.negated ? 'neg' : ''}`
-														return (
-															<div key={permKey} className="flex items-start justify-between p-2 bg-muted/50 rounded text-sm">
-																<div className="space-y-1">
-																	<div className="flex items-center gap-2">
-																		{perm.negated && (
-																			<Badge variant="destructive" className="text-xs">
-																				negated
-																			</Badge>
-																		)}
-																		{perm.negating && (
-																			<Badge variant="outline" className="text-xs border-orange-500 text-orange-700">
-																				negating
-																			</Badge>
-																		)}
-																		<div className="font-mono">
-																			{perm.type}
-																		</div>
-																	</div>
-																	<div className="text-muted-foreground">
-																		{getPermissionDescription(perm.type)}
-																	</div>
-																</div>
-																<Badge variant="outline" className="text-xs">
-																	{formatPermissionScope(perm)}
-																</Badge>
-															</div>
-														)
-													})}
-												</div>
-											)}
+											{!simulatable && <Badge variant="outline" className="text-xs">Grants permissions you don't have</Badge>}
 										</div>
 									)
 								})}
-							</div>
+							</section>
 						</div>
 					</TabsContent>
 				</Tabs>

--- a/src/rbac.models.test.ts
+++ b/src/rbac.models.test.ts
@@ -90,3 +90,54 @@ describe('settings access aggregation', () => {
 		expect(RBAC.settingsPathAllowed(access, ['queue', 'mainPool'])).toBe(false)
 	})
 })
+
+describe('permSubsumedBy', () => {
+	it('global perms match on identity', () => {
+		expect(RBAC.permSubsumedBy(RBAC.perm('vote:manage'), [RBAC.perm('vote:manage')])).toBe(true)
+		expect(RBAC.permSubsumedBy(RBAC.perm('vote:manage'), [RBAC.perm('queue:write')])).toBe(false)
+		expect(RBAC.permSubsumedBy(RBAC.perm('vote:manage'), [])).toBe(false)
+	})
+
+	it('filter-scoped perms match on their args', () => {
+		expect(RBAC.permSubsumedBy(RBAC.perm('filters:write', { filterId: 'f1' }), [RBAC.perm('filters:write', { filterId: 'f1' })])).toBe(true)
+		expect(RBAC.permSubsumedBy(RBAC.perm('filters:write', { filterId: 'f1' }), [RBAC.perm('filters:write', { filterId: 'f2' })])).toBe(
+			false,
+		)
+	})
+
+	it('timeouts are subsumed by an equal or longer grant', () => {
+		expect(RBAC.permSubsumedBy(timeoutPerm(60_000), [timeoutPerm(600_000)])).toBe(true)
+		expect(RBAC.permSubsumedBy(timeoutPerm(60_000), [timeoutPerm(60_000)])).toBe(true)
+		expect(RBAC.permSubsumedBy(timeoutPerm(600_000), [timeoutPerm(60_000)])).toBe(false)
+		expect(RBAC.permSubsumedBy(timeoutPerm(600_000), [timeoutPerm(null)])).toBe(true)
+		// unlimited is only subsumed by unlimited
+		expect(RBAC.permSubsumedBy(timeoutPerm(null), [timeoutPerm(600_000)])).toBe(false)
+		expect(RBAC.permSubsumedBy(timeoutPerm(60_000), [])).toBe(false)
+	})
+
+	it('settings path grants are subsumed by any covering prefix', () => {
+		const restricted = [RBAC.perm('global-settings:write', { paths: ['queue'] })]
+		expect(RBAC.permSubsumedBy(RBAC.perm('global-settings:write', { paths: ['queue.mainPool'] }), restricted)).toBe(true)
+		expect(RBAC.permSubsumedBy(RBAC.perm('global-settings:write', { paths: ['queue', 'vote'] }), restricted)).toBe(false)
+		// an unrestricted grant is only subsumed by another unrestricted one
+		expect(RBAC.permSubsumedBy(RBAC.perm('global-settings:write', { paths: null }), restricted)).toBe(false)
+		expect(
+			RBAC.permSubsumedBy(RBAC.perm('global-settings:write', { paths: null }), [RBAC.perm('global-settings:write', { paths: null })]),
+		).toBe(true)
+	})
+
+	it('server settings grants respect both server id and paths', () => {
+		const perms = [RBAC.perm('server-settings:write', { serverId: 's1', paths: ['queue'] })]
+		expect(RBAC.permSubsumedBy(RBAC.perm('server-settings:write', { serverId: 's1', paths: ['queue.mainPool'] }), perms)).toBe(true)
+		expect(RBAC.permSubsumedBy(RBAC.perm('server-settings:write', { serverId: 's2', paths: ['queue'] }), perms)).toBe(false)
+		expect(RBAC.permSubsumedBy(RBAC.perm('server-settings:write', { serverId: 's1', paths: ['vote'] }), perms)).toBe(false)
+		// an all-servers grant needs an all-servers grant behind it, not a per-server one
+		expect(RBAC.permSubsumedBy(RBAC.perm('server-settings:write', { serverId: null, paths: ['queue'] }), perms)).toBe(false)
+		expect(
+			RBAC.permSubsumedBy(RBAC.perm('server-settings:read', { serverId: null }), [RBAC.perm('server-settings:read', { serverId: 's1' })]),
+		).toBe(false)
+		expect(
+			RBAC.permSubsumedBy(RBAC.perm('server-settings:read', { serverId: 's1' }), [RBAC.perm('server-settings:read', { serverId: null })]),
+		).toBe(true)
+	})
+})

--- a/src/rbac.models.ts
+++ b/src/rbac.models.ts
@@ -366,6 +366,12 @@ export function arePermsEqual(perm1: Permission & Partial<PermissionTrace>, perm
 	return Obj.deepEqual(perm1, perm2)
 }
 
+// matches on identity alone (type + scope + args). Unlike arePermsEqual this ignores negation state, which changes as
+// permission simulation is applied and so can't be part of a perm's identity.
+export function isSamePerm(perm1: Permission & Partial<PermissionTrace>, perm2: Permission & Partial<PermissionTrace>) {
+	return arePermsEqual(Obj.selectProps(perm1, ['args', 'scope', 'type']), Obj.selectProps(perm2, ['args', 'scope', 'type']))
+}
+
 export function getWritePermReqForFilterEntity(id: F.FilterEntityId): PermissionReq {
 	return {
 		check: 'any',
@@ -486,6 +492,58 @@ export function settingsPathOverlaps(access: SettingsWriteAccess, path: string |
 	if (access.kind === 'none') return false
 	const dotted = dottedSettingsPath(path)
 	return access.paths.some((p) => dotted === p || dotted.startsWith(p + '.') || p.startsWith(dotted + '.'))
+}
+
+// does `perms` already grant everything `perm` grants? The scoped permissions ("up to N ms", "these paths on these
+// servers") are comparators rather than equality matches, so they're covered scope-by-scope here.
+export function permSubsumedBy(perm: Permission, perms: Permission[]): boolean {
+	switch (perm.type) {
+		case 'squad-server:timeout-players': {
+			const args = perm.args as z.infer<(typeof PERM_SCOPE_ARGS)['timeout']> | undefined
+			const max = maxTimeoutDurationMs(perms)
+			if (max === undefined) return false
+			if (max === null) return true
+			if (!args || args.maxDurationMs === null) return false
+			return args.maxDurationMs <= max
+		}
+		case 'global-settings:write': {
+			const args = perm.args as GlobalWriteArgs | undefined
+			return pathsCoveredBy(args ? args.paths : null, globalSettingsWriteAccess(perms))
+		}
+		case 'server-settings:read':
+		case 'server-settings:write-sensitive': {
+			const serverId = (perm.args as ServerScopeArgs | undefined)?.serverId ?? null
+			// an all-servers grant can only be covered by another all-servers grant
+			if (serverId === null) {
+				return perms.some((p) => p.type === perm.type && ((p.args as ServerScopeArgs | undefined)?.serverId ?? null) === null)
+			}
+			return perm.type === 'server-settings:read'
+				? canReadServerSettings(perms, serverId)
+				: canWriteSensitiveServerSettings(perms, serverId)
+		}
+		case 'server-settings:write': {
+			const args = perm.args as ServerWriteArgs | undefined
+			const serverId = args?.serverId ?? null
+			if (serverId === null) {
+				const allServerPathSets = perms.flatMap((p) => {
+					if (p.type !== 'server-settings:write') return []
+					const pArgs = p.args as ServerWriteArgs | undefined
+					return (pArgs?.serverId ?? null) === null ? [pArgs?.paths ?? null] : []
+				})
+				return pathsCoveredBy(args ? args.paths : null, collectWriteAccess(allServerPathSets))
+			}
+			return pathsCoveredBy(args ? args.paths : null, serverSettingsWriteAccess(perms, serverId))
+		}
+		default:
+			return perms.some((p) => arePermsEqual(p, perm))
+	}
+}
+
+// null paths = unrestricted, so only an unrestricted grant covers it
+function pathsCoveredBy(paths: string[] | null, access: SettingsWriteAccess): boolean {
+	if (access.kind === 'all') return true
+	if (access.kind === 'none' || paths === null) return false
+	return paths.every((path) => settingsPathAllowed(access, path))
 }
 
 export function getPermissionsByRole(permissions: TracedPermission[]): [Role, TracedPermission[]][] {

--- a/src/systems/rbac.client.tsx
+++ b/src/systems/rbac.client.tsx
@@ -52,6 +52,11 @@ export function useUserDefinedRoles() {
 	return useQuery(RPC.orpc.rbac.getUserDefinedRoles.queryOptions())
 }
 
+// the user's own roles. Can't be derived from their permissions' traces, since a role granting nothing appears in none
+export function useMyRoles() {
+	return useQuery(RPC.orpc.rbac.getMyRoles.queryOptions())
+}
+
 // roles the user doesn't hold but may simulate holding, along with the permissions each would grant
 export type SimulatableRole = { role: RBAC.Role; perms: RBAC.TracedPermission[] }
 export function useSimulatableRoles() {

--- a/src/systems/rbac.client.tsx
+++ b/src/systems/rbac.client.tsx
@@ -52,32 +52,61 @@ export function useUserDefinedRoles() {
 	return useQuery(RPC.orpc.rbac.getUserDefinedRoles.queryOptions())
 }
 
+// roles the user doesn't hold but may simulate holding, along with the permissions each would grant
+export type SimulatableRole = { role: RBAC.Role; perms: RBAC.TracedPermission[] }
+export function useSimulatableRoles() {
+	return useQuery(RPC.orpc.rbac.getSimulatableRoles.queryOptions())
+}
+
+// simulation can only ever narrow what the user can do: roles and permissions may be switched off, and roles may only
+// be switched on when the server has vouched that they grant nothing the user doesn't already have.
 export type RbacStore = {
-	simulateRoles: boolean
-	setSimulateRoles: (simulateRoles: boolean) => void
+	simulate: boolean
+	setSimulate: (simulate: boolean) => void
 	disabledRoles: RBAC.Role[]
 	disableRole: (role: RBAC.Role) => void
 	enableRole: (role: RBAC.Role) => void
+	// simulatable roles the user has opted into, carrying the perms the server attributed to them
+	addedRoles: SimulatableRole[]
+	addRole: (added: SimulatableRole) => void
+	removeRole: (role: RBAC.Role) => void
+	// permissions switched off individually, independent of the roles granting them
+	disabledPerms: RBAC.Permission[]
+	disablePerm: (perm: RBAC.Permission) => void
+	enablePerm: (perm: RBAC.Permission) => void
 }
 
 export const RbacStore = Zus.createStore<RbacStore>((set, get) => ({
-	simulateRoles: false,
-	setSimulateRoles: (simulateRoles: boolean) => {
-		set({ simulateRoles })
-		if (!simulateRoles) {
-			set({ disabledRoles: [] })
+	simulate: false,
+	setSimulate: (simulate: boolean) => {
+		if (!simulate) {
+			set({ simulate, disabledRoles: [], addedRoles: [], disabledPerms: [] })
+			return
 		}
+		set({ simulate })
 	},
 
 	disabledRoles: [],
 	disableRole: (roleToDisable) => {
 		const disabledRoles = get().disabledRoles
-		for (const roleToCompare of disabledRoles) {
-			if (Obj.deepEqual(roleToDisable, roleToCompare)) {
-				return
-			}
-		}
+		if (disabledRoles.some(r => Obj.deepEqual(roleToDisable, r))) return
 		set({ disabledRoles: [...disabledRoles, roleToDisable] })
 	},
 	enableRole: (role) => set({ disabledRoles: get().disabledRoles.filter(r => !Obj.deepEqual(r, role)) }),
+
+	addedRoles: [],
+	addRole: (added) => {
+		const addedRoles = get().addedRoles
+		if (addedRoles.some(a => Obj.deepEqual(a.role, added.role))) return
+		set({ addedRoles: [...addedRoles, added], disabledRoles: get().disabledRoles.filter(r => !Obj.deepEqual(r, added.role)) })
+	},
+	removeRole: (role) => set({ addedRoles: get().addedRoles.filter(a => !Obj.deepEqual(a.role, role)) }),
+
+	disabledPerms: [],
+	disablePerm: (perm) => {
+		const disabledPerms = get().disabledPerms
+		if (disabledPerms.some(p => RBAC.isSamePerm(p, perm))) return
+		set({ disabledPerms: [...disabledPerms, Obj.selectProps(perm, ['type', 'scope', 'args'])] })
+	},
+	enablePerm: (perm) => set({ disabledPerms: get().disabledPerms.filter(p => !RBAC.isSamePerm(p, perm)) }),
 }))

--- a/src/systems/rbac.server.ts
+++ b/src/systems/rbac.server.ts
@@ -360,6 +360,16 @@ export const orpcRouter = {
 		return userDefinedRoles
 	}),
 
+	// the caller's own roles. Not derivable from their permissions' traces: a role granting nothing appears in no trace,
+	// but is still a role they hold
+	getMyRoles: orpcBase.handler(async ({ context: _ctx }) => {
+		const ctx = DB.addPooledDb(_ctx as any) as C.Db & C.UserId
+		const roles = await getRolesForDiscordUser(ctx)
+		// matches how the super bootstrap attributes its grants in getUserRbacPerms
+		if (await isSuperUser(ctx)) return [SUPER_ROLE, ...roles]
+		return roles
+	}),
+
 	// roles the caller doesn't hold but whose permissions they already hold anyway, so the permissions dialog can offer
 	// them for simulation. Returning the role's traced perms lets the client attribute its own perms to the simulated
 	// role without granting anything: a role is only offered when every permission it grants is subsumed by the caller's.
@@ -372,8 +382,9 @@ export const orpcRouter = {
 		for (const role of userDefinedRoles) {
 			if (heldRoles.has(role.type)) continue
 			const perms = permsFromRoleConfigs([role])
+			// a role granting nothing (or only negations) is vacuously subsumed, and simulating it is still meaningful:
+			// its negations take access away
 			const granted = RBAC.fromTracedPermissions(perms)
-			if (granted.length === 0) continue
 			if (!granted.every((p) => RBAC.permSubsumedBy(p, userPerms))) continue
 			simulatable.push({ role, perms })
 		}

--- a/src/systems/rbac.server.ts
+++ b/src/systems/rbac.server.ts
@@ -129,6 +129,82 @@ export const getRolesForDiscordUser = C.spanOp(
 	},
 )
 
+// the permissions a set of roles grants purely from their rbac settings config. Negations only apply within the given
+// set, which is what lets a single role be evaluated in isolation (see getSimulatableRoles).
+function permsFromRoleConfigs(roles: RBAC.Role[]): RBAC.TracedPermission[] {
+	const perms: RBAC.TracedPermission[] = []
+	const allNegatingPerms: Set<RBAC.RoleGrantablePermissionType> = new Set()
+
+	for (const role of roles) {
+		for (const permExpr of userDefinedPermissionExpressions[role.type] ?? []) {
+			const perm = RBAC.parseNegatingPermissionType(permExpr)
+			if (!perm) continue
+			allNegatingPerms.add(perm)
+			perms.push(RBAC.tracedPerm(perm, [role], { negated: true, negating: true }, RBAC.unrestrictedRoleGrantArgs(perm)))
+		}
+	}
+
+	const isNegated = (perm: RBAC.PermissionType) => allNegatingPerms.has(perm as RBAC.RoleGrantablePermissionType)
+
+	for (const role of roles) {
+		if ((userDefinedPermissionExpressions[role.type] ?? []).includes('*')) {
+			for (const permType of RBAC.ROLE_GRANTABLE_PERMISSION_TYPE.options) {
+				perms.push(
+					RBAC.tracedPerm(permType, [role], { negated: allNegatingPerms.has(permType) }, RBAC.unrestrictedRoleGrantArgs(permType)),
+				)
+			}
+		}
+		for (const permExpr of userDefinedPermissionExpressions[role.type] ?? []) {
+			if (!RBAC.isRoleGrantablePermissionType(permExpr)) continue
+			RBAC.addTracedPerms(
+				perms,
+				RBAC.tracedPerm(permExpr, [role], { negated: allNegatingPerms.has(permExpr) }, RBAC.unrestrictedRoleGrantArgs(permExpr)),
+			)
+		}
+		if (roleMaxTimeouts[role.type] !== undefined) {
+			RBAC.addTracedPerms(
+				perms,
+				RBAC.tracedPerm('squad-server:timeout-players', [role], {}, { maxDurationMs: roleMaxTimeouts[role.type] }),
+			)
+		}
+		// restricted settings grants; a matching negation in any role's expressions wins over these too
+		const globalPaths = roleGlobalSettingsGrants[role.type]
+		if (globalPaths && globalPaths.length > 0) {
+			RBAC.addTracedPerms(
+				perms,
+				RBAC.tracedPerm('global-settings:write', [role], { negated: isNegated('global-settings:write') }, { paths: [...globalPaths] }),
+			)
+		}
+		for (const grant of roleServerSettingsGrants[role.type] ?? []) {
+			const serverIds: (string | null)[] = grant.serverIds.length > 0 ? grant.serverIds : [null]
+			for (const serverId of serverIds) {
+				if (grant.access === 'read') {
+					RBAC.addTracedPerms(
+						perms,
+						RBAC.tracedPerm('server-settings:read', [role], { negated: isNegated('server-settings:read') }, { serverId }),
+					)
+				} else if (grant.access === 'write') {
+					RBAC.addTracedPerms(
+						perms,
+						RBAC.tracedPerm('server-settings:write', [role], { negated: isNegated('server-settings:write') }, {
+							serverId,
+							paths: grant.paths.length > 0 ? [...grant.paths] : null,
+						}),
+					)
+				} else {
+					RBAC.addTracedPerms(
+						perms,
+						RBAC.tracedPerm('server-settings:write-sensitive', [role], { negated: isNegated('server-settings:write-sensitive') }, {
+							serverId,
+						}),
+					)
+				}
+			}
+		}
+	}
+	return perms
+}
+
 export const getUserRbacPerms = C.spanOp(
 	'getUserRbacPerms',
 	{ module, levels: { event: 'trace' }, attrs: (ctx: C.UserId) => ({ [ATTRS.User.ID]: String(ctx.user.discordId) }) },
@@ -140,7 +216,6 @@ export const getUserRbacPerms = C.spanOp(
 		const filterRowsPromise = getFilterPermissionRows()
 
 		const perms: RBAC.TracedPermission[] = []
-		const allNegatingPerms: Set<RBAC.RoleGrantablePermissionType> = new Set()
 
 		// super users/roles are granted every role-grantable permission (unrestricted), overriding any negations.
 		// timeout grants are not expression-grantable, so the unlimited grant is added explicitly
@@ -153,75 +228,12 @@ export const getUserRbacPerms = C.spanOp(
 				RBAC.tracedPerm('squad-server:timeout-players', [SUPER_ROLE], { negated: false }, { maxDurationMs: null }),
 			)
 		}
-		for (const role of roles) {
-			for (const permExpr of userDefinedPermissionExpressions[role.type]) {
-				const perm = RBAC.parseNegatingPermissionType(permExpr)
-				if (!perm) continue
-				allNegatingPerms.add(perm)
-				perms.push(RBAC.tracedPerm(perm, [role], { negated: true, negating: true }, RBAC.unrestrictedRoleGrantArgs(perm)))
-			}
+
+		for (const rolePerm of permsFromRoleConfigs(roles)) {
+			RBAC.addTracedPerms(perms, rolePerm)
 		}
 
-		const isNegated = (perm: RBAC.PermissionType) => allNegatingPerms.has(perm as RBAC.RoleGrantablePermissionType)
-
-		for (const role of roles) {
-			if (userDefinedPermissionExpressions[role.type].includes('*')) {
-				for (const permType of RBAC.ROLE_GRANTABLE_PERMISSION_TYPE.options) {
-					perms.push(
-						RBAC.tracedPerm(permType, [role], { negated: allNegatingPerms.has(permType) }, RBAC.unrestrictedRoleGrantArgs(permType)),
-					)
-				}
-			}
-			for (const permExpr of userDefinedPermissionExpressions[role.type]) {
-				if (!RBAC.isRoleGrantablePermissionType(permExpr)) continue
-				RBAC.addTracedPerms(
-					perms,
-					RBAC.tracedPerm(permExpr, [role], { negated: allNegatingPerms.has(permExpr) }, RBAC.unrestrictedRoleGrantArgs(permExpr)),
-				)
-			}
-			if (roleMaxTimeouts[role.type] !== undefined) {
-				RBAC.addTracedPerms(
-					perms,
-					RBAC.tracedPerm('squad-server:timeout-players', [role], {}, { maxDurationMs: roleMaxTimeouts[role.type] }),
-				)
-			}
-			// restricted settings grants; a matching negation in any role's expressions wins over these too
-			const globalPaths = roleGlobalSettingsGrants[role.type]
-			if (globalPaths && globalPaths.length > 0) {
-				RBAC.addTracedPerms(
-					perms,
-					RBAC.tracedPerm('global-settings:write', [role], { negated: isNegated('global-settings:write') }, { paths: [...globalPaths] }),
-				)
-			}
-			for (const grant of roleServerSettingsGrants[role.type] ?? []) {
-				const serverIds: (string | null)[] = grant.serverIds.length > 0 ? grant.serverIds : [null]
-				for (const serverId of serverIds) {
-					if (grant.access === 'read') {
-						RBAC.addTracedPerms(
-							perms,
-							RBAC.tracedPerm('server-settings:read', [role], { negated: isNegated('server-settings:read') }, { serverId }),
-						)
-					} else if (grant.access === 'write') {
-						RBAC.addTracedPerms(
-							perms,
-							RBAC.tracedPerm('server-settings:write', [role], { negated: isNegated('server-settings:write') }, {
-								serverId,
-								paths: grant.paths.length > 0 ? [...grant.paths] : null,
-							}),
-						)
-					} else {
-						RBAC.addTracedPerms(
-							perms,
-							RBAC.tracedPerm('server-settings:write-sensitive', [role], { negated: isNegated('server-settings:write-sensitive') }, {
-								serverId,
-							}),
-						)
-					}
-				}
-			}
-		}
-
-		const negatedFiltersWrite = isNegated('filters:write')
+		const negatedFiltersWrite = perms.some((p) => p.negating && p.type === 'filters:write')
 		for (const row of await filterRowsPromise) {
 			const source: RBAC.TracedPermission['allowedByRoles'][number] = row.source === 'owner'
 				? { type: 'filter-owner', filterId: row.filterId }
@@ -346,6 +358,26 @@ export async function tryDenyAnyTimeoutGrant(
 export const orpcRouter = {
 	getUserDefinedRoles: orpcBase.handler(() => {
 		return userDefinedRoles
+	}),
+
+	// roles the caller doesn't hold but whose permissions they already hold anyway, so the permissions dialog can offer
+	// them for simulation. Returning the role's traced perms lets the client attribute its own perms to the simulated
+	// role without granting anything: a role is only offered when every permission it grants is subsumed by the caller's.
+	getSimulatableRoles: orpcBase.handler(async ({ context: _ctx }) => {
+		const ctx = DB.addPooledDb(_ctx as any) as C.Db & C.UserId
+		const userPerms = RBAC.fromTracedPermissions(await getUserRbacPerms(ctx))
+		const heldRoles = new Set((await getRolesForDiscordUser(ctx)).map((r) => r.type))
+
+		const simulatable: { role: RBAC.Role; perms: RBAC.TracedPermission[] }[] = []
+		for (const role of userDefinedRoles) {
+			if (heldRoles.has(role.type)) continue
+			const perms = permsFromRoleConfigs([role])
+			const granted = RBAC.fromTracedPermissions(perms)
+			if (granted.length === 0) continue
+			if (!granted.every((p) => RBAC.permSubsumedBy(p, userPerms))) continue
+			simulatable.push({ role, perms })
+		}
+		return simulatable
 	}),
 
 	// the env-configured SUPER_USERS/SUPER_ROLES bootstrap, surfaced read-only in the settings rbac section.

--- a/src/systems/users.client.ts
+++ b/src/systems/users.client.ts
@@ -58,22 +58,45 @@ export function useLoggedInUserBase() {
 
 // NOTE: this method of simulating perms will not work with actions that aren't validated client-side.
 export function useLoggedInUser() {
-	const { simulateRoles, disabledRoles } = ZusUtils.useStore(RbacClient.RbacStore)
+	const { simulate, disabledRoles, addedRoles, disabledPerms } = ZusUtils.useStore(RbacClient.RbacStore)
 	const loggedInUser = useLoggedInUserBase()
 
 	return React.useMemo(() => {
 		if (!loggedInUser) return undefined
-
-		if (!simulateRoles) return loggedInUser
-		const simulatedPerms = loggedInUser.perms.filter((p: RBAC.TracedPermission) =>
-			p.allowedByRoles.some((r) => !disabledRoles.some(toCompare => Obj.deepEqual(r, toCompare)))
-		)
+		if (!simulate) return loggedInUser
 
 		return {
 			...loggedInUser,
-			perms: RBAC.recalculateNegations(simulatedPerms),
+			perms: RBAC.recalculateNegations(
+				simulatePerms(loggedInUser.perms, { disabledRoles, addedRoles, disabledPerms }),
+			),
 		}
-	}, [loggedInUser, simulateRoles, disabledRoles])
+	}, [loggedInUser, simulate, disabledRoles, addedRoles, disabledPerms])
+}
+
+export type Simulation = {
+	disabledRoles: RBAC.Role[]
+	addedRoles: RbacClient.SimulatableRole[]
+	disabledPerms: RBAC.Permission[]
+}
+
+// the perms a simulation leaves the user with, before negations are recalculated. Added roles contribute perms the user
+// already holds, so the only thing they change on their own is which roles a perm is attributed to.
+export function simulatePerms(basePerms: RBAC.TracedPermission[], simulation: Simulation): RBAC.TracedPermission[] {
+	const isRoleDisabled = (role: RBAC.Role) => simulation.disabledRoles.some(disabled => Obj.deepEqual(role, disabled))
+
+	const perms: RBAC.TracedPermission[] = basePerms.map(p => ({ ...p, allowedByRoles: [...p.allowedByRoles] }))
+	for (const added of simulation.addedRoles) {
+		if (isRoleDisabled(added.role)) continue
+		for (const perm of added.perms) {
+			RBAC.addTracedPerms(perms, { ...perm, allowedByRoles: [...perm.allowedByRoles] })
+		}
+	}
+
+	return perms.filter(p =>
+		p.allowedByRoles.some(role => !isRoleDisabled(role))
+		&& !simulation.disabledPerms.some(disabled => RBAC.isSamePerm(disabled, p))
+	)
 }
 
 export async function fetchLoggedInUser() {


### PR DESCRIPTION
Reworks the user permissions dialog per the four requested changes.

## Changes

**One `Simulate` switch, above the tabs** (was a `Simulate roles` switch on the roles tab only). It now covers a reduction of both roles and permissions, and turning it off clears the whole simulation.

**Permissions tab**
- A checkbox per row switches that permission off on its own, independent of the roles granting it. Negating permissions have no checkbox: switching one off could only ever *grant* access.
- The role badges under "Granted By" are now buttons that deselect (and re-select) the role they name.
- The table is built from the user's real permissions rather than the simulated ones, so switching something off greys the row instead of removing it along with the control that switches it back on.
- Ends with a "Permissions you don't have" list.

**Roles tab**
- Ends with a "Roles you don't have" list. A role there can be selected when every permission it grants is already covered by the user's own permissions; the rest are greyed with a "Grants permissions you don't have" note.

## How selecting an unheld role stays safe

The new `rbac.getSimulatableRoles` endpoint decides this server-side and returns each offered role along with the permissions to attribute to it, so the client never sees (or invents) a grant the user doesn't already hold. Deciding it on the server also keeps role configs the user isn't covered by out of the response.

Subsumption is per-scope, since the scoped permissions are comparators rather than equality matches: a timeout grant is covered by an equal or longer one, a settings-path grant by any covering prefix on a covering server id, and an unrestricted (all-servers / all-paths) grant only by another unrestricted one. `RBAC.permSubsumedBy` carries this, covered by unit tests in `rbac.models.test.ts`.

To evaluate one role in isolation, the role-config half of `getUserRbacPerms` is extracted into `permsFromRoleConfigs(roles)`. Permissions granted by several roles now merge into one entry attributed to both, where the `*` expansion previously produced a duplicate entry per role.

No persisted data or config changes: the simulation state is in-memory only.

## Testing

`pnpm run check`, `pnpm run test` (411 pass), `pnpm run lint` all clean. Not exercised in a running app: the new endpoint means the dialog needs a backend built from this branch, and standing one up alongside the running dev instance would have contended with its database and live connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)