### PR TITLE
Show admin cam status in the player list

### DIFF
--- a/src/components/teams-panel.tsx
+++ b/src/components/teams-panel.tsx
@@ -761,8 +761,13 @@ function nameColumn<T extends TeamsPanelModels.EnrichedPlayer>(helper: ColumnHel
 			const meta = table.options.meta as BasePlayerTableMeta
 			// let the enclosing row context menu (bulk-aware) handle right-clicks on the name
 			return (
-				<span onClick={e => e.stopPropagation()}>
+				<span onClick={e => e.stopPropagation()} className="inline-flex items-center gap-1">
 					<PlayerDisplay stores={meta.stores} player={row.original} matchId={meta.matchId} disableContextMenu />
+					{row.original.inAdminCam && (
+						<span title="In admin camera">
+							<Icons.Camera className="h-3 w-3 text-purple-500 shrink-0" />
+						</span>
+					)}
 				</span>
 			)
 		},

--- a/src/dev/emu-control.ts
+++ b/src/dev/emu-control.ts
@@ -96,6 +96,19 @@ export function createEmuCommands(ctx: { emu: Emulator; bm: BmServer }): { comma
 				return `${name} created squad ${squad.squadId} '${rest.join(' ')}' on team ${squad.teamId}`
 			},
 		},
+		cam: {
+			usage: 'cam <name> [off]       a player enters admin camera, or leaves it with `off`',
+			run: ([name, off]) => {
+				if (!name || (off && off !== 'off')) throw new Error('usage: cam <name> [off]')
+				const player = requirePlayer(name)
+				if (off) {
+					emu.world.unpossessAdminCam(player)
+					return `${name} left admin camera`
+				}
+				emu.world.possessAdminCam(player)
+				return `${name} entered admin camera`
+			},
+		},
 		end: {
 			usage: 'end [1|2]              end the match, optionally naming the winning team',
 			run: ([team]) => {

--- a/src/models/chat.models.test.ts
+++ b/src/models/chat.models.test.ts
@@ -322,3 +322,49 @@ describe('warn target summary grouping', () => {
 		expect(summaryFor(players, squads, ['a', 'c'])).toEqual({ type: 'players' })
 	})
 })
+
+describe('admin camera tracking', () => {
+	function seededState(players: SM.Player[]): CHAT.ChatState {
+		const state = CHAT.getInitialChatState()
+		state.interpolatedState.players = players
+		return state
+	}
+
+	function possessed(player: SM.PlayerId, id: number): SE.PossessedAdminCamera {
+		return { type: 'POSSESSED_ADMIN_CAMERA', id, time: id, matchId: 1, player }
+	}
+	function unpossessed(player: SM.PlayerId, id: number): SE.UnpossessedAdminCamera {
+		return { type: 'UNPOSSESSED_ADMIN_CAMERA', id, time: id, matchId: 1, player }
+	}
+
+	it('tracks possess and unpossess', () => {
+		const state = seededState([makePlayer('a'), makePlayer('b')])
+		CHAT.handleEvent(state, possessed('a', 1))
+		CHAT.handleEvent(state, possessed('b', 2))
+		expect(state.interpolatedState.adminCamPlayerIds).toEqual(['a', 'b'])
+
+		CHAT.handleEvent(state, unpossessed('a', 3))
+		expect(state.interpolatedState.adminCamPlayerIds).toEqual(['b'])
+	})
+
+	it('drops a player who disconnects while in admin camera', () => {
+		const state = seededState([makePlayer('a')])
+		CHAT.handleEvent(state, possessed('a', 1))
+		CHAT.handleEvent(state, { type: 'PLAYER_DISCONNECTED', id: 2, time: 2, matchId: 1, player: 'a' })
+		expect(state.interpolatedState.adminCamPlayerIds).toEqual([])
+	})
+
+	it('assumes nobody is in admin camera after a RESET', () => {
+		const state = seededState([makePlayer('a')])
+		CHAT.handleEvent(state, possessed('a', 1))
+		CHAT.handleEvent(state, {
+			type: 'RESET',
+			id: 2,
+			time: 2,
+			matchId: 1,
+			source: 'rcon-reconnected',
+			state: { players: [makePlayer('a')], squads: [] },
+		})
+		expect(state.interpolatedState.adminCamPlayerIds).toEqual([])
+	})
+})

--- a/src/models/chat.models.ts
+++ b/src/models/chat.models.ts
@@ -56,6 +56,9 @@ export type InterpolableState = {
 	squads: SM.UniqueSquad[]
 	// per-match combat stats, keyed by player id. kept separate from players rather than stored on them
 	playerStats: PlayerStatsMap
+	// players currently in admin camera, tracked from POSSESSED/UNPOSSESSED_ADMIN_CAMERA. kept separate from players
+	// since the roster is replaced wholesale by the teams poll, which knows nothing about admin camera
+	adminCamPlayerIds: SM.PlayerId[]
 }
 
 export namespace InterpolableState {
@@ -64,6 +67,7 @@ export namespace InterpolableState {
 			players: state.players.map(p => ({ ...p, ids: { ...p.ids } })),
 			squads: [...state.squads],
 			playerStats: { ...state.playerStats },
+			adminCamPlayerIds: [...state.adminCamPlayerIds],
 		}
 	}
 }
@@ -189,6 +193,7 @@ export function getInitialInterpolatedState(): InterpolableState {
 		players: [],
 		squads: [],
 		playerStats: {},
+		adminCamPlayerIds: [],
 	}
 }
 
@@ -436,6 +441,9 @@ function interpolateEvent(
 		case 'NEW_GAME':
 		case 'RESET': {
 			if (event.type === 'NEW_GAME' || event.type === 'RESET') state.playerStats = {}
+			// RESET restates the roster from scratch and carries no admin camera information, so anyone we thought was
+			// in admin camera is no longer known to be
+			if (event.type === 'RESET') state.adminCamPlayerIds = []
 			applyEventTeamMutations(chatLog, state, event)
 			return event
 		}
@@ -470,6 +478,7 @@ function interpolateEvent(
 				return noop(`Player ${SM.PlayerIds.prettyPrint(event.player)} disconnected but was not found in the player list`)
 			}
 			const player = state.players[index]
+			state.adminCamPlayerIds = state.adminCamPlayerIds.filter(id => id !== event.player)
 			applyEventTeamMutations(chatLog, state, event)
 			return { ...event, player }
 		}
@@ -631,6 +640,12 @@ function interpolateEvent(
 			}
 			if (event.type === 'PLAYER_KICKED') {
 				return { ...event, player, reason: event.reason?.replace('Kicked from the server: ', '').trim() }
+			}
+			if (event.type === 'POSSESSED_ADMIN_CAMERA' && !state.adminCamPlayerIds.includes(event.player)) {
+				state.adminCamPlayerIds = [...state.adminCamPlayerIds, event.player]
+			}
+			if (event.type === 'UNPOSSESSED_ADMIN_CAMERA') {
+				state.adminCamPlayerIds = state.adminCamPlayerIds.filter(id => id !== event.player)
 			}
 			return { ...event, player }
 		}

--- a/src/models/teams-panel.models.ts
+++ b/src/models/teams-panel.models.ts
@@ -11,6 +11,7 @@ export type EnrichedPlayer = SM.Player & {
 	bmProfile: Omit<BM.PlayerFlagsAndProfile, 'playerIds'> | undefined
 	grouping?: string
 	stats: CHAT.PlayerStats | undefined
+	inAdminCam: boolean
 }
 
 export namespace Sel {
@@ -36,12 +37,13 @@ export namespace Sel {
 			[
 				(...[store, currentMatch]: Inputs) => ChatPrt.Sel.playersForTeam(teamId)(store, currentMatch),
 				(...[store]: Inputs) => ChatPrt.Sel.chatState(store).playerStats,
+				(...[store]: Inputs) => ChatPrt.Sel.chatState(store).adminCamPlayerIds,
 				(...[, , bmData]: Inputs) => bmData,
 				(...[, , , bmStore]: Inputs) => bmStore.selectedModeId,
 				(...[, , , bmStore]: Inputs) => bmStore.orgFlags,
 				(...[, , , , settings]: Inputs) => settings?.playerFlagGroupings,
 			],
-			(players, playerStats, bmData, selectedModeId, orgFlags, groupings) => {
+			(players, playerStats, adminCamPlayerIds, bmData, selectedModeId, orgFlags, groupings) => {
 				const playerFlagGroupings = groupings ?? BM.EMPTY_PLAYER_FLAG_GROUPINGS
 				const modeIds = BM.getGroupingModeIds(playerFlagGroupings)
 				const activeModeId = selectedModeId !== null && modeIds.includes(selectedModeId)
@@ -68,6 +70,7 @@ export namespace Sel {
 						bmProfile: profile ? Obj.omit(profile, ['playerIds']) : undefined,
 						grouping: allGroups.get(playerId),
 						stats: playerStats[playerId],
+						inAdminCam: adminCamPlayerIds.includes(playerId),
 					}
 				})
 			},


### PR DESCRIPTION
Players currently in admin camera now get a camera icon next to their name in the teams panel, matching the icon the admin cam feed events already use.

## How it works
- `CHAT.InterpolableState` gains `adminCamPlayerIds`, folded from `POSSESSED_ADMIN_CAMERA` / `UNPOSSESSED_ADMIN_CAMERA`. It is kept separate from `players` because the roster is replaced wholesale by the teams poll, which knows nothing about admin camera.
- `RESET` clears it: it restates the roster from scratch and carries no admin camera information, so nobody is assumed to be in cam afterwards. A disconnect drops that player too.
- `TeamsPanelModels.EnrichedPlayer` exposes `inAdminCam`, derived in the existing `playersForTeam` selector.
- The icon renders in the teams-panel name column rather than in `PlayerDisplay`, so it stays out of the chat feed.

## Also here
`pnpm emuctl cam <name> [off]` -- the emulator world could already possess/unpossess admin camera, but nothing exposed it, so the events were not drivable from a dev instance.

## Testing
Verified against a real dev instance (`dev:init` / `dev:emu` / `dev`) driven with `emuctl`:
- `cam Alice` -> only Alice gets the icon, Bob and Carol do not.
- `cycle` (rcon reconnect -> RESET) -> icon clears for everyone.
- `cam Carol` then `cam Carol off` -> icon appears and clears live.

Also 3 new cases in `chat.models.test.ts`; 41/41 pass across chat + emulator tests. `tsc -b --force` and `oxlint` clean.

State is client-side only, so no persisted data or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)