### PR TITLE
Default NODE_ENV to test in the playwright config

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from '@playwright/test'
 
+// The fixtures import app modules that resolve env, which requires NODE_ENV. Vitest defaults it to
+// 'test' and the docker image sets it, but a bare `playwright test` has neither, so default it here
+// (config is loaded in every worker before the test files are).
+process.env.NODE_ENV ??= 'test'
+
 // E2E tests drive the real client against a real app instance backed by the squad server emulator
 // (see test/e2e/fixtures.ts). The app is spawned per test file by the fixture rather than by a
 // `webServer` here, because each one serves its own frontend on its own port.


### PR DESCRIPTION
## Problem

Every e2e test fails on `main` when run locally (`pnpm test:e2e`), all 17 dying in fixture setup with:

```
Error: Env errors:
Invalid value for NODE_ENV: expected one of "development"|"production"|"test"
  at ensureEnvSetup (src/server/env.ts:413)
  at env (src/systems/layer-artifacts.server.ts:48)
  at ensureLayerData (test/harness/app-fixture.ts:35)
```

The playwright worker process itself needs `NODE_ENV`, because the fixture imports `layer-artifacts.server` to resolve the layer artifact pair the same way the app under test does, and that module's env parser requires it.

Nothing sets it for playwright:
- vitest defaults `NODE_ENV=test`, so the unit and integration runs are fine
- the docker image sets `ENV NODE_ENV=test`, so `test:e2e:ci` is fine in CI
- `test:e2e` sets `NODE_ENV=production` only for the `vite build` step, so `playwright test` gets nothing

## Fix

Default it in `playwright.config.ts`, which is loaded in every worker before the test files are. That covers `pnpm test:e2e`, a bare `playwright test`, and IDE runs, rather than patching one script.

## Verification

On this branch: `pnpm test:e2e` 17 passed, `pnpm test` 406 passed, `pnpm test:integration` 25 passed / 2 skipped, plus `pnpm run check` and `pnpm run lint` clean.

Note for anyone reproducing in a fresh worktree: `assets/layer-engine.wasm` is a gitignored build artifact, so run `pnpm run build:engine` first or the integration suite fails on an unrelated ENOENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)