### PR TITLE
Hide the Hide Repeats checkbox when there's no cursor

### DIFF
--- a/src/components/select-layers-dialog.tsx
+++ b/src/components/select-layers-dialog.tsx
@@ -109,6 +109,7 @@ const SelectLayersDialogContent = React.memo<SelectLayersDialogContentProps>(fun
 	}, [fullTableWidth])
 
 	const canSubmit = ZusUtils.useStore(frameKey, (s) => s.layerTable.selected.length > 0 && !submitted)
+	const showPoolCheckboxes = ZusUtils.useStore(frameKey, SelectLayersFrame.Sel.repeatRulesApplicable)
 
 	const submit = props.selectQueueItems
 		? () => {
@@ -160,7 +161,7 @@ const SelectLayersDialogContent = React.memo<SelectLayersDialogContentProps>(fun
 				<div className="flex flex-col space-y-2 justify-between h-full">
 					<div className="flex h-full">
 						<LayerTable
-							extraPanelItems={<PoolCheckboxes stores={{ poolCheckboxes: frameKey }} />}
+							extraPanelItems={showPoolCheckboxes ? <PoolCheckboxes stores={{ poolCheckboxes: frameKey }} /> : undefined}
 							stores={{ layerTable: frameKey }}
 							canChangeRowsPerPage={false}
 							canToggleColumns

--- a/src/frames/select-layers.frame.ts
+++ b/src/frames/select-layers.frame.ts
@@ -195,6 +195,12 @@ export const frame = frameManager.createFrame<Types>({
 export namespace Sel {
 	const EMPTY_LAYER_ITEMS = LQY.initLayerItemsState()
 
+	// repeat rules are evaluated against the layers surrounding a position in the list, so without a cursor there's
+	// nothing for them to say
+	export function repeatRulesApplicable(state: State) {
+		return state.cursor !== undefined
+	}
+
 	export function preMenuFilteredQueryInput(
 		state: State,
 		squadServer?: SquadServerFrame.State,


### PR DESCRIPTION
The "Hide Repeats" checkbox showed up on the Explore Layers dialog, where it does nothing useful: Explore builds its `selectLayers` frame with no cursor, and repeat rules are evaluated against the layers surrounding a position in the list.

`SelectLayersDialog` now renders `PoolCheckboxes` only when the frame has a cursor, via a new `Sel.repeatRulesApplicable` selector on the select-layers frame. The queue-driven dialogs (edit layer, add layer at a cursor) are unaffected; `gen-vote-dialog` has its own frame and was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)