### PR TITLE
don't tag :latest or deploy from a stale main commit

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -147,8 +147,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, quality-checks, integration-tests]
     if: github.ref == 'refs/heads/main'
+    outputs:
+      is-current: ${{ steps.tip.outputs.IS_CURRENT }}
     steps:
+      # runs gated on the integration suite can finish out of order, so an older
+      # commit's run must not clobber :latest (or deploy) behind a newer one
+      - name: Check this commit is still the tip of main
+        id: tip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TIP_SHA=$(gh api "repos/${{ github.repository }}/commits/main" --jq '.sha')
+          if [[ "$TIP_SHA" == "${{ github.sha }}" ]]; then
+            echo "IS_CURRENT=true" >> $GITHUB_OUTPUT
+          else
+            echo "IS_CURRENT=false" >> $GITHUB_OUTPUT
+            echo "::notice::main has moved to $TIP_SHA; skipping latest tag and deploy for ${{ github.sha }}"
+          fi
+
       - name: Login to GitHub Container Registry
+        if: steps.tip.outputs.IS_CURRENT == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -156,6 +174,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tag image as latest
+        if: steps.tip.outputs.IS_CURRENT == 'true'
         run: |
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           COMMIT_TAG="${{ needs.build.outputs.image-tag }}"
@@ -167,7 +186,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [build, quality-checks, integration-tests, tag-latest]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && needs.tag-latest.outputs.is-current == 'true'
     steps:
       - name: Run deployment script from variable
         env:


### PR DESCRIPTION
## Problem

`tag-latest` and `deploy` are gated on `integration-tests`, whose runtime varies. Two pushes to `main` landing close together produce two runs, and nothing orders them: if the older commit's suite happens to finish last, it tags `:latest` last and `:latest` ends up pointing at the older image. `deploy` inherits the same race and ships the older commit to production, which is the worse half.

## Fix

`tag-latest` now checks that `github.sha` is still the tip of `main` (via `gh api repos/{repo}/commits/main`) before doing anything, and exposes the answer as an `is-current` output that `deploy` gates on. A superseded run logs a notice and skips both, leaving `:latest` and production on the newer commit. The commit-SHA and branch tags still get pushed by `build` regardless, so nothing that identifies the older image is lost.

An alternative would be a `concurrency` group on `main` with `cancel-in-progress`, but that also kills the older run's build and its commit tag. This keeps the change to the two jobs that actually care about ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)