### PR TITLE
Improve the in-game command editing experience

### DIFF
--- a/src/components/commands-help-dialog.tsx
+++ b/src/components/commands-help-dialog.tsx
@@ -20,16 +20,16 @@ interface CommandsHelpDialogProps {
 	onOpenChange?: (open: boolean) => void
 }
 
-type TimeoutAlias = PublicSettings['timeoutCommandAliases'][number]
+type CommandAlias = PublicSettings['commandAliases'][number]
 
 // one listing in the help body, anchored by `id` so the table of contents can scroll it into view
 type Entry =
 	| { kind: 'command'; id: string; label: string; search: string; cmdId: CMD.CommandId; cmd: CMD.CommandConfig }
-	| { kind: 'alias'; id: string; label: string; search: string; alias: TimeoutAlias }
+	| { kind: 'alias'; id: string; label: string; search: string; alias: CommandAlias }
 
 type Section = { id: string; label: string; entries: Entry[] }
 
-const TIMEOUT_ALIASES_SECTION_ID = 'command-group:timeout-aliases'
+const ALIASES_SECTION_ID = 'command-group:aliases'
 
 // the reason arg (if any) for a command's args; drives the applicable-reasons listing
 function reasonArgOf(args: readonly CMD.ArgDef[]) {
@@ -108,14 +108,24 @@ function CommandEntry(
 	)
 }
 
+// an alias takes no arguments, so its listing is the shortcut itself, what it expands to, and (when the command it
+// points at is disabled or no longer exists) why it currently does nothing
 function AliasEntry(
 	{ entry, settings }: { entry: Extract<Entry, { kind: 'alias' }>; settings: PublicSettings },
 ) {
-	const cmdString = `${entry.alias.string} ${CMD.formatArgSignature(CMD.TIMEOUT_ALIAS_ARG_DEFS, settings.requireReasonFor)}`
+	const res = CMD.resolveAliasCommand(entry.alias.command, settings.commands)
+	const target = res.code === 'ok' ? settings.commands[res.cmdId] : undefined
+	const unusable = res.code !== 'ok' ? 'Unavailable' : !target!.enabled ? 'Disabled' : undefined
+	const chatScope = target?.scopes.includes('public') && !target.scopes.includes('admin') ? 'ChatToAll' : 'ChatToAdmin'
 	return (
 		<div id={entry.id} data-cmd-anchor className="space-y-1 scroll-mt-9">
-			<CopyableCommand cmdString={cmdString} chatScope="ChatToAdmin" />
-			<p className="text-sm text-muted-foreground">{Messages.GENERAL.command.timeoutAliasDescription(entry.alias.duration)}</p>
+			<div className="flex items-center gap-2">
+				<CopyableCommand cmdString={entry.alias.alias} chatScope={chatScope} />
+				{unusable && <Badge variant="destructive" className="text-xs">{unusable}</Badge>}
+			</div>
+			<p className="text-sm text-muted-foreground">{Messages.GENERAL.command.aliasDescription(entry.alias.command)}</p>
+			{res.code === 'ok' && <p className="text-sm text-muted-foreground">{Messages.GENERAL.command.descriptions[res.cmdId]}</p>}
+			{res.code === 'err:unknown-command' && <p className="text-sm text-destructive">{res.msg}</p>}
 		</div>
 	)
 }
@@ -176,15 +186,15 @@ export default function CommandsHelpDialog({ children, open, onOpenChange }: Com
 				}
 			}),
 		}))
-		if (settings.timeoutCommandAliases.length > 0) {
+		if (settings.commandAliases.length > 0) {
 			sections.push({
-				id: TIMEOUT_ALIASES_SECTION_ID,
-				label: 'Timeout Aliases',
-				entries: settings.timeoutCommandAliases.map((alias): Entry => ({
+				id: ALIASES_SECTION_ID,
+				label: 'Aliases',
+				entries: settings.commandAliases.map((alias): Entry => ({
 					kind: 'alias',
-					id: `timeout-alias:${alias.string}`,
-					label: alias.string,
-					search: `${alias.string} timeout alias kick`,
+					id: `alias:${alias.alias}`,
+					label: alias.alias,
+					search: `${alias.alias} ${alias.command} alias shortcut`.toLowerCase(),
 					alias,
 				})),
 			})
@@ -272,13 +282,11 @@ export default function CommandsHelpDialog({ children, open, onOpenChange }: Com
 						{visible.map((section) => (
 							<section key={section.id}>
 								<h3 className="sticky top-0 z-10 bg-background py-1 text-sm font-semibold">{section.label}</h3>
-								{section.id === TIMEOUT_ALIASES_SECTION_ID && (
-									<div className="space-y-2 pb-2">
-										<p className="text-sm text-muted-foreground">
-											Fixed-duration kick shortcuts, usable in admin chat only. Each kicks a player with its configured timeout.
-										</p>
-										<CommandReasons reasonArg={reasonArgOf(CMD.TIMEOUT_ALIAS_ARG_DEFS)!} reasons={settings.adminActionReasons} />
-									</div>
+								{section.id === ALIASES_SECTION_ID && (
+									<p className="pb-2 text-sm text-muted-foreground">
+										Shortcuts for complete commands. An alias takes no arguments of its own, and runs in the same chats as the command it
+										points at.
+									</p>
 								)}
 								<div className="space-y-4 pb-4">
 									{section.entries.map((entry) =>

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -7,6 +7,7 @@ import LayerTableConfigEditor from '@/components/layer-table-config-editor'
 import { GenerationPoolFiltersPanel, MainPoolFiltersPanel, RepeatRulesPanel } from '@/components/pool-config-panels'
 import type { PoolConfigApi } from '@/components/pool-config-panels.helpers'
 import { StickyGroup } from '@/components/sticky-group'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
@@ -22,7 +23,7 @@ import { useDebounced } from '@/hooks/use-debounce'
 import { createId } from '@/lib/id'
 import * as Obj from '@/lib/object'
 import type { SettingsGroup } from '@/lib/settings-groups'
-import { splitByGroups } from '@/lib/settings-groups'
+import { HIDDEN_GLOBAL_SETTINGS_KEYS, splitByGroups } from '@/lib/settings-groups'
 import { humanize, settingLabel } from '@/lib/settings-labels'
 import * as SettingsNav from '@/lib/settings-nav'
 import * as Templating from '@/lib/templating'
@@ -30,6 +31,7 @@ import { cn } from '@/lib/utils'
 import * as ZusUtils from '@/lib/zustand'
 import * as AAR from '@/models/admin-action-reasons.models'
 import type * as BM from '@/models/battlemetrics.models'
+import * as CMD from '@/models/command.models'
 import type * as LP from '@/models/labeled-presets.models'
 import * as LC from '@/models/layer-columns'
 import * as SETTINGS from '@/models/settings.models'
@@ -237,6 +239,10 @@ const FormOptionsContext = React.createContext<{ idPrefix: string }>({ idPrefix:
 // the whole settings document being edited, so a bespoke field can read a sibling it isn't scoped to (e.g. the admin
 // list sftp editor copying connection details from `connections.sftp`). Null when unset (e.g. tests).
 const RootValueContext = React.createContext<ValueState | null>(null)
+
+// the root document's onChange, so a bespoke field can write siblings it isn't scoped to. The command-prefix editor
+// uses it to propagate a prefix rename across every command string / timeout alias that uses that prefix.
+const RootOnChangeContext = React.createContext<((next: any) => void) | null>(null)
 
 // the user's write grant over the settings being edited; leaves outside it render dimmed + inert (see LeafField)
 const WRITE_ACCESS_ALL: RBAC.SettingsWriteAccess = { kind: 'all' }
@@ -496,6 +502,404 @@ function PlayerFlagGroupingsField({ value$, reset$, onChange }: OverrideProps) {
 		</div>
 	)
 }
+// -------- command prefixes editor --------
+
+// a small "?" affordance that reveals a longer explanation on hover, so compact editors can drop verbose inline descriptions
+function HelpTip({ text }: { text: string }) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button type="button" className="text-muted-foreground hover:text-foreground" aria-label="Help">
+					<Icons.CircleHelp className="h-3.5 w-3.5" />
+				</button>
+			</TooltipTrigger>
+			<TooltipContent className="max-w-xs">{text}</TooltipContent>
+		</Tooltip>
+	)
+}
+
+// which allowed prefix an inline command string uses: the longest one it starts with (so "!!" wins over "!")
+function prefixUsedBy(str: string, prefixes: string[]): string | undefined {
+	let best: string | undefined
+	for (const p of prefixes) if (p && str.startsWith(p) && (best === undefined || p.length > best.length)) best = p
+	return best
+}
+
+// re-point an inline string from `oldPrefix` to `newPrefix`
+function repointPrefix(str: string, oldPrefix: string, newPrefix: string): string {
+	return newPrefix + str.slice(oldPrefix.length)
+}
+
+type CommandsMap = Record<string, { strings?: string[] } | undefined>
+type AliasList = { alias: string; command: string }[]
+
+function mapCommandStrings(commands: CommandsMap, fn: (s: string) => string): CommandsMap {
+	const out: CommandsMap = {}
+	for (const [id, cmd] of Object.entries(commands)) out[id] = { ...cmd, strings: (cmd?.strings ?? []).map(fn) }
+	return out
+}
+
+// the command string an alias's expansion starts with (its remaining words are arguments, which carry no prefix)
+function aliasCommandWord(command: string): string {
+	return command.trim().split(/\s+/)[0] ?? ''
+}
+
+// re-points the leading command string of an alias's expansion, leaving its arguments and spacing untouched
+function repointCommandText(command: string, oldPrefix: string, newPrefix: string, prefixes: string[]): string {
+	const match = /^(\s*)(\S+)([\s\S]*)$/.exec(command)
+	if (!match || prefixUsedBy(match[2], prefixes) !== oldPrefix) return command
+	return match[1] + repointPrefix(match[2], oldPrefix, newPrefix) + match[3]
+}
+
+// one editable prefix. The char input is committed on blur/Enter (not per keystroke) because committing propagates a
+// rewrite across every string using it; re-seeded by remounting (its key includes the committed value).
+function PrefixRow(
+	{ index, prefix, isDefault, usage, onCommit, onSetDefault, onRemove }: {
+		index: number
+		prefix: string
+		isDefault: boolean
+		usage: number
+		onCommit: (next: string) => void
+		onSetDefault: () => void
+		onRemove: () => void
+	},
+) {
+	const [draft, setDraft] = React.useState(prefix)
+	const invalid = !CMD.isValidPrefix(draft.trim())
+	// discard an invalid edit on blur (reverting to the committed value) rather than propagating a bad prefix into every string
+	const commit = () => {
+		const next = draft.trim()
+		if (!CMD.isValidPrefix(next)) {
+			setDraft(prefix)
+			return
+		}
+		onCommit(next)
+	}
+	const removable = !isDefault && usage === 0
+	return (
+		<div className="flex items-center gap-2 rounded-md border px-2 py-1.5">
+			<span className="text-xs text-muted-foreground tabular-nums">#{index + 1}</span>
+			<Input
+				aria-label={`Prefix ${index + 1}`}
+				className={cn('h-7 w-16 font-mono text-sm', invalid && 'border-destructive focus-visible:ring-destructive')}
+				title={invalid ? CMD.PREFIX_ERROR : undefined}
+				value={draft}
+				onChange={(e) => setDraft(e.target.value)}
+				onBlur={commit}
+				onKeyDown={(e) => {
+					if (e.key === 'Enter') {
+						e.preventDefault()
+						e.currentTarget.blur()
+					}
+				}}
+			/>
+			<label className="flex items-center gap-1 text-xs text-muted-foreground">
+				<input type="radio" checked={isDefault} onChange={onSetDefault} aria-label={`Make prefix ${index + 1} the default`} />
+				Default
+			</label>
+			<span className="whitespace-nowrap text-xs text-muted-foreground">{usage} {usage === 1 ? 'use' : 'uses'}</span>
+			<Button
+				type="button"
+				size="icon"
+				variant="ghost"
+				className="h-6 w-6 shrink-0 text-destructive disabled:opacity-40"
+				aria-label={`Remove prefix ${index + 1}`}
+				disabled={!removable}
+				title={isDefault ? 'The default prefix cannot be removed' : usage > 0 ? `${usage} strings still use this prefix` : undefined}
+				onClick={onRemove}
+			>
+				<Icons.X className="h-4 w-4" />
+			</Button>
+		</div>
+	)
+}
+
+// bespoke editor for `allowedPrefixes`: prefixes are numbered so they have their own identity. Editing a prefix's
+// characters propagates the change to every command string and timeout alias that uses it; one prefix is marked the
+// default (new commands seed from it); a prefix in use can't be removed. Reads/writes siblings via the root contexts.
+function AllowedPrefixesField({ value$, reset$ }: OverrideProps) {
+	const root$ = React.useContext(RootValueContext) ?? EMPTY_ROOT_VALUE$
+	const rootOnChange = React.useContext(RootOnChangeContext)
+	const root = (useFieldValue(root$, reset$) as
+		| { defaultPrefix?: string; commands?: CommandsMap; commandAliases?: AliasList }
+		| undefined) ?? {}
+	const prefixes = (useFieldValue(value$, reset$) as string[] | undefined) ?? []
+	const commands = root.commands ?? {}
+	const aliases = root.commandAliases ?? []
+	const defaultPrefix = root.defaultPrefix ?? prefixes[0] ?? ''
+
+	const [newPrefix, setNewPrefix] = React.useState('')
+
+	function writeRoot(patch: Record<string, unknown>) {
+		const cur = (root$.getValue() as Record<string, unknown>) ?? {}
+		rootOnChange?.({ ...cur, ...patch })
+		reset$.next()
+	}
+
+	// an alias counts twice over: once for the shortcut, once for the command string it expands to
+	function usageOf(prefix: string): number {
+		let n = 0
+		for (const cmd of Object.values(commands)) for (const s of cmd?.strings ?? []) if (prefixUsedBy(s, prefixes) === prefix) n++
+		for (const a of aliases) {
+			if (prefixUsedBy(a.alias, prefixes) === prefix) n++
+			if (prefixUsedBy(aliasCommandWord(a.command), prefixes) === prefix) n++
+		}
+		return n
+	}
+
+	function commitEdit(idx: number, next: string) {
+		const oldPrefix = prefixes[idx]
+		if (!next || next === oldPrefix || !CMD.isValidPrefix(next)) return
+		const nextPrefixes = prefixes.map((p, i) => (i === idx ? next : p))
+		// target by the OLD prefix list so longest-match stays stable while rewriting
+		const nextCommands = mapCommandStrings(
+			commands,
+			(s) => (prefixUsedBy(s, prefixes) === oldPrefix ? repointPrefix(s, oldPrefix, next) : s),
+		)
+		const nextAliases = aliases.map((a) => ({
+			...a,
+			alias: prefixUsedBy(a.alias, prefixes) === oldPrefix ? repointPrefix(a.alias, oldPrefix, next) : a.alias,
+			command: repointCommandText(a.command, oldPrefix, next, prefixes),
+		}))
+		writeRoot({
+			allowedPrefixes: nextPrefixes,
+			commands: nextCommands,
+			commandAliases: nextAliases,
+			defaultPrefix: defaultPrefix === oldPrefix ? next : defaultPrefix,
+		})
+	}
+
+	const newTrimmed = newPrefix.trim()
+	const newInvalid = newTrimmed !== '' && !CMD.isValidPrefix(newTrimmed)
+	const newDuplicate = newTrimmed !== '' && prefixes.includes(newTrimmed)
+	function addPrefix() {
+		if (!newTrimmed || newInvalid || newDuplicate) return
+		writeRoot({ allowedPrefixes: [...prefixes, newTrimmed] })
+		setNewPrefix('')
+	}
+
+	function removePrefix(idx: number) {
+		const p = prefixes[idx]
+		if (p === defaultPrefix || usageOf(p) > 0) return
+		writeRoot({ allowedPrefixes: prefixes.filter((_, i) => i !== idx) })
+	}
+
+	return (
+		<div className="space-y-2">
+			<p className="text-xs text-muted-foreground">
+				Editing a prefix updates every command string and alias that uses it. The default prefix seeds new commands.
+			</p>
+			<div className="flex flex-wrap items-center gap-3">
+				{prefixes.map((p, idx) => (
+					<PrefixRow
+						// key carries the committed value so the row's uncontrolled draft re-seeds on external change; idx keeps it unique across duplicate prefixes
+						// oxlint-disable-next-line no-array-index-key
+						key={`${idx}:${p}`}
+						index={idx}
+						prefix={p}
+						isDefault={p === defaultPrefix}
+						usage={usageOf(p)}
+						onCommit={(next) => commitEdit(idx, next)}
+						onSetDefault={() => writeRoot({ defaultPrefix: p })}
+						onRemove={() => removePrefix(idx)}
+					/>
+				))}
+				<div className="flex items-center gap-2">
+					<Input
+						aria-label="New prefix"
+						className={cn(
+							'h-7 w-16 font-mono text-sm',
+							(newInvalid || newDuplicate) && 'border-destructive focus-visible:ring-destructive',
+						)}
+						title={newInvalid ? CMD.PREFIX_ERROR : newDuplicate ? 'That prefix already exists' : undefined}
+						placeholder="$"
+						value={newPrefix}
+						onChange={(e) => setNewPrefix(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === 'Enter') {
+								e.preventDefault()
+								addPrefix()
+							}
+						}}
+					/>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						disabled={!newTrimmed || newInvalid || newDuplicate}
+						onClick={addPrefix}
+					>
+						Add prefix
+					</Button>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+// bespoke editor for a command's `strings` array (inline-prefixed, short): lays the inputs out horizontally so they
+// don't each hog a full row. Each string is an uncontrolled TextInputField scoped to its index (re-seeds on reset$).
+function CommandStringsField({ value$, reset$, onChange }: OverrideProps) {
+	const strings = (useFieldValue(value$, reset$) as string[] | undefined) ?? []
+	function structural(next: string[]) {
+		onChange(next)
+		reset$.next()
+	}
+	return (
+		<div className="flex flex-wrap items-center gap-2">
+			{strings.map((_, idx) => (
+				// oxlint-disable-next-line no-array-index-key
+				<div key={idx} className="flex items-center gap-1">
+					<div className="w-40">
+						<TextInputField
+							value$={scopeValue(value$, idx)}
+							reset$={reset$}
+							numeric={false}
+							placeholder="prefix + command"
+							onChange={(v) => onChange(((value$.getValue() as string[]) ?? []).map((s, i) => (i === idx ? (v ?? '') : s)))}
+						/>
+					</div>
+					<Button
+						type="button"
+						size="icon"
+						variant="ghost"
+						className="h-6 w-6 shrink-0 text-destructive"
+						aria-label={`Remove string ${idx + 1}`}
+						onClick={() => structural(strings.filter((_, i) => i !== idx))}
+					>
+						<Icons.X className="h-4 w-4" />
+					</Button>
+				</div>
+			))}
+			<Button type="button" variant="outline" size="sm" onClick={() => structural([...strings, ''])}>
+				<Icons.Plus className="mr-1 h-4 w-4" />Add
+			</Button>
+		</div>
+	)
+}
+
+// compact editor for a single command (`commands.<id>`): collapses the strings/scopes/enabled sub-sections into a
+// couple of tight rows, moving their descriptions into `?` tooltips. The command name + reset come from the LeafField
+// shell. Schema issues (e.g. a string missing an allowed prefix) still surface under the card via the field's issues.
+function CommandCard({ value$, reset$, onChange }: OverrideProps) {
+	const cfg = (useFieldValue(value$, reset$) as { scopes?: CMD.CommandScope[]; enabled?: boolean }) ?? {}
+	const scopes = cfg.scopes ?? []
+	const enabled = cfg.enabled ?? true
+	const strings$ = React.useMemo(() => scopeValue(value$, 'strings'), [value$])
+	function patch(p: Record<string, unknown>) {
+		onChange({ ...((value$.getValue() as Record<string, unknown>) ?? {}), ...p })
+	}
+	return (
+		<div className="space-y-2">
+			<div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+				<span className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+					Strings <HelpTip text="Command strings that trigger this command. Each must start with one of the allowed prefixes." />
+				</span>
+				<CommandStringsField value$={strings$} reset$={reset$} onChange={(v) => patch({ strings: v })} path={[]} />
+			</div>
+			<div className="flex flex-wrap items-center gap-4">
+				<div className="flex items-center gap-2">
+					<span className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+						Scopes <HelpTip text="Chat scopes this command is available in (admin and/or public chats)." />
+					</span>
+					<ComboBoxMulti
+						title="Scope"
+						values={scopes}
+						options={[...CMD.COMMAND_SCOPES.options]}
+						onSelect={(next) => patch({ scopes: (typeof next === 'function' ? next(scopes) : next) })}
+					/>
+				</div>
+				<label className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+					<Switch checked={enabled} onCheckedChange={(v) => patch({ enabled: v })} />
+					Enabled
+				</label>
+			</div>
+		</div>
+	)
+}
+
+// what an alias's command text points at, for the status column. `undefined` means there's nothing useful to say:
+// either the text is still empty, or its args are malformed, which surfaces as a schema issue under the field instead.
+type AliasStatus = { broken: boolean; label: string; title: string }
+function aliasStatus(command: string, commands: CMD.CommandConfigs | undefined): AliasStatus | undefined {
+	if (!commands || command.trim() === '') return undefined
+	const res = CMD.resolveAliasCommand(command, commands)
+	if (res.code === 'err:invalid-args') return undefined
+	if (res.code === 'err:unknown-command') return { broken: true, label: 'Unavailable', title: res.msg }
+	if (!commands[res.cmdId].enabled) {
+		return { broken: true, label: 'Disabled', title: `The "${res.cmdId}" command is disabled, so this alias does nothing.` }
+	}
+	return { broken: false, label: res.cmdId, title: `Runs the "${res.cmdId}" command.` }
+}
+
+// bespoke editor for `commandAliases`: an alias is just a shortcut string and the full command it runs, so the row is
+// two text fields plus a status showing which command it resolves to (and whether that command is usable).
+function CommandAliasesField({ value$, reset$, onChange }: OverrideProps) {
+	return (
+		<PresetTableField
+			value$={value$}
+			reset$={reset$}
+			onChange={onChange}
+			headers={
+				<>
+					<TableHead className="w-[12rem]">Alias</TableHead>
+					<TableHead>Full command</TableHead>
+					<TableHead className="w-[9rem]">Runs</TableHead>
+					<TableHead className="w-8" />
+				</>
+			}
+			newRow={() => ({ alias: '', command: '' })}
+			Row={CommandAliasRow}
+		/>
+	)
+}
+
+function CommandAliasRow({ idx, parent$, reset$, parentOnChange, onRemove }: PresetRowProps) {
+	const row$ = React.useMemo(() => scopeValue(parent$, idx), [parent$, idx])
+	const alias$ = React.useMemo(() => scopeValue(row$, 'alias'), [row$])
+	const command$ = React.useMemo(() => scopeValue(row$, 'command'), [row$])
+	const root$ = React.useContext(RootValueContext) ?? EMPTY_ROOT_VALUE$
+	// the command text is read reactively so the status follows the input (a debounce behind it, like every other field)
+	const command = (useFieldValue(command$, reset$) as string | undefined) ?? ''
+	const commands = ((useFieldValue(root$, reset$) as { commands?: CMD.CommandConfigs } | undefined) ?? {}).commands
+	const status = aliasStatus(command, commands)
+
+	const setField = (key: 'alias' | 'command') => (v: any) => {
+		const arr = [...((parent$.getValue() as CMD.CommandAlias[]) ?? [])]
+		arr[idx] = { ...arr[idx], [key]: v ?? '' }
+		parentOnChange(arr)
+	}
+
+	return (
+		<TableRow>
+			<TableCell className="align-top">
+				<TextInputField value$={alias$} reset$={reset$} onChange={setField('alias')} numeric={false} placeholder="/rules" />
+			</TableCell>
+			<TableCell className="align-top">
+				<TextInputField
+					value$={command$}
+					reset$={reset$}
+					onChange={setField('command')}
+					numeric={false}
+					placeholder="/broadcast Read the rules"
+				/>
+			</TableCell>
+			<TableCell className="align-top">
+				{status && (
+					<Badge variant={status.broken ? 'destructive' : 'outline'} className="font-mono text-xs" title={status.title}>
+						{status.label}
+					</Badge>
+				)}
+			</TableCell>
+			<TableCell className="align-top">
+				<Button type="button" size="icon" variant="ghost" className="h-8 w-8 text-destructive" onClick={onRemove}>
+					<Icons.X className="h-4 w-4" />
+				</Button>
+			</TableCell>
+		</TableRow>
+	)
+}
+
 function PasswordField({ value$, reset$, onChange }: OverrideProps) {
 	return <TextInputField value$={value$} reset$={reset$} onChange={onChange} numeric={false} secret placeholder="Password" />
 }
@@ -1746,6 +2150,10 @@ function RoleAssignmentsEditor(
 function overrideFor(path: Path, _node: Node): React.FC<OverrideProps> | undefined {
 	const last = path[path.length - 1]
 	if (path.length === 1 && last === 'adminListSources') return AdminListSourcesField
+	if (path.length === 1 && last === 'allowedPrefixes') return AllowedPrefixesField
+	// each command renders as one compact card (which itself renders the strings sub-editor), so there's no separate strings override
+	if (path.length === 2 && path[0] === 'commands') return CommandCard
+	if (path.length === 1 && last === 'commandAliases') return CommandAliasesField
 	if (path.length === 1 && last === 'adminActionReasons') return AdminActionReasonsField
 	if (path.length === 1 && last === 'broadcasts') return BroadcastsField
 	if (path.length === 1 && last === 'layerTable') return LayerTableField
@@ -2570,6 +2978,9 @@ function Field(
 		(v: any) => parentOnChange({ ...((parent$.getValue() as Record<string, any>) ?? {}), [name]: v }),
 		[parentOnChange, parent$, name],
 	)
+	// keys managed inline by a sibling editor render no field of their own (e.g. defaultPrefix, chosen via the
+	// "default" markers in the allowedPrefixes editor)
+	if (path.length === 1 && HIDDEN_GLOBAL_SETTINGS_KEYS.has(name)) return null
 	const { inner } = stripNullable(node)
 	const hasOverride = !!overrideFor(path, node)
 	const isSection = !hasOverride
@@ -2699,17 +3110,19 @@ export default function SettingsForm(
 	return (
 		<FormOptionsContext.Provider value={formOptions}>
 			<RootValueContext.Provider value={value$}>
-				<WriteAccessContext.Provider value={writeAccess}>
-					<SavedRootContext.Provider value={savedCtx}>
-						<MessageVarsContext.Provider value={messageVars}>
-							<ValidationContext.Provider value={normIssues}>
-								{groups
-									? <GroupedRootFields node={jsonSchema} groups={groups} value$={value$} reset$={reset$} onChange={onChange} />
-									: <ObjectField node={jsonSchema} path={rootPath} value$={value$} reset$={reset$} onChange={onChange} />}
-							</ValidationContext.Provider>
-						</MessageVarsContext.Provider>
-					</SavedRootContext.Provider>
-				</WriteAccessContext.Provider>
+				<RootOnChangeContext.Provider value={onChange}>
+					<WriteAccessContext.Provider value={writeAccess}>
+						<SavedRootContext.Provider value={savedCtx}>
+							<MessageVarsContext.Provider value={messageVars}>
+								<ValidationContext.Provider value={normIssues}>
+									{groups
+										? <GroupedRootFields node={jsonSchema} groups={groups} value$={value$} reset$={reset$} onChange={onChange} />
+										: <ObjectField node={jsonSchema} path={rootPath} value$={value$} reset$={reset$} onChange={onChange} />}
+								</ValidationContext.Provider>
+							</MessageVarsContext.Provider>
+						</SavedRootContext.Provider>
+					</WriteAccessContext.Provider>
+				</RootOnChangeContext.Provider>
 			</RootValueContext.Provider>
 		</FormOptionsContext.Provider>
 	)

--- a/src/components/settings-toc.tsx
+++ b/src/components/settings-toc.tsx
@@ -2,7 +2,7 @@ import { StickyGroup } from '@/components/sticky-group'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { SettingsGroup } from '@/lib/settings-groups'
-import { GLOBAL_SETTINGS_GROUPS, splitByGroups, TOC_LEAF_PATHS } from '@/lib/settings-groups'
+import { GLOBAL_SETTINGS_GROUPS, HIDDEN_GLOBAL_SETTINGS_KEYS, splitByGroups, TOC_LEAF_PATHS } from '@/lib/settings-groups'
 import { settingLabel } from '@/lib/settings-labels'
 import * as SettingsNav from '@/lib/settings-nav'
 import { cn } from '@/lib/utils'
@@ -38,7 +38,8 @@ function stripNullable(node: Node): Node {
 function buildChildren(node: Node, path: (string | number)[], idPrefix: string, access: RBAC.SettingsWriteAccess): TocNode[] {
 	const props: Record<string, Node> | undefined = node?.properties
 	if (!props) return []
-	return Object.keys(props).map((key): TocNode => {
+	// top-level keys managed inline by a sibling editor (e.g. defaultPrefix) render no field, so emit no TOC anchor either
+	return Object.keys(props).filter((key) => !(path.length === 0 && HIDDEN_GLOBAL_SETTINGS_KEYS.has(key))).map((key): TocNode => {
 		const inner = stripNullable(props[key])
 		const childPath = [...path, key]
 		const pathStr = childPath.join('.')

--- a/src/lib/settings-groups.ts
+++ b/src/lib/settings-groups.ts
@@ -4,6 +4,11 @@
 
 export type SettingsGroup = { slug: string; label: string; keys: string[] }
 
+// top-level global-settings keys that render no field of their own in the GUI (they're managed inline by a sibling
+// editor), so neither the form nor the TOC should emit a row/anchor for them. `defaultPrefix` is chosen via the
+// "default" markers in the allowedPrefixes editor.
+export const HIDDEN_GLOBAL_SETTINGS_KEYS: ReadonlySet<string> = new Set(['defaultPrefix'])
+
 export const GLOBAL_SETTINGS_GROUPS: SettingsGroup[] = [
 	{ slug: 'general', label: 'General', keys: ['topBarColor', 'navLinks', 'warnOnSlmStart'] },
 	{
@@ -11,7 +16,7 @@ export const GLOBAL_SETTINGS_GROUPS: SettingsGroup[] = [
 		label: 'Messaging & Reasons',
 		keys: ['warnPrefix', 'adminActionReasons', 'requireReasonFor', 'broadcasts', 'messageVariables', 'chat'],
 	},
-	{ slug: 'commands', label: 'In-game Commands', keys: ['allowedPrefixes', 'defaultPrefix', 'commands', 'timeoutCommandAliases'] },
+	{ slug: 'commands', label: 'In-game Commands', keys: ['allowedPrefixes', 'defaultPrefix', 'commands', 'commandAliases'] },
 	{ slug: 'queue-and-votes', label: 'Queue & Votes', keys: ['layerQueue', 'vote', 'layerTable', 'layerGeneration'] },
 	{
 		slug: 'squad-server',

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,7 +1,6 @@
 import * as Arr from '@/lib/array'
 import * as DH from '@/lib/display-helpers'
 import * as Obj from '@/lib/object'
-import { formatHumanTime } from '@/lib/zod'
 import * as BAL from '@/models/balance-triggers.models'
 import * as CMD from '@/models/command.models'
 import * as L from '@/models/layer'
@@ -259,18 +258,20 @@ export const WARNS = {
 		wrongChat: (correctChats: string[]) => `Command not available in this chat. Try using ${correctChats.join(' or ')}`,
 		help(
 			commands: Record<CMD.CommandId, CMD.CommandConfig>,
-			timeoutAliases: readonly { string: string; duration: number }[] = [],
+			aliases: readonly CMD.CommandAlias[] = [],
 		) {
 			const commandLines = Obj.objEntries(commands).filter(([_, cmd]) => cmd.enabled).map(([id, cmd]) => {
 				const sortedStrings = cmd.strings.toSorted((a, b) => a.length - b.length)
 				const signature = CMD.formatArgSignature(CMD.COMMAND_DECLARATIONS[id].args)
 				return `[${sortedStrings.join(', ')}]${signature ? ` ${signature}` : ''}: ${GENERAL.command.descriptions[id]}`
 			})
-			// fixed-duration timeout aliases aren't in COMMAND_DECLARATIONS; append them with a generated description
-			const aliasSignature = CMD.formatArgSignature(CMD.TIMEOUT_ALIAS_ARG_DEFS)
-			const aliasLines = timeoutAliases.map((a) =>
-				`[${a.string}]${aliasSignature ? ` ${aliasSignature}` : ''}: ${GENERAL.command.timeoutAliasDescription(a.duration)}`
-			)
+			// aliases take no args of their own, so they list as the shortcut and what it expands to. Ones pointing at a
+			// disabled or no-longer-existing command are dropped: they can't be run.
+			const aliasLines = aliases.flatMap((a) => {
+				const res = CMD.resolveAliasCommand(a.command, commands)
+				if (res.code !== 'ok' || !commands[res.cmdId].enabled) return []
+				return [`[${a.alias}]: ${GENERAL.command.aliasDescription(a.command)}`]
+			})
 			const groups = Arr.paged([...commandLines, ...aliasLines], 3)
 			if (groups.length === 0) groups.push([])
 			groups[0].unshift(`Available commands:`)
@@ -385,7 +386,7 @@ export const GENERAL = {
 			clearTimeout: "Cancel a player's active timeout (works for offline players)",
 		} satisfies Record<CMD.CommandId, string>,
 		// configurable fixed-duration timeout aliases; shared by the in-game help and the web help dialog
-		timeoutAliasDescription: (durationMs: number) => `Kick with a ${formatHumanTime(durationMs)} timeout`,
+		aliasDescription: (command: string) => `Shortcut for "${command}"`,
 	},
 }
 

--- a/src/migrations/0080_command_aliases.ts
+++ b/src/migrations/0080_command_aliases.ts
@@ -1,0 +1,35 @@
+import type { MigrationDriver } from '@/server/migrate'
+
+// `timeoutCommandAliases` ({ string, duration }: a fixed-duration kick whose player and reason were typed in chat)
+// became the general `commandAliases` ({ alias, command }: a shortcut to a complete command invocation).
+//
+// The old aliases cannot be carried across. A command alias takes no arguments of its own, and the old ones took a
+// <player> (and an optional reason) at call time while pinning only the duration -- there is no `command` text that
+// expresses "timeout whoever I name for 5m". Converting them would produce aliases that fail on every use, so they're
+// dropped and logged instead, leaving the admin to re-add whichever ones still make sense.
+//
+// `settings` is stored superjson-wrapped ({ json, meta }) in a drizzle json(text) column; both keys are plain JSON,
+// so superjson's `meta` never references them.
+export async function up(db: MigrationDriver): Promise<void> {
+	const row = db.prepare(`SELECT settings FROM globalSettings WHERE id = 1`).get() as { settings: string } | undefined
+	if (!row?.settings) return
+
+	const wrapper = JSON.parse(row.settings) as { json?: any; meta?: any }
+	if (!wrapper?.json || typeof wrapper.json !== 'object') return
+	const settings = wrapper.json
+	if (settings.commandAliases !== undefined) return
+
+	const dropped = Array.isArray(settings.timeoutCommandAliases) ? settings.timeoutCommandAliases : []
+	if (dropped.length > 0) {
+		const listed = dropped.map((a: any) => `${a?.string} (${a?.duration})`).join(', ')
+		console.warn(
+			`0080_command_aliases: dropping ${dropped.length} timeout alias(es) that the new alias model cannot express: ${listed}. `
+				+ `Re-add them under Settings > In-game Commands > Command Aliases if still wanted.`,
+		)
+	}
+
+	settings.commandAliases = []
+	delete settings.timeoutCommandAliases
+
+	db.prepare(`UPDATE globalSettings SET settings = ? WHERE id = 1`).run(JSON.stringify(wrapper))
+}

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -29,6 +29,7 @@ import * as m0076 from './0076_player_flag_groupings_restructure'
 import * as m0077 from './0077_sftp_tuning_into_connection'
 import * as m0078 from './0078_admin_list_sources_per_server'
 import * as m0079 from './0079_connection_modes'
+import * as m0080 from './0080_command_aliases'
 
 export const tsMigrations: TsMigration[] = [
 	{ name: '0062_filter_nodes_operator_model', up: m0062.up },
@@ -49,4 +50,5 @@ export const tsMigrations: TsMigration[] = [
 	{ name: '0077_sftp_tuning_into_connection', up: m0077.up },
 	{ name: '0078_admin_list_sources_per_server', up: m0078.up },
 	{ name: '0079_connection_modes', up: m0079.up },
+	{ name: '0080_command_aliases', up: m0080.up },
 ]

--- a/src/models/command.models.test.ts
+++ b/src/models/command.models.test.ts
@@ -230,3 +230,52 @@ describe('seedCommandConfigs', () => {
 		expect(Object.keys(seeded).sort()).toEqual(Object.keys(CMD.COMMAND_DECLARATIONS).sort())
 	})
 })
+
+describe('resolveAliasCommand', () => {
+	const configs = CMD.seedCommandConfigs({}, '!') as unknown as CMD.CommandConfigs
+
+	it('resolves a command string to its id and trailing tokens', () => {
+		expect(CMD.resolveAliasCommand('!broadcast Read the rules', configs)).toEqual({
+			code: 'ok',
+			cmdId: 'broadcast',
+			tokens: ['Read', 'the', 'rules'],
+		})
+	})
+
+	it('matches command strings case-insensitively and tolerates surrounding whitespace', () => {
+		expect(CMD.resolveAliasCommand('  !BROADCAST   hi there  ', configs)).toMatchObject({ code: 'ok', cmdId: 'broadcast' })
+	})
+
+	// resolves as unknown rather than invalid: an alias stored before a command's strings were renamed must still load
+	it('reports an unresolvable command string separately from bad args', () => {
+		expect(CMD.resolveAliasCommand('!nosuchcommand', configs)).toMatchObject({ code: 'err:unknown-command' })
+		expect(CMD.resolveAliasCommand('', configs)).toMatchObject({ code: 'err:unknown-command' })
+		expect(CMD.resolveAliasCommand('!broadcast', configs)).toMatchObject({ code: 'err:invalid-args' })
+	})
+
+	it('enforces required args and checks the tokens it can parse without a roster', () => {
+		expect(CMD.resolveAliasCommand('!timeout bob', configs)).toMatchObject({ code: 'err:invalid-args' })
+		expect(CMD.resolveAliasCommand('!timeout bob notaduration', configs)).toMatchObject({ code: 'err:invalid-args' })
+		expect(CMD.resolveAliasCommand('!timeout bob 2h griefing', configs)).toMatchObject({ code: 'ok', cmdId: 'timeout' })
+	})
+
+	it('accepts a command whose optional args are all omitted', () => {
+		expect(CMD.resolveAliasCommand('!startvote', configs)).toEqual({ code: 'ok', cmdId: 'startVote', tokens: [] })
+	})
+})
+
+describe('findAlias', () => {
+	const configs = CMD.seedCommandConfigs({}, '!') as unknown as CMD.CommandConfigs
+	const aliases: CMD.CommandAlias[] = [{ alias: '!rules', command: '!broadcast Read the rules' }]
+
+	it('matches an alias case-insensitively', () => {
+		expect(CMD.findAlias(aliases, configs, '!RULES')).toEqual(aliases[0])
+		expect(CMD.findAlias(aliases, configs, '!nope')).toBeUndefined()
+	})
+
+	// aliases are a fallback, so shadowing a real command string with one is a no-op rather than an override
+	it('lets a real command string win on collision', () => {
+		const shadowing: CMD.CommandAlias[] = [{ alias: '!help', command: '!broadcast nope' }]
+		expect(CMD.findAlias(shadowing, configs, '!help')).toBeUndefined()
+	})
+})

--- a/src/models/command.models.ts
+++ b/src/models/command.models.ts
@@ -207,13 +207,6 @@ export const COMMAND_DECLARATIONS = {
 	}),
 }
 
-// configurable fixed-duration timeout aliases (e.g. !yeet = timeout with 2h) share these args: a player and an
-// optional reason. shared so both the command dispatcher and the help listings can describe them.
-export const TIMEOUT_ALIAS_ARG_DEFS = [
-	{ kind: 'player', name: 'player' },
-	{ kind: 'reason', name: 'reason', action: 'timeout', optional: true },
-] as const satisfies readonly ArgDef[]
-
 export type CommandId = keyof typeof COMMAND_DECLARATIONS
 export const COMMAND_ID = z.enum(Object.keys(COMMAND_DECLARATIONS) as [CommandId, ...CommandId[]])
 export type CommandDeclaration<Id extends CommandId> = (typeof COMMAND_DECLARATIONS)[Id]
@@ -221,6 +214,16 @@ export type CommandDeclaration<Id extends CommandId> = (typeof COMMAND_DECLARATI
 // the prefix a fresh install seeds command strings with, when no settings exist yet to read `defaultPrefix` from.
 // matches the prefix migration 0074 falls back to, so a fresh install and a migrated one agree on what to type.
 export const FALLBACK_PREFIX = '!'
+
+// a command prefix: one or more ASCII special (punctuation/symbol) characters. Letters, digits, whitespace and
+// non-ASCII are excluded so a prefix can't be mistaken for the command word itself. Exported so the settings editor
+// can validate the prefix inputs the same way the schema does.
+export const PREFIX_ERROR = 'Prefix must be one or more ASCII special characters (e.g. ! . @ #)'
+const ASCII_SPECIAL = /^[!-/:-@[-`{-~]+$/
+export function isValidPrefix(s: string): boolean {
+	return ASCII_SPECIAL.test(s)
+}
+export const PrefixSchema = z.string().min(1).regex(ASCII_SPECIAL, PREFIX_ERROR)
 
 // declared strings are bare (`help`); the stored ones carry a prefix (`!help`), which is attached by
 // seedCommandConfigs using the installation's configured defaultPrefix
@@ -514,6 +517,63 @@ function matchCommandText(configs: CommandConfigs, cmdText: string) {
 		}
 	}
 	return null
+}
+
+// -------- command aliases --------
+
+// A shortcut to a complete command invocation: `/rules` -> `/broadcast Read the rules`. The aliased command carries
+// all of its own arguments and tokens typed after the alias are ignored, so an alias is a plain text substitution.
+//
+// If aliases ever need to take arguments, pin them by name (`/timeout duration=2h`, leaving `player` and `reason` to
+// be typed in chat) rather than splicing tokens positionally: a positional splice can only fix arguments that come
+// first, which can't express the old fixed-duration timeout aliases (`duration` sits between `player` and `reason`).
+export type CommandAlias = { alias: string; command: string }
+
+export type AliasResolution =
+	// the target is resolved but may be disabled; callers decide whether that's an error (dispatch) or a display
+	// concern (the settings editor and help listings, which show it as unavailable)
+	| { code: 'ok'; cmdId: CommandId; tokens: string[] }
+	// the first word matches no configured command string. Not a schema error: a later SLM release can rename a
+	// command's strings out from under a stored alias, and that must not stop the settings from loading
+	| { code: 'err:unknown-command'; msg: string }
+	| { code: 'err:invalid-args'; msg: string }
+
+// Static validation of an alias's command text: everything checkable without the live roster or the configured
+// reasons. Resolves the command string, then checks the args assign (all required ones present) and that int and
+// duration tokens parse. Player/squad/reason tokens can only be checked at dispatch, so they're taken on faith.
+export function resolveAliasCommand(command: string, configs: CommandConfigs): AliasResolution {
+	const words = command.trim().split(/\s+/).filter((w) => w !== '')
+	if (words.length === 0) return { code: 'err:unknown-command', msg: 'No command given' }
+	const cmdId = matchCommandText(configs, words[0])
+	if (!cmdId) return { code: 'err:unknown-command', msg: `"${words[0]}" is not a configured command string` }
+
+	const tokens = words.slice(1)
+	const args = COMMAND_DECLARATIONS[cmdId].args as readonly ArgDef[]
+	// permissive predicates: a team can be named by the current layer's faction, which isn't knowable here, and
+	// treating no token as a configured reason keeps the squad window from being narrowed on a guess
+	const assigned = assignArgTokens(args, tokens, { isTeamToken: () => true, isPresetToken: () => false })
+	if (assigned.code === 'err:missing-arg') {
+		return { code: 'err:invalid-args', msg: `Missing <${assigned.argName}>. Usage: ${words[0]} ${formatArgSignature(args)}`.trim() }
+	}
+	for (const def of args) {
+		const window = assigned.windows[def.name]
+		if (!window || window.length === 0) continue
+		if (def.kind === 'int') {
+			const res = coerceIntArg(def.name, window[0])
+			if (res.code !== 'ok') return { code: 'err:invalid-args', msg: res.msg }
+		}
+		if (def.kind === 'duration') {
+			const res = resolveDurationArg(def.name, window[0])
+			if (res.code !== 'ok') return { code: 'err:invalid-args', msg: res.msg }
+		}
+	}
+	return { code: 'ok', cmdId, tokens }
+}
+
+// a real command string always wins on collision, so an alias is only consulted when the token matches none
+export function findAlias(aliases: readonly CommandAlias[], configs: CommandConfigs, token: string): CommandAlias | undefined {
+	if (matchCommandText(configs, token)) return undefined
+	return aliases.find((a) => a.alias.toLowerCase() === token.toLowerCase())
 }
 
 export function chatInScope(scopes: CommandScope[], msgChat: SM.ChatChannelType) {

--- a/src/models/settings.models.ts
+++ b/src/models/settings.models.ts
@@ -201,17 +201,18 @@ export const GlobalSettingsSchema = z.object({
 	),
 	navLinks: NavLinkSchema.optional().describe('Global links to display in the navbar dropdown menu'),
 	warnOnSlmStart: z.boolean().prefault(false).describe('Warn all in-game admins when SLM starts or restarts.'),
-	allowedPrefixes: z.array(BasicStrNoWhitespace).min(1).prefault([CMD.FALLBACK_PREFIX]).describe(
+	allowedPrefixes: z.array(CMD.PrefixSchema).min(1).prefault([CMD.FALLBACK_PREFIX]).describe(
 		'Prefixes an in-game command may start with. Every command string and timeout alias must begin with one of these',
 	),
-	defaultPrefix: BasicStrNoWhitespace.prefault(CMD.FALLBACK_PREFIX).describe(
+	defaultPrefix: CMD.PrefixSchema.prefault(CMD.FALLBACK_PREFIX).describe(
 		'The allowed prefix that commands introduced by future SLM versions are seeded with',
 	),
-	timeoutCommandAliases: z.array(z.object({
-		string: BasicStrNoWhitespace.describe('Command string, including its prefix'),
-		duration: HumanTime.describe('Fixed timeout duration this alias kicks with'),
+	commandAliases: z.array(z.object({
+		alias: BasicStrNoWhitespace.describe('The shortcut typed in chat, including its prefix'),
+		command: z.string().min(1).describe('The full command this alias runs, including its prefix and every argument'),
 	})).prefault([]).describe(
-		'Extra admin-chat commands that kick with a fixed timeout, e.g. !yeet = 2h. Real command strings win on collision.',
+		'Shortcuts to complete commands, e.g. /rules = /broadcast Read the rules. An alias takes no arguments of its own '
+			+ '(anything typed after it is ignored), runs in the scopes of the command it points at, and loses to a real command string on collision.',
 	),
 	commands: CMD.AllCommandConfigSchema,
 	rbac: RbacSettingsSchema,
@@ -275,8 +276,8 @@ export const GlobalSettingsSchema = z.object({
 		})
 	}
 
-	// command strings and timeout-alias strings share one namespace: a real command always wins on collision, so
-	// a timeout alias that clashes is unreachable (and vice versa). matching is case-insensitive, like dispatch.
+	// command strings and alias strings share one namespace: a real command always wins on collision, so an alias
+	// that clashes is unreachable. matching is case-insensitive, like dispatch.
 	const commandOwner = new Map<string, string>()
 	for (const [id, cmd] of Object.entries(val.commands ?? {})) {
 		;(cmd.strings ?? []).forEach((s, j) => {
@@ -285,21 +286,29 @@ export const GlobalSettingsSchema = z.object({
 		})
 	}
 	const seenAlias = new Set<string>()
-	val.timeoutCommandAliases?.forEach((alias, i) => {
-		const key = alias.string.toLowerCase()
-		if (!hasAllowedPrefix(alias.string)) prefixIssue(alias.string, 'Timeout alias', ['timeoutCommandAliases', i, 'string'])
+	val.commandAliases?.forEach((alias, i) => {
+		const key = alias.alias.toLowerCase()
+		if (!hasAllowedPrefix(alias.alias)) prefixIssue(alias.alias, 'Alias', ['commandAliases', i, 'alias'])
 		const owner = commandOwner.get(key)
 		if (owner) {
 			ctx.addIssue({
 				code: 'custom',
-				message: `Timeout alias "${alias.string}" clashes with the command "${owner}". Pick a different string.`,
-				path: ['timeoutCommandAliases', i, 'string'],
+				message: `Alias "${alias.alias}" clashes with the command "${owner}". Pick a different string.`,
+				path: ['commandAliases', i, 'alias'],
 			})
 		}
 		if (seenAlias.has(key)) {
-			ctx.addIssue({ code: 'custom', message: `Duplicate timeout alias "${alias.string}"`, path: ['timeoutCommandAliases', i, 'string'] })
+			ctx.addIssue({ code: 'custom', message: `Duplicate alias "${alias.alias}"`, path: ['commandAliases', i, 'alias'] })
 		}
 		seenAlias.add(key)
+
+		// only malformed args are an error here. An alias whose command string doesn't resolve is left to load and
+		// surface as unavailable in the editor and the help listings: a later SLM release can rename a command's
+		// strings, and stored settings that predate the rename must not stop the server booting.
+		const res = CMD.resolveAliasCommand(alias.command, val.commands as CMD.CommandConfigs)
+		if (res.code === 'err:invalid-args') {
+			ctx.addIssue({ code: 'custom', message: res.msg, path: ['commandAliases', i, 'command'] })
+		}
 	})
 })
 

--- a/src/systems/commands.server.ts
+++ b/src/systems/commands.server.ts
@@ -70,7 +70,6 @@ export async function handleCommand(ctx: C.Db & C.ServerSlice, msg: SM.RconEvent
 		}
 	}
 
-	// sender resolution happens before parsing so timeout aliases (which dispatch on unknown commands) share it
 	const playerRes = await SquadRcon.getPlayer(ctx, msg.playerIds)
 	if (playerRes.code === 'err:rcon') {
 		return await error('rcon-error', 'RCON error')
@@ -84,13 +83,19 @@ export async function handleCommand(ctx: C.Db & C.ServerSlice, msg: SM.RconEvent
 	const user: USR.GuiOrChatUserId = { steamId: sender.ids.steam }
 	const h: HandlerCtx = { ctx, msg, sender, user, reply, error }
 
-	const parseRes = CMD.parseCommand(msg, Settings.GLOBAL_SETTINGS.commands)
+	// an alias is a plain text substitution for a complete command, so it's expanded up front and everything after
+	// this point (scope, enabled, arg resolution) runs against the command it points at. Anything typed after the
+	// alias is dropped: aliases take no arguments of their own.
+	const alias = CMD.findAlias(Settings.GLOBAL_SETTINGS.commandAliases, Settings.GLOBAL_SETTINGS.commands, msg.message.split(/\s+/)[0])
+	if (alias) log.info('Command alias expanded: %s -> %s', alias.alias, alias.command)
+	const effectiveMsg = alias ? { ...msg, message: alias.command } : msg
+
+	const parseRes = CMD.parseCommand(effectiveMsg, Settings.GLOBAL_SETTINGS.commands)
 	if (parseRes.code === 'err:unknown-command') {
 		// just don't respond to unknown commands from non-admins
 		if (!sender.isAdmin) return
-		// real command strings win by construction: aliases are only consulted after parseCommand misses
-		const aliasRes = await tryTimeoutAlias(h)
-		if (aliasRes) return aliasRes
+		// an alias pointing at a command string that no longer exists: report the alias, not its stale expansion
+		if (alias) return await error('unknown-command', `Alias "${alias.alias}" points at a command that no longer exists`)
 		return await error('unknown-command', parseRes.msg)
 	}
 
@@ -120,23 +125,6 @@ export async function handleCommand(ctx: C.Db & C.ServerSlice, msg: SM.RconEvent
 	// TS cannot correlate handlers[cmd] with CommandArgs<typeof cmd> across the union, so the args
 	// are cast at this single dispatch point; each handler's signature is still fully typed
 	return await handlers[cmd](h, resolved.args as never)
-}
-
-// configurable fixed-duration timeout aliases (e.g. !yeet = timeout with 2h). Admin chat only.
-async function tryTimeoutAlias(h: HandlerCtx): Promise<HandlerResult | undefined> {
-	if (h.msg.channelType !== 'ChatAdmin') return undefined
-	const words = h.msg.message.split(/\s+/)
-	const token = words[0].toLowerCase()
-	const alias = Settings.GLOBAL_SETTINGS.timeoutCommandAliases.find(a => a.string.toLowerCase() === token)
-	if (!alias) return undefined
-	log.info('Timeout alias received: %s', alias.string)
-	const resolved = await resolveArgDefs(h.ctx, CMD.TIMEOUT_ALIAS_ARG_DEFS, words.slice(1), h.sender)
-	if (resolved.code === 'err:missing-arg') {
-		return await h.error('invalid-args', `Usage: ${alias.string} ${CMD.formatArgSignature(CMD.TIMEOUT_ALIAS_ARG_DEFS)}`)
-	}
-	if (resolved.code !== 'ok') return await h.error('invalid-args', resolved.msg)
-	const args = resolved.args as CMD.ResolvedArgs<typeof CMD.TIMEOUT_ALIAS_ARG_DEFS>
-	return await executeTimeout(h, [args.player], alias.duration, args.reason, args.player.ids.username)
 }
 
 // resolves a chat team token: 1|2, normalized A|B, or the faction name of the current layer
@@ -321,7 +309,7 @@ const handlers: { [Id in CMD.CommandId]: (h: HandlerCtx, args: CMD.CommandArgs<I
 		await h.reply(
 			Messages.WARNS.commands.help(
 				Settings.GLOBAL_SETTINGS.commands,
-				Settings.GLOBAL_SETTINGS.timeoutCommandAliases,
+				Settings.GLOBAL_SETTINGS.commandAliases,
 			),
 		)
 		return { code: 'ok' }

--- a/src/systems/settings.server.ts
+++ b/src/systems/settings.server.ts
@@ -449,7 +449,7 @@ export type PublicSettings = {
 	navLinks: SETTINGS.GlobalSettings['navLinks']
 	chat: SETTINGS.GlobalSettings['chat']
 	commands: SETTINGS.GlobalSettings['commands']
-	timeoutCommandAliases: SETTINGS.GlobalSettings['timeoutCommandAliases']
+	commandAliases: SETTINGS.GlobalSettings['commandAliases']
 	vote: { voteDuration: number; voteDisplayProps: SETTINGS.GlobalSettings['vote']['voteDisplayProps'] }
 	servers: ServerEntry[]
 	playerFlagGroupings: SETTINGS.GlobalSettings['playerFlagGroupings']
@@ -466,7 +466,7 @@ function buildPublicSettings(): PublicSettings {
 		navLinks: GLOBAL_SETTINGS.navLinks,
 		chat: GLOBAL_SETTINGS.chat,
 		commands: GLOBAL_SETTINGS.commands,
-		timeoutCommandAliases: GLOBAL_SETTINGS.timeoutCommandAliases,
+		commandAliases: GLOBAL_SETTINGS.commandAliases,
 		vote: {
 			voteDuration: GLOBAL_SETTINGS.vote.voteDuration,
 			voteDisplayProps: GLOBAL_SETTINGS.vote.voteDisplayProps,


### PR DESCRIPTION
Reworks the settings editor for in-game commands, and generalizes timeout aliases into command aliases.

## Prefix editor

Prefixes are now numbered cards. Editing a prefix's characters propagates the rewrite to every command string and alias that uses it (matched by longest prefix, committed on blur rather than per keystroke); one is marked default via a radio; a prefix that's in use or is the default can't be removed. `PrefixSchema` constrains prefixes to ASCII punctuation and the editor mirrors that validation. Each command renders as a compact card with `?` tooltips instead of verbose inline descriptions. `defaultPrefix` is chosen inline, so it's hidden from both the form and the TOC.

## Command aliases

`timeoutCommandAliases` (`{string, duration}`) becomes `commandAliases` (`{alias, command}`): a shortcut to a **complete** command invocation, e.g. `/rules` = `/broadcast Read the rules`.

An alias is a plain text substitution done up front in `handleCommand`, so scope, enabled and arg resolution all run against the command it points at. Aliases take no arguments of their own (anything typed after is ignored), and a real command string still wins on collision.

### Why the old timeout aliases can't be carried across

They pinned `duration` while taking `<player>` at call time, and `timeout` is declared `<player> <duration> [reason]` — the fixed value sits mid-list, where no text splice can put it. Migration 0080 drops them and logs which. Pinning args by name (`/timeout duration=2h`) is the documented future extension if aliases ever need arguments.

### Validation is deliberately split

- **Malformed args block the save** (missing required arg, unparseable int/duration).
- **A command string that no longer resolves does not.** A later release renaming a command's strings must not stop the server booting; it shows as an `Unavailable` badge instead.
- A **disabled** target is likewise valid, shown as a `Disabled` badge, and both are filtered out of the in-game help listing.

## Breaking

Global settings key rename. **Migration 0080 required.**

## Testing

- 7 new unit tests over `resolveAliasCommand` / `findAlias`; full suite green (413 tests).
- All six validation cases exercised against the real schema (valid, disabled, unknown, missing arg, bad duration, alias/command clash).
- Verified in the browser: all three badge states, the blocking vs non-blocking save behavior, and the help dialog's Aliases section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)