### PR TITLE
trim settings grants referencing non-existent settings

### DIFF
--- a/src/models/settings.models.ts
+++ b/src/models/settings.models.ts
@@ -114,6 +114,67 @@ export function serverSettingsGrantableTopLevelKeys(): string[] {
 
 export type RbacSettings = z.infer<typeof RbacSettingsSchema>
 
+// Grants reference settings by path, so a setting a later SLM release renames or removes leaves behind grants the
+// RbacSettingsSchema refine above rejects -- taking the whole install down at boot over a reference that is merely
+// stale. Drop those grants instead (same reasoning as unresolvable command aliases below) and hand the caller a
+// description of each one to report. Operates on raw settings, so it must run before the schema parses them.
+export function trimStaleSettingsGrants(raw: unknown): { settings: unknown; dropped: string[] } {
+	const dropped: string[] = []
+	if (!raw || typeof raw !== 'object') return { settings: raw, dropped }
+	const rbac = (raw as Record<string, unknown>).rbac
+	if (!rbac || typeof rbac !== 'object') return { settings: raw, dropped }
+	const rolesRaw = (rbac as Record<string, unknown>).roles
+	if (!rolesRaw || typeof rolesRaw !== 'object') return { settings: raw, dropped }
+
+	const globalKeys = globalSettingsTopLevelKeys()
+	const serverKeys = serverSettingsGrantableTopLevelKeys()
+	// only the head segment is checked, matching the refine: deeper segments that don't resolve simply never match a write
+	const keepPaths = (paths: unknown, liveKeys: string[], describe: (path: string, index: number) => string) => {
+		if (!Array.isArray(paths)) return paths
+		const kept = paths.filter((p, i) => {
+			if (typeof p !== 'string' || liveKeys.includes(p.split('.')[0])) return true
+			dropped.push(describe(p, i))
+			return false
+		})
+		return kept.length === paths.length ? paths : kept
+	}
+
+	let rolesChanged = false
+	const roles: Record<string, unknown> = {}
+	for (const [roleId, cfgRaw] of Object.entries(rolesRaw as Record<string, unknown>)) {
+		roles[roleId] = cfgRaw
+		if (!cfgRaw || typeof cfgRaw !== 'object') continue
+		const cfg = cfgRaw as Record<string, unknown>
+
+		const globalGrants = keepPaths(
+			cfg.globalSettingsGrants,
+			globalKeys,
+			(path, i) => `rbac.roles.${roleId}.globalSettingsGrants[${i}] ("${path}")`,
+		)
+
+		let serverGrants = cfg.serverSettingsGrants
+		if (Array.isArray(serverGrants)) {
+			const nextGrants = serverGrants.map((grantRaw, gi) => {
+				if (!grantRaw || typeof grantRaw !== 'object') return grantRaw
+				const grant = grantRaw as Record<string, unknown>
+				const paths = keepPaths(
+					grant.paths,
+					serverKeys,
+					(path, i) => `rbac.roles.${roleId}.serverSettingsGrants[${gi}].paths[${i}] ("${path}")`,
+				)
+				return paths === grant.paths ? grantRaw : { ...grant, paths }
+			})
+			if (nextGrants.some((g, i) => g !== (serverGrants as unknown[])[i])) serverGrants = nextGrants
+		}
+
+		if (globalGrants === cfg.globalSettingsGrants && serverGrants === cfg.serverSettingsGrants) continue
+		roles[roleId] = { ...cfg, globalSettingsGrants: globalGrants, serverSettingsGrants: serverGrants }
+		rolesChanged = true
+	}
+	if (!rolesChanged) return { settings: raw, dropped }
+	return { settings: { ...(raw as Record<string, unknown>), rbac: { ...(rbac as Record<string, unknown>), roles } }, dropped }
+}
+
 export const NavLinkSchema = z.array(z.object({
 	label: z.string(),
 	url: z.url(),

--- a/src/systems/settings.server.ts
+++ b/src/systems/settings.server.ts
@@ -50,8 +50,18 @@ async function loadGlobalSettings(ctx: C.Db) {
 		log.info('Created default global settings row')
 	} else {
 		const raw = unsuperjsonify(Schema.globalSettings, rows[0]) as any
+		// the trim isn't written back: it costs nothing to redo each boot, and leaving the row alone keeps the grants
+		// recoverable if the setting they name comes back under a migration
+		const trimRes = SETTINGS.trimStaleSettingsGrants(raw.settings)
+		if (trimRes.dropped.length > 0) {
+			log.warn(
+				'Ignoring %d settings grant(s) referencing settings that no longer exist: %s',
+				trimRes.dropped.length,
+				trimRes.dropped.join(', '),
+			)
+		}
 		// seeds any command this installation's settings predate (see SETTINGS.parseGlobalSettings)
-		const parseRes = SETTINGS.parseGlobalSettings(raw.settings)
+		const parseRes = SETTINGS.parseGlobalSettings(trimRes.settings)
 		if (!parseRes.success) {
 			// refuse to start rather than silently reset to defaults: a validation failure means either a bad manual
 			// edit or a breaking schema change with a missing/incorrect migration, and booting on defaults would quietly


### PR DESCRIPTION
A grant referencing a setting that a later SLM release renamed or removed (e.g. `timeoutCommandAliases` after migration 0080) fails the `RbacSettingsSchema` refine, and `loadGlobalSettings` refuses to boot on a global-settings validation failure. The result is a fatal at startup over a reference that is merely stale.

`SETTINGS.trimStaleSettingsGrants` now drops grants whose head segment is not a current setting key -- both `globalSettingsGrants` and `serverSettingsGrants[].paths` -- and returns a description of each one. `loadGlobalSettings` runs it before parsing and logs a single warning listing what it ignored. Same reasoning as the existing carve-out for command aliases that no longer resolve.

Nothing further happens: the trim is not written back to the DB (so the grants come back for free if a migration restores the setting), the refine still rejects bad grants coming from an editor save, and the trim is copy-on-write so the stored blob is untouched.

Verified against the reported payload: a role carrying `timeoutCommandAliases` plus a stale server-settings path fails `parseGlobalSettings` before the trim and parses after it, keeping every live grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)