### PR TITLE
Restructure player groupings around groupings and groups

### DIFF
--- a/src/components/bm-flag-picker.tsx
+++ b/src/components/bm-flag-picker.tsx
@@ -23,11 +23,18 @@ export function FlagBadge({ flag, className }: { flag: BM.PlayerFlag; className?
 	)
 }
 
-// shows a resolved flag badge if the id is known, otherwise the raw id (so stale/unknown ids stay visible + removable)
+// A flag id that resolves to nothing: removed from the org, or config written against a different one. Flag ids are
+// uuids and tell a reader nothing, so say what is wrong instead and keep the id in the tooltip for whoever fixes it.
+// The entry stays present and removable either way -- a reference is never silently dropped.
+export function UnknownFlagLabel({ id }: { id: string }) {
+	return <span className="text-xs italic text-muted-foreground" title={`Unknown flag: ${id}`}>Unknown flag</span>
+}
+
+// shows a resolved flag badge if the id is known, otherwise marks it unknown (never the bare uuid)
 export function FlagLabel({ id, flags }: { id: string; flags: BM.PlayerFlag[] | undefined }) {
 	const flag = flags?.find((f) => f.id === id)
 	if (flag) return <FlagBadge flag={flag} />
-	return <span className="font-mono text-xs text-muted-foreground">{id}</span>
+	return <UnknownFlagLabel id={id} />
 }
 
 function useFlagOptions(): ComboBoxOption<string>[] | typeof LOADING {
@@ -108,6 +115,10 @@ export function BmFlagSelect(
 	}
 	if (selectable !== LOADING && exclude?.length) {
 		selectable = selectable.filter((o) => o.value === value || !exclude.includes(o.value))
+	}
+	// an unresolved id has no option to take a label from, and ComboBox would fall back to printing the raw uuid
+	if (selectable !== LOADING && value && !selectable.some((o) => o.value === value)) {
+		selectable = [...selectable, { value, label: <UnknownFlagLabel id={value} />, keywords: ['unknown'] }]
 	}
 	return (
 		<ComboBox

--- a/src/components/bm-flag-picker.tsx
+++ b/src/components/bm-flag-picker.tsx
@@ -3,7 +3,6 @@ import type { ComboBoxOption } from '@/components/combo-box/combo-box'
 import ComboBoxMulti from '@/components/combo-box/combo-box-multi'
 import { LOADING } from '@/components/combo-box/constants.ts'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 import type * as BM from '@/models/battlemetrics.models'
 import { useOrgFlags } from '@/systems/battlemetrics.client'
@@ -85,102 +84,30 @@ export function BmFlagMultiSelect(
 	)
 }
 
-// editor for a Record<flagId, priority> map (e.g. a flag grouping's `associations`)
-export function FlagPriorityMap(
-	{ value, onChange, disabled }: { value: Record<string, number>; onChange: (next: Record<string, number>) => void; disabled?: boolean },
+// single flag select. `exclude` drops flags already spoken for by a sibling row.
+export function BmFlagSelect(
+	{ value, onChange, disabled, exclude, className }: {
+		value: string | undefined
+		onChange: (next: string) => void
+		disabled?: boolean
+		exclude?: string[]
+		className?: string
+	},
 ) {
-	const orgFlags = useOrgFlags()
 	const options = useFlagOptions()
-	const entries = Object.entries(value)
-	const addOptions = options === LOADING ? LOADING : options.filter((o) => !(o.value in value))
-
-	function setPriority(id: string, priority: number) {
-		onChange({ ...value, [id]: priority })
-	}
-	function remove(id: string) {
-		const next = { ...value }
-		delete next[id]
-		onChange(next)
-	}
-	function add(id: string) {
-		const nextPriority = entries.length === 0 ? 1 : Math.max(...entries.map(([, p]) => p)) + 1
-		onChange({ ...value, [id]: nextPriority })
-	}
-
+	const selectable = options === LOADING || !exclude?.length
+		? options
+		: options.filter((o) => o.value === value || !exclude.includes(o.value))
 	return (
-		<div className="space-y-1.5">
-			{entries.length === 0 && <p className="text-xs text-muted-foreground">No flags in this group.</p>}
-			<ul className="space-y-1">
-				{entries.map(([id, priority]) => (
-					<li key={id} className="grid grid-cols-[minmax(0,1fr)_auto_5rem_auto] items-center gap-2">
-						<div className="min-w-0 overflow-hidden">
-							<FlagLabel id={id} flags={orgFlags} />
-						</div>
-						<label className="text-xs text-muted-foreground">priority</label>
-						<Input
-							type="number"
-							className="h-8 w-full"
-							value={priority}
-							disabled={disabled}
-							onChange={(e) => setPriority(id, e.target.valueAsNumber)}
-						/>
-						<Button
-							type="button"
-							size="icon"
-							variant="ghost"
-							className="h-6 w-6 text-destructive"
-							disabled={disabled}
-							onClick={() => remove(id)}
-						>
-							<Icons.X className="h-4 w-4" />
-						</Button>
-					</li>
-				))}
-			</ul>
-			<ComboBox
-				title="Add flag"
-				value={undefined}
-				options={addOptions}
-				disabled={disabled}
-				onSelect={(id) => {
-					if (id) add(id)
-				}}
-			/>
-		</div>
-	)
-}
-
-// a value that is either a flag id (color taken from that flag) or a raw CSS color (e.g. "#ef4444")
-export function BmFlagOrColorSelect(
-	{ value, onChange, disabled }: { value: string; onChange: (next: string) => void; disabled?: boolean },
-) {
-	const orgFlags = useOrgFlags()
-	const options = useFlagOptions()
-	const isKnownFlag = orgFlags?.some((f) => f.id === value)
-	return (
-		<div className="flex items-center gap-2">
-			<ComboBox
-				className="flex-1"
-				title="Flag color"
-				value={isKnownFlag ? value : undefined}
-				options={options}
-				disabled={disabled}
-				onSelect={(id) => {
-					if (id) onChange(id)
-				}}
-			/>
-			<span className="text-xs text-muted-foreground">or</span>
-			<Input
-				className="w-28 font-mono"
-				placeholder="#rrggbb"
-				value={isKnownFlag ? '' : value}
-				disabled={disabled}
-				onChange={(e) => onChange(e.target.value)}
-			/>
-			<span
-				className="h-6 w-6 rounded border shrink-0"
-				style={{ backgroundColor: isKnownFlag ? orgFlags?.find((f) => f.id === value)?.color ?? undefined : value }}
-			/>
-		</div>
+		<ComboBox
+			className={className}
+			title="Flag"
+			value={value}
+			options={selectable}
+			disabled={disabled}
+			onSelect={(id) => {
+				if (id) onChange(id)
+			}}
+		/>
 	)
 }

--- a/src/components/bm-flag-picker.tsx
+++ b/src/components/bm-flag-picker.tsx
@@ -84,24 +84,35 @@ export function BmFlagMultiSelect(
 	)
 }
 
-// single flag select. `exclude` drops flags already spoken for by a sibling row.
+// single flag select. `exclude` drops flags already spoken for by a sibling row; `only` narrows the choice to a given
+// set (and keeps their order), for callers where an arbitrary org flag would be meaningless.
 export function BmFlagSelect(
-	{ value, onChange, disabled, exclude, className }: {
+	{ value, onChange, disabled, exclude, only, title, className }: {
 		value: string | undefined
 		onChange: (next: string) => void
 		disabled?: boolean
 		exclude?: string[]
+		only?: string[]
+		title?: string
 		className?: string
 	},
 ) {
 	const options = useFlagOptions()
-	const selectable = options === LOADING || !exclude?.length
-		? options
-		: options.filter((o) => o.value === value || !exclude.includes(o.value))
+	let selectable = options
+	if (selectable !== LOADING && only) {
+		const byId = new Map(selectable.map((o) => [o.value, o]))
+		selectable = only.flatMap((id) => {
+			const option = byId.get(id)
+			return option ? [option] : []
+		})
+	}
+	if (selectable !== LOADING && exclude?.length) {
+		selectable = selectable.filter((o) => o.value === value || !exclude.includes(o.value))
+	}
 	return (
 		<ComboBox
 			className={className}
-			title="Flag"
+			title={title ?? 'Flag'}
 			value={value}
 			options={selectable}
 			disabled={disabled}

--- a/src/components/player-context-menu-options.tsx
+++ b/src/components/player-context-menu-options.tsx
@@ -259,7 +259,7 @@ export function PlayerMenuItems(
 		},
 	)
 
-	const grouping = ZusUtils.useStore(
+	const group = ZusUtils.useStore(
 		stores.squadServer,
 		MatchHistoryClient.currentMatch$(serverId),
 		BattlemetricsClient.playerBmData$,
@@ -275,7 +275,7 @@ export function PlayerMenuItems(
 			const player = SM.PlayerIds.find(ChatPrt.Sel.chatState(chatStore).players, p => p.ids, playerId)
 			if (player?.teamId == null) return undefined
 			const enriched = TeamsPanelModels.Sel.playersForTeam(player.teamId)(chatStore, currentMatch, bmData, bmStore, settings)
-			return SM.PlayerIds.find(enriched, p => p.ids, playerId)?.grouping
+			return SM.PlayerIds.find(enriched, p => p.ids, playerId)?.group
 		},
 	)
 
@@ -582,15 +582,15 @@ export function PlayerMenuItems(
 					<ContextMenuShortcut>{sc('⇧+click role cell', '⇧+Ctrl+click role cell')}</ContextMenuShortcut>
 				</Item>
 				<Item
-					disabled={grouping == null || teamMissing}
+					disabled={group == null || teamMissing}
 					onClick={() => {
-						if (grouping == null) return
+						if (group == null) return
 						TSWClient.Actions.ensureViewingTeams(serverId)
-						SquadServerFrame.Actions.selectGrouping(stores, grouping, teamId)
+						SquadServerFrame.Actions.selectGroup(stores, group, teamId)
 					}}
 				>
-					Grouping{grouping != null ? ` (${grouping})` : ''}
-					<ContextMenuShortcut>{sc('⇧+click grouping cell', '⇧+Ctrl+click grouping cell')}</ContextMenuShortcut>
+					Group{group != null ? ` (${group})` : ''}
+					<ContextMenuShortcut>{sc('⇧+click group cell', '⇧+Ctrl+click group cell')}</ContextMenuShortcut>
 				</Item>
 				<Item
 					disabled={!playerInfo?.isLeader || teamMissing}

--- a/src/components/player-details-window.tsx
+++ b/src/components/player-details-window.tsx
@@ -78,7 +78,6 @@ function PlayerDetailsWindow({ playerId, stores }: PlayerDetailsWindowProps) {
 	const { data: bmData } = useQuery(RPC.orpc.battlemetrics.getPlayerBmData.queryOptions({ input: { playerId }, staleTime: Infinity }))
 	const orgFlags = useOrgFlags()
 	const flags = bmData && orgFlags ? BM.resolveFlags(bmData.flagIds, orgFlags) : undefined
-	const groupColor = usePlayerGroupColor(playerId)
 	const profile = bmData ? (({ flagIds: _, ...rest }) => rest)(bmData) : null
 	const currentMatch = MatchHistoryClient.useCurrentMatch(serverId)
 	const currentMatchEvents = ZusUtils.useStore(
@@ -100,6 +99,7 @@ function PlayerDetailsWindow({ playerId, stores }: PlayerDetailsWindowProps) {
 	const livePlayer = ZusUtils.useStore(squadServerFrameKey, (s) => ChatPrt.Sel.player(playerId)(s) ?? null)
 	const recentPlayer = ZusUtils.useStore(squadServerFrameKey, (s) => ChatPrt.Sel.recentPlayer(playerId)(s) ?? null)
 	const ids = livePlayer?.ids ?? recentPlayer?.ids
+	const groupColor = usePlayerGroupColor(playerId, livePlayer?.adminGroups ?? recentPlayer?.adminGroups ?? [])
 
 	const connectionStatus = data?.connectionStatus ?? null
 	const elapsed = useElapsed(connectionStatus?.status === 'online' ? connectionStatus.connectedSince : null)

--- a/src/components/player-details-window.tsx
+++ b/src/components/player-details-window.tsx
@@ -15,7 +15,7 @@ import * as BM from '@/models/battlemetrics.models'
 import * as CHAT from '@/models/chat.models'
 import { WINDOW_ID } from '@/models/draggable-windows.models'
 import * as RPC from '@/orpc.client'
-import { useGroupedPlayerFlagColor, useOrgFlags } from '@/systems/battlemetrics.client'
+import { useOrgFlags, usePlayerGroupColor } from '@/systems/battlemetrics.client'
 import { DraggableWindowStore } from '@/systems/draggable-window.client'
 import * as MatchHistoryClient from '@/systems/match-history.client'
 import * as TimeoutsClient from '@/systems/timeouts.client'
@@ -78,7 +78,7 @@ function PlayerDetailsWindow({ playerId, stores }: PlayerDetailsWindowProps) {
 	const { data: bmData } = useQuery(RPC.orpc.battlemetrics.getPlayerBmData.queryOptions({ input: { playerId }, staleTime: Infinity }))
 	const orgFlags = useOrgFlags()
 	const flags = bmData && orgFlags ? BM.resolveFlags(bmData.flagIds, orgFlags) : undefined
-	const flagColor = useGroupedPlayerFlagColor(playerId)
+	const groupColor = usePlayerGroupColor(playerId)
 	const profile = bmData ? (({ flagIds: _, ...rest }) => rest)(bmData) : null
 	const currentMatch = MatchHistoryClient.useCurrentMatch(serverId)
 	const currentMatchEvents = ZusUtils.useStore(
@@ -117,7 +117,7 @@ function PlayerDetailsWindow({ playerId, stores }: PlayerDetailsWindowProps) {
 	return (
 		<div className="min-w-0 min-h-0 flex-1 flex flex-col">
 			<DraggableWindowDragBar>
-				<DraggableWindowTitle style={flagColor ? { color: flagColor } : undefined}>
+				<DraggableWindowTitle style={groupColor ? { color: groupColor } : undefined}>
 					{player?.ids.username ?? 'Player Details'}
 					{livePlayer && (livePlayer.teamId !== null || livePlayer.squadId !== null) && (
 						<span className="text-muted-foreground font-normal ml-1">

--- a/src/components/player-display.tsx
+++ b/src/components/player-display.tsx
@@ -57,7 +57,7 @@ export function PlayerDisplay(
 ) {
 	const playerId = SM.PlayerIds.getPlayerId(player.ids)
 	const windowProps: PlayerDetailsWindowProps = { playerId, stores }
-	const groupColor = usePlayerGroupColor(playerId)
+	const groupColor = usePlayerGroupColor(playerId, player.adminGroups)
 
 	return (
 		<span className={cn('inline-flex items-baseline', className)}>

--- a/src/components/player-display.tsx
+++ b/src/components/player-display.tsx
@@ -3,7 +3,7 @@ import * as SquadServerFrame from '@/frames/squad-server.frame'
 import { cn } from '@/lib/utils'
 import { WINDOW_ID } from '@/models/draggable-windows.models'
 import * as SM from '@/models/squad.models'
-import { useGroupedPlayerFlagColor } from '@/systems/battlemetrics.client'
+import { usePlayerGroupColor } from '@/systems/battlemetrics.client'
 import { ContextMenu } from '@radix-ui/react-context-menu'
 import * as Icons from 'lucide-react'
 import React from 'react'
@@ -57,7 +57,7 @@ export function PlayerDisplay(
 ) {
 	const playerId = SM.PlayerIds.getPlayerId(player.ids)
 	const windowProps: PlayerDetailsWindowProps = { playerId, stores }
-	const flagColor = useGroupedPlayerFlagColor(playerId)
+	const groupColor = usePlayerGroupColor(playerId)
 
 	return (
 		<span className={cn('inline-flex items-baseline', className)}>
@@ -89,7 +89,7 @@ export function PlayerDisplay(
 				playerId={SM.PlayerIds.getPlayerId(player.ids)}
 				stores={stores}
 				disableContextMenu={disableContextMenu}
-				style={flagColor ? { color: flagColor } : undefined}
+				style={groupColor ? { color: groupColor } : undefined}
 			/>
 			{(showTeam && player.teamId !== null) || (showSquad && player.squadId !== null)
 				? (

--- a/src/components/server-activity-charts.tsx
+++ b/src/components/server-activity-charts.tsx
@@ -269,17 +269,16 @@ export function ServerActivityCharts(props: {
 
 		const chartPlayers = slsOnly ? livePlayers.filter(p => p.isLeader) : livePlayers
 
-		// Build [eosId, flags[]] pairs for all live players — bmData is keyed by EOS ID
-		const playerFlagPairs: [SM.PlayerId, BM.PlayerFlag[]][] = chartPlayers
+		// Build [eosId, facts] pairs for all live players -- bmData is keyed by EOS ID
+		const playerFacts: [SM.PlayerId, PG.PlayerFacts][] = chartPlayers
 			.filter(p => p.ids.eos != null)
 			.map(p => {
 				const eosId = p.ids.eos!
 				const flagIds = bmData[eosId]?.flagIds ?? []
-				const flags = orgFlags ? BM.resolveFlags(flagIds, orgFlags) : []
-				return [eosId, flags]
+				return [eosId, { flags: orgFlags ? BM.resolveFlags(flagIds, orgFlags) : [], adminGroups: p.adminGroups }]
 			})
 
-		const playerGroups = PG.resolvePlayerGroups(playerFlagPairs, playerGroupings, activeGroupingId)
+		const playerGroups = PG.resolvePlayerGroups(playerFacts, playerGroupings, activeGroupingId)
 
 		// Count per group per team, with "Other" for unmatched players
 		// Group names are unique within a grouping, so we can use a Map for O(1) lookup

--- a/src/components/server-activity-charts.tsx
+++ b/src/components/server-activity-charts.tsx
@@ -5,6 +5,7 @@ import type * as SquadServerFrame from '@/frames/squad-server.frame'
 import * as ZusUtils from '@/lib/zustand'
 import * as BM from '@/models/battlemetrics.models'
 import * as L from '@/models/layer'
+import * as PG from '@/models/player-groupings.models'
 import type * as SM from '@/models/squad.models'
 import * as BattlemetricsClient from '@/systems/battlemetrics.client'
 import { GlobalSettingsStore } from '@/systems/client-only-settings.client'
@@ -210,14 +211,14 @@ export function ServerActivityCharts(props: {
 	const bmData = BattlemetricsClient.usePlayerBmData()
 	const orgFlags = BattlemetricsClient.useOrgFlags()
 	const config = ZusUtils.useStore(SettingsClient.PublicSettingsStore)
-	const playerFlagGroupings = config?.playerFlagGroupings
+	const playerGroupings = config?.playerGroupings
 
-	const groupingModeIds = React.useMemo(
-		() => playerFlagGroupings ? BM.getGroupingModeIds(playerFlagGroupings) : [],
-		[playerFlagGroupings],
+	const groupingIds = React.useMemo(
+		() => playerGroupings ? PG.getGroupingIds(playerGroupings) : [],
+		[playerGroupings],
 	)
 	const slsOnly = ZusUtils.useStore(BattlemetricsClient.Store, s => s.slsOnly)
-	const activeModeId = ZusUtils.useStore(BattlemetricsClient.Store, BattlemetricsClient.Sel.activeGroupingModeId(groupingModeIds))
+	const activeGroupingId = ZusUtils.useStore(BattlemetricsClient.Store, BattlemetricsClient.Sel.activeGroupingId(groupingIds))
 
 	const events = selectedMatchOrdinal !== null ? props.historicalEvents : liveUnfilteredEvents
 	const isEmpty = !events || events.length === 0
@@ -259,11 +260,12 @@ export function ServerActivityCharts(props: {
 		]
 	}, [displayTeamsNormalized, props.currentMatchOrdinal, props.layerId])
 
-	// Build flag group counts per team from live players
+	// Build group counts per team from live players
 	const flagGroupChart = React.useMemo(() => {
-		if (!playerFlagGroupings || !livePlayers || activeModeId === null) return null
+		if (!playerGroupings || !livePlayers || activeGroupingId === null) return null
 
-		const modeGroupings = playerFlagGroupings.groupings.filter(g => g.modeIds.includes(activeModeId))
+		const grouping = playerGroupings[activeGroupingId]
+		if (!grouping) return null
 
 		const chartPlayers = slsOnly ? livePlayers.filter(p => p.isLeader) : livePlayers
 
@@ -277,11 +279,11 @@ export function ServerActivityCharts(props: {
 				return [eosId, flags]
 			})
 
-		const playerGroups = BM.resolvePlayerFlagGroups(playerFlagPairs, playerFlagGroupings, activeModeId)
+		const playerGroups = PG.resolvePlayerGroups(playerFlagPairs, playerGroupings, activeGroupingId)
 
 		// Count per group per team, with "Other" for unmatched players
-		// Labels are unique within a mode, so we can use a Map for O(1) lookup
-		const groupLabels = [...modeGroupings.map(g => g.label), 'Other']
+		// Group names are unique within a grouping, so we can use a Map for O(1) lookup
+		const groupLabels = [...PG.getGroupNames(grouping), PG.UNGROUPED_LABEL]
 		const labelToIdx = new Map(groupLabels.map((label, i) => [label, i]))
 		const team1Counts = new Array(groupLabels.length).fill(0)
 		const team2Counts = new Array(groupLabels.length).fill(0)
@@ -303,21 +305,7 @@ export function ServerActivityCharts(props: {
 			}
 		}
 
-		// Build a flagId -> color lookup from org flags
-		const flagColorById = new Map<string, string>()
-		for (const flag of orgFlags ?? []) {
-			if (flag.color) flagColorById.set(flag.id, flag.color)
-		}
-
-		const groupColorByLabel = new Map(modeGroupings.map(g => [g.label, g.color]))
-		const resolveGroupColor = (label: string): string => {
-			const raw = groupColorByLabel.get(label)
-			if (!raw) return '#888'
-			// If raw looks like a UUID, treat it as a flag ID and look up its color
-			return flagColorById.get(raw) ?? raw
-		}
-
-		const groupColors = groupLabels.map(resolveGroupColor)
+		const groupColors = groupLabels.map(label => PG.getGroupColor(grouping, label))
 
 		return createFlagGroupChartOption(
 			groupLabels,
@@ -331,8 +319,8 @@ export function ServerActivityCharts(props: {
 			isDark,
 		)
 	}, [
-		playerFlagGroupings,
-		activeModeId,
+		playerGroupings,
+		activeGroupingId,
 		livePlayers,
 		slsOnly,
 		bmData,
@@ -388,18 +376,20 @@ export function ServerActivityCharts(props: {
 				<div>
 					<div className="flex items-center gap-1 px-1 mb-0.5">
 						<span className="text-xs text-muted-foreground">Team Breakdowns</span>
-						{groupingModeIds.length > 1 && (
+						{groupingIds.length > 1 && (
 							<div className="flex gap-0.5 ml-2">
-								{groupingModeIds.map(modeId => (
+								{groupingIds.map(groupingId => (
 									<button
 										type="button"
-										key={modeId}
-										onClick={() => BattlemetricsClient.Actions.setSelectedModeId(modeId)}
+										key={groupingId}
+										onClick={() => BattlemetricsClient.Actions.setSelectedGroupingId(groupingId)}
 										className={`text-xs px-2 py-0.5 rounded ${
-											activeModeId === modeId ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'
+											activeGroupingId === groupingId
+												? 'bg-primary text-primary-foreground'
+												: 'text-muted-foreground hover:text-foreground'
 										}`}
 									>
-										{modeId}
+										{groupingId}
 									</button>
 								))}
 							</div>

--- a/src/components/server-activity-charts.tsx
+++ b/src/components/server-activity-charts.tsx
@@ -305,7 +305,7 @@ export function ServerActivityCharts(props: {
 			}
 		}
 
-		const groupColors = groupLabels.map(label => PG.getGroupColor(grouping, label))
+		const groupColors = groupLabels.map(label => PG.getGroupColor(grouping, label, orgFlags))
 
 		return createFlagGroupChartOption(
 			groupLabels,

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -1,4 +1,4 @@
-import { BmFlagMultiSelect, BmFlagOrColorSelect, FlagPriorityMap } from '@/components/bm-flag-picker'
+import { BmFlagMultiSelect, BmFlagSelect } from '@/components/bm-flag-picker'
 import type { ComboBoxOption } from '@/components/combo-box/combo-box'
 import ComboBoxMulti from '@/components/combo-box/combo-box-multi'
 import { DiscordMemberSelect, DiscordRoleSelect } from '@/components/discord-picker'
@@ -34,10 +34,12 @@ import type * as BM from '@/models/battlemetrics.models'
 import * as CMD from '@/models/command.models'
 import type * as LP from '@/models/labeled-presets.models'
 import * as LC from '@/models/layer-columns'
+import * as PG from '@/models/player-groupings.models'
 import * as SETTINGS from '@/models/settings.models'
 import type * as SM from '@/models/squad.models'
 import * as RPC from '@/orpc.client'
 import * as RBAC from '@/rbac.models'
+import * as BattlemetricsClient from '@/systems/battlemetrics.client'
 import * as ConfigClient from '@/systems/config.client'
 import * as SettingsClient from '@/systems/settings.client'
 import * as UsersClient from '@/systems/users.client'
@@ -366,139 +368,278 @@ function FlagMultiSelectField({ value$, reset$, onChange }: OverrideProps) {
 	return <BmFlagMultiSelect value={value ?? []} onChange={onChange} />
 }
 
-type FlagGrouping = BM.PlayerFlagGrouping
-type FlagGroupingsValue = { modeIds?: string[]; groupings?: FlagGrouping[] }
+type PlayerGroupingsValue = Record<string, PG.Grouping | undefined>
 
-function newFlagGrouping(): FlagGrouping {
-	return { label: '', modeIds: [], associations: {}, color: '' }
+// A group's color is seeded from the flag of the first rule naming it, so picking flags is usually all an operator has to
+// do. An entry that already exists is never re-derived -- an explicit color would otherwise be undone by a flag change.
+// Half-finished rules must not leave an entry behind: a placeholder written before a flag is picked would count as
+// existing and block the seeding it is standing in for.
+function syncedGroups(grouping: PG.Grouping, orgFlags: BM.PlayerFlag[] | undefined): Record<string, PG.Group> {
+	const groups: Record<string, PG.Group> = {}
+	for (const rule of grouping.rules) {
+		if (!rule.group || groups[rule.group]) continue
+		const existing = grouping.groups?.[rule.group]
+		if (existing) {
+			groups[rule.group] = existing
+			continue
+		}
+		const derived = derivedGroupColor(grouping, rule.group, orgFlags)
+		if (derived) groups[rule.group] = { color: derived }
+	}
+	return groups
 }
 
-// bespoke editor for `playerFlagGroupings`: display modes are declared upfront (as chips), and each grouping picks its
-// modes from that declared list (dropdown) plus a label, color and priority-ordered flag associations.
-function PlayerFlagGroupingsField({ value$, reset$, onChange }: OverrideProps) {
-	const value = (useFieldValue(value$, reset$) as FlagGroupingsValue) ?? {}
-	const modeIds = value.modeIds ?? []
-	const groupings = value.groupings ?? []
+// undefined until some flag of the group actually carries a color -- callers leave the entry out rather than pinning a
+// placeholder, so `getGroupColor`'s fallback covers the gap and a later flag pick can still seed it.
+function derivedGroupColor(grouping: PG.Grouping, group: string, orgFlags: BM.PlayerFlag[] | undefined): string | undefined {
+	for (const rule of grouping.rules) {
+		if (rule.group !== group) continue
+		const color = orgFlags?.find((f) => f.id === rule.flag)?.color
+		if (color) return color
+	}
+	return undefined
+}
 
-	// `quiet` skips reset$: use it for the uncontrolled label input, where re-emitting would clobber an in-flight keystroke.
-	// Structural edits (add/remove modes or groupings) leave it off so the label inputs re-seed after re-indexing.
-	const update = React.useCallback((fn: (v: FlagGroupingsValue) => FlagGroupingsValue, quiet?: boolean) => {
-		onChange(fn((value$.getValue() as FlagGroupingsValue) ?? {}))
+// bespoke editor for `playerGroupings`. Each grouping is an ordered rule list (first match wins), so priority is row
+// position rather than a number. Group colors are derived from the rules' flags and kept in a secondary section.
+function PlayerGroupingsField({ value$, reset$, onChange }: OverrideProps) {
+	const value = (useFieldValue(value$, reset$) as PlayerGroupingsValue) ?? {}
+	const groupingIds = Object.keys(value)
+	const orgFlags = BattlemetricsClient.useOrgFlags()
+
+	// `quiet` skips reset$: use it for edits driven by an uncontrolled input (the group name), where re-emitting would
+	// clobber an in-flight keystroke. Structural edits leave it off so inputs re-seed after re-indexing.
+	const update = React.useCallback((fn: (v: PlayerGroupingsValue) => PlayerGroupingsValue, quiet?: boolean) => {
+		onChange(fn((value$.getValue() as PlayerGroupingsValue) ?? {}))
 		if (!quiet) reset$.next()
 	}, [onChange, value$, reset$])
 
-	const [newMode, setNewMode] = React.useState('')
-	const trimmedMode = newMode.trim()
-	const canAddMode = trimmedMode.length > 0 && !modeIds.includes(trimmedMode)
-	function addMode() {
-		if (!canAddMode) return
-		update((v) => ({ ...v, modeIds: [...(v.modeIds ?? []), trimmedMode] }))
-		setNewMode('')
-	}
-	// removing a mode also strips it from every grouping that referenced it
-	function removeMode(id: string) {
-		update((v) => ({
-			...v,
-			modeIds: (v.modeIds ?? []).filter((m) => m !== id),
-			groupings: (v.groupings ?? []).map((g) => ({ ...g, modeIds: g.modeIds.filter((m) => m !== id) })),
-		}))
-	}
+	// every rule edit re-syncs the group map, so a group can never outlive the last rule naming it
+	const updateGrouping = React.useCallback((id: string, fn: (g: PG.Grouping) => PG.Grouping, quiet?: boolean) => {
+		update((v) => {
+			const next = fn(v[id] ?? PG.EMPTY_GROUPING)
+			return { ...v, [id]: { ...next, groups: syncedGroups(next, orgFlags) } }
+		}, quiet)
+	}, [update, orgFlags])
 
+	const [newGrouping, setNewGrouping] = React.useState('')
+	const trimmedNew = newGrouping.trim()
+	const canAdd = trimmedNew.length > 0 && !(trimmedNew in value)
 	function addGrouping() {
-		update((v) => ({ ...v, groupings: [...(v.groupings ?? []), newFlagGrouping()] }))
+		if (!canAdd) return
+		update((v) => ({ ...v, [trimmedNew]: PG.EMPTY_GROUPING }))
+		setNewGrouping('')
 	}
-	function removeGrouping(idx: number) {
-		update((v) => ({ ...v, groupings: (v.groupings ?? []).filter((_, i) => i !== idx) }))
+	function removeGrouping(id: string) {
+		update((v) => {
+			const next = { ...v }
+			delete next[id]
+			return next
+		})
 	}
-	function changeGrouping(idx: number, patch: Partial<FlagGrouping>, quiet?: boolean) {
-		update((v) => ({ ...v, groupings: (v.groupings ?? []).map((g, i) => i === idx ? { ...g, ...patch } : g) }), quiet)
-	}
-
-	const modeOptions: ComboBoxOption<string>[] = modeIds.map((id) => ({ value: id, label: id }))
 
 	return (
 		<div className="space-y-4">
-			<div className="space-y-1.5">
-				<Label className="text-sm font-medium">Grouping modes</Label>
-				<p className="text-xs text-muted-foreground">Declared upfront; each grouping and the players panel select from these.</p>
-				<div className="flex flex-wrap items-center gap-1.5">
-					{modeIds.length === 0 && <span className="text-xs text-muted-foreground">No modes defined.</span>}
-					{modeIds.map((id) => (
-						<span key={id} className="flex items-center gap-1 rounded border bg-background px-1.5 py-0.5 text-xs">
-							{id}
-							<button type="button" className="text-destructive" aria-label={`Remove mode ${id}`} onClick={() => removeMode(id)}>
-								<Icons.X className="h-3 w-3" />
-							</button>
-						</span>
-					))}
-				</div>
-				<div className="flex max-w-sm items-center gap-2">
-					<Input
-						placeholder="New mode id"
-						value={newMode}
-						onChange={(e) => setNewMode(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === 'Enter') {
-								e.preventDefault()
-								addMode()
-							}
-						}}
-					/>
-					<Button type="button" variant="outline" size="sm" disabled={!canAddMode} onClick={addMode}>Add mode</Button>
-				</div>
+			{groupingIds.length === 0 && (
+				<p className="text-xs text-muted-foreground">
+					No groupings defined. A grouping is one way of sorting players into groups; the players panel and activity charts pick between
+					them by name.
+				</p>
+			)}
+			{groupingIds.map((id) => (
+				<GroupingCard
+					key={id}
+					groupingId={id}
+					grouping={value[id] ?? PG.EMPTY_GROUPING}
+					value$={scopeValue(value$, id)}
+					reset$={reset$}
+					orgFlags={orgFlags}
+					onUpdate={updateGrouping}
+					onRemove={removeGrouping}
+				/>
+			))}
+			<div className="flex max-w-sm items-center gap-2">
+				<Input
+					placeholder="New grouping name"
+					value={newGrouping}
+					onChange={(e) => setNewGrouping(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter') {
+							e.preventDefault()
+							addGrouping()
+						}
+					}}
+				/>
+				<Button type="button" variant="outline" size="sm" disabled={!canAdd} onClick={addGrouping}>
+					<Icons.Plus className="mr-1 h-4 w-4" />Add grouping
+				</Button>
+			</div>
+		</div>
+	)
+}
+
+function GroupingCard(
+	{ groupingId, grouping, value$, reset$, orgFlags, onUpdate, onRemove }: {
+		groupingId: string
+		grouping: PG.Grouping
+		value$: ValueState
+		reset$: Rx.Subject<void>
+		orgFlags: BM.PlayerFlag[] | undefined
+		onUpdate: (id: string, fn: (g: PG.Grouping) => PG.Grouping, quiet?: boolean) => void
+		onRemove: (id: string) => void
+	},
+) {
+	const rules = grouping.rules ?? []
+	// a rule the operator is still filling in names no group yet, and an unnamed color row is just noise
+	const groupNames = PG.getGroupNames(grouping).filter(Boolean)
+
+	function changeRule(idx: number, patch: Partial<PG.GroupRule>, quiet?: boolean) {
+		onUpdate(groupingId, (g) => ({ ...g, rules: g.rules.map((r, i) => i === idx ? { ...r, ...patch } : r) }), quiet)
+	}
+	function addRule() {
+		onUpdate(groupingId, (g) => ({ ...g, rules: [...g.rules, { type: 'battlemetrics', flag: '', group: '' }] }))
+	}
+	function removeRule(idx: number) {
+		onUpdate(groupingId, (g) => ({ ...g, rules: g.rules.filter((_, i) => i !== idx) }))
+	}
+	function moveRule(idx: number, delta: number) {
+		onUpdate(groupingId, (g) => {
+			const target = idx + delta
+			if (target < 0 || target >= g.rules.length) return g
+			const next = [...g.rules]
+			const moved = next[idx]
+			next[idx] = next[target]
+			next[target] = moved
+			return { ...g, rules: next }
+		})
+	}
+	function setGroupColor(group: string, color: string) {
+		onUpdate(groupingId, (g) => ({ ...g, groups: { ...g.groups, [group]: { color } } }), true)
+	}
+	function resetGroupColor(group: string) {
+		onUpdate(groupingId, (g) => {
+			const groups = { ...g.groups }
+			delete groups[group]
+			return { ...g, groups }
+		})
+	}
+
+	return (
+		<div className="space-y-3 rounded-md border p-3">
+			<div className="flex items-center justify-between gap-2">
+				<span className="text-sm font-medium">{groupingId}</span>
+				<Button
+					type="button"
+					size="icon"
+					variant="ghost"
+					className="h-6 w-6 shrink-0 text-destructive"
+					aria-label={`Remove grouping ${groupingId}`}
+					onClick={() => onRemove(groupingId)}
+				>
+					<Icons.X className="h-4 w-4" />
+				</Button>
 			</div>
 
-			<div className="space-y-2">
-				<Label className="text-sm font-medium">Groupings</Label>
-				{groupings.length === 0 && <p className="text-xs text-muted-foreground">No groupings defined.</p>}
-				{groupings.map((g, idx) => (
-					// oxlint-disable-next-line no-array-index-key
-					<div key={idx} className="space-y-3 rounded-md border p-3">
-						<div className="flex items-start gap-2">
-							<div className="flex-1 space-y-1">
-								<Label className="text-xs text-muted-foreground">Label</Label>
-								<TextInputField
-									value$={scopeValue(scopeValue(scopeValue(value$, 'groupings'), idx), 'label')}
-									reset$={reset$}
-									onChange={(next) => changeGrouping(idx, { label: (next as string) ?? '' }, true)}
-									numeric={false}
-									placeholder="Grouping label"
-								/>
+			<div className="space-y-1.5">
+				<Label className="text-xs text-muted-foreground">Rules</Label>
+				<p className="text-xs text-muted-foreground">A player joins the group of the first rule whose flag they carry.</p>
+				{rules.length === 0 && <p className="text-xs text-muted-foreground">No rules yet.</p>}
+				<ol className="space-y-1">
+					{rules.map((rule, idx) => (
+						// oxlint-disable-next-line no-array-index-key
+						<li key={idx} className="grid grid-cols-[1.5rem_minmax(0,1fr)_auto_minmax(0,1fr)_auto_auto] items-center gap-2">
+							<span className="text-xs tabular-nums text-muted-foreground">{idx + 1}</span>
+							<BmFlagSelect
+								value={rule.flag || undefined}
+								exclude={rules.map((r) => r.flag)}
+								onChange={(flag) => changeRule(idx, { flag })}
+							/>
+							<Icons.ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+							<TextInputField
+								value$={scopeValue(scopeValue(scopeValue(value$, 'rules'), idx), 'group')}
+								reset$={reset$}
+								onChange={(next) => changeRule(idx, { group: (next as string) ?? '' }, true)}
+								numeric={false}
+								placeholder="Group name"
+							/>
+							<div className="flex">
+								<Button
+									type="button"
+									size="icon"
+									variant="ghost"
+									className="h-6 w-6"
+									disabled={idx === 0}
+									aria-label="Raise priority"
+									onClick={() => moveRule(idx, -1)}
+								>
+									<Icons.ChevronUp className="h-4 w-4" />
+								</Button>
+								<Button
+									type="button"
+									size="icon"
+									variant="ghost"
+									className="h-6 w-6"
+									disabled={idx === rules.length - 1}
+									aria-label="Lower priority"
+									onClick={() => moveRule(idx, 1)}
+								>
+									<Icons.ChevronDown className="h-4 w-4" />
+								</Button>
 							</div>
 							<Button
 								type="button"
 								size="icon"
 								variant="ghost"
-								className="mt-6 h-6 w-6 shrink-0 text-destructive"
-								aria-label="Remove grouping"
-								onClick={() => removeGrouping(idx)}
+								className="h-6 w-6 text-destructive"
+								aria-label="Remove rule"
+								onClick={() => removeRule(idx)}
 							>
 								<Icons.X className="h-4 w-4" />
 							</Button>
-						</div>
-						<div className="space-y-1">
-							<Label className="text-xs text-muted-foreground">Modes</Label>
-							<ComboBoxMulti
-								title="Mode"
-								values={g.modeIds}
-								options={modeOptions}
-								onSelect={(next) => changeGrouping(idx, { modeIds: typeof next === 'function' ? next(g.modeIds) : next })}
-							/>
-						</div>
-						<div className="space-y-1">
-							<Label className="text-xs text-muted-foreground">Color</Label>
-							<BmFlagOrColorSelect value={g.color ?? ''} onChange={(next) => changeGrouping(idx, { color: next })} />
-						</div>
-						<div className="space-y-1">
-							<Label className="text-xs text-muted-foreground">Flags</Label>
-							<FlagPriorityMap value={g.associations ?? {}} onChange={(next) => changeGrouping(idx, { associations: next })} />
-						</div>
-					</div>
-				))}
-				<Button type="button" variant="outline" size="sm" onClick={addGrouping}>
-					<Icons.Plus className="mr-1 h-4 w-4" />Add grouping
+						</li>
+					))}
+				</ol>
+				<Button type="button" variant="outline" size="sm" onClick={addRule}>
+					<Icons.Plus className="mr-1 h-4 w-4" />Add rule
 				</Button>
 			</div>
+
+			{groupNames.length > 0 && (
+				<details>
+					<summary className="cursor-pointer text-xs text-muted-foreground">Colors ({groupNames.length})</summary>
+					<ul className="mt-1.5 space-y-1">
+						{groupNames.map((group) => {
+							const color = PG.getGroupColor(grouping, group)
+							const isDerived = !grouping.groups?.[group]
+							return (
+								<li key={group} className="flex items-center gap-2">
+									<span className="h-5 w-5 shrink-0 rounded border" style={{ backgroundColor: color }} />
+									<span className="min-w-0 flex-1 truncate text-xs">{group}</span>
+									<Input
+										key={`${group}:${color}`}
+										className="h-8 w-28 font-mono"
+										placeholder={PG.DEFAULT_GROUP_COLOR}
+										defaultValue={color}
+										onChange={(e) => setGroupColor(group, e.target.value)}
+									/>
+									<Button
+										type="button"
+										size="icon"
+										variant="ghost"
+										className="h-6 w-6"
+										disabled={isDerived}
+										title="Take the color from this group's first flag"
+										aria-label={`Reset color for ${group}`}
+										onClick={() => resetGroupColor(group)}
+									>
+										<Icons.RotateCcw className="h-3.5 w-3.5" />
+									</Button>
+								</li>
+							)
+						})}
+					</ul>
+				</details>
+			)}
 		</div>
 	)
 }
@@ -2159,7 +2300,7 @@ function overrideFor(path: Path, _node: Node): React.FC<OverrideProps> | undefin
 	if (path.length === 1 && last === 'layerTable') return LayerTableField
 	if (path.length === 1 && last === 'layerGeneration') return LayerGenerationField
 	if (path.length === 1 && last === 'playerFlagsRequiringNote') return FlagMultiSelectField
-	if (path.length === 1 && last === 'playerFlagGroupings') return PlayerFlagGroupingsField
+	if (path.length === 1 && last === 'playerGroupings') return PlayerGroupingsField
 	// the entire `rbac` subtree is rendered by RbacBody (see FieldControl), so no per-field rbac overrides are needed here
 	// server settings: the pool configuration reuses the dashboard popover's panels; connection passwords are masked
 	if (path.length === 2 && path[0] === 'queue' && last === 'mainPool') return MainPoolField

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -370,34 +370,24 @@ function FlagMultiSelectField({ value$, reset$, onChange }: OverrideProps) {
 
 type PlayerGroupingsValue = Record<string, PG.Grouping | undefined>
 
-// A group's color is seeded from the flag of the first rule naming it, so picking flags is usually all an operator has to
-// do. An entry that already exists is never re-derived -- an explicit color would otherwise be undone by a flag change.
+// A group's color defaults to a reference to the first of its flags that has one, so picking flags is usually all an
+// operator has to do and the color keeps tracking battlemetrics afterwards. An entry that already exists is left alone.
 // Half-finished rules must not leave an entry behind: a placeholder written before a flag is picked would count as
-// existing and block the seeding it is standing in for.
+// existing and block the seeding it is standing in for. A reference to a flag the group no longer carries is dropped
+// rather than kept, since the picker would not offer that flag any more.
 function syncedGroups(grouping: PG.Grouping, orgFlags: BM.PlayerFlag[] | undefined): Record<string, PG.Group> {
 	const groups: Record<string, PG.Group> = {}
 	for (const rule of grouping.rules) {
 		if (!rule.group || groups[rule.group]) continue
 		const existing = grouping.groups?.[rule.group]
-		if (existing) {
+		if (existing && (existing.color.type === 'custom' || PG.getGroupFlags(grouping, rule.group).includes(existing.color.flag))) {
 			groups[rule.group] = existing
 			continue
 		}
-		const derived = derivedGroupColor(grouping, rule.group, orgFlags)
+		const derived = PG.defaultGroupColor(grouping, rule.group, orgFlags)
 		if (derived) groups[rule.group] = { color: derived }
 	}
 	return groups
-}
-
-// undefined until some flag of the group actually carries a color -- callers leave the entry out rather than pinning a
-// placeholder, so `getGroupColor`'s fallback covers the gap and a later flag pick can still seed it.
-function derivedGroupColor(grouping: PG.Grouping, group: string, orgFlags: BM.PlayerFlag[] | undefined): string | undefined {
-	for (const rule of grouping.rules) {
-		if (rule.group !== group) continue
-		const color = orgFlags?.find((f) => f.id === rule.flag)?.color
-		if (color) return color
-	}
-	return undefined
 }
 
 // bespoke editor for `playerGroupings`. Each grouping is an ordered rule list (first match wins), so priority is row
@@ -513,15 +503,9 @@ function GroupingCard(
 			return { ...g, rules: next }
 		})
 	}
-	function setGroupColor(group: string, color: string) {
-		onUpdate(groupingId, (g) => ({ ...g, groups: { ...g.groups, [group]: { color } } }), true)
-	}
-	function resetGroupColor(group: string) {
-		onUpdate(groupingId, (g) => {
-			const groups = { ...g.groups }
-			delete groups[group]
-			return { ...g, groups }
-		})
+	// `quiet` for the custom-color text field only, so an in-flight keystroke is not clobbered
+	function setGroupColor(group: string, color: PG.GroupColor, quiet?: boolean) {
+		onUpdate(groupingId, (g) => ({ ...g, groups: { ...g.groups, [group]: { color } } }), quiet)
 	}
 
 	return (
@@ -607,33 +591,31 @@ function GroupingCard(
 			{groupNames.length > 0 && (
 				<details>
 					<summary className="cursor-pointer text-xs text-muted-foreground">Colors ({groupNames.length})</summary>
+					<p className="mt-1 text-xs text-muted-foreground">
+						Following a flag keeps the color in step with battlemetrics; a custom color stays put.
+					</p>
 					<ul className="mt-1.5 space-y-1">
 						{groupNames.map((group) => {
-							const color = PG.getGroupColor(grouping, group)
-							const isDerived = !grouping.groups?.[group]
+							const color = grouping.groups?.[group]?.color
+							const resolved = PG.getGroupColor(grouping, group, orgFlags)
 							return (
-								<li key={group} className="flex items-center gap-2">
-									<span className="h-5 w-5 shrink-0 rounded border" style={{ backgroundColor: color }} />
-									<span className="min-w-0 flex-1 truncate text-xs">{group}</span>
-									<Input
-										key={`${group}:${color}`}
-										className="h-8 w-28 font-mono"
-										placeholder={PG.DEFAULT_GROUP_COLOR}
-										defaultValue={color}
-										onChange={(e) => setGroupColor(group, e.target.value)}
+								<li key={group} className="grid grid-cols-[1.25rem_minmax(0,8rem)_minmax(0,1fr)_auto_7rem] items-center gap-2">
+									<span className="h-5 w-5 shrink-0 rounded border" style={{ backgroundColor: resolved }} />
+									<span className="min-w-0 truncate text-xs" title={group}>{group}</span>
+									<BmFlagSelect
+										title="Color from flag"
+										value={color?.type === 'flag' ? color.flag : undefined}
+										only={PG.getGroupFlags(grouping, group)}
+										onChange={(flag) => setGroupColor(group, { type: 'flag', flag })}
 									/>
-									<Button
-										type="button"
-										size="icon"
-										variant="ghost"
-										className="h-6 w-6"
-										disabled={isDerived}
-										title="Take the color from this group's first flag"
-										aria-label={`Reset color for ${group}`}
-										onClick={() => resetGroupColor(group)}
-									>
-										<Icons.RotateCcw className="h-3.5 w-3.5" />
-									</Button>
+									<span className="text-xs text-muted-foreground">or</span>
+									<Input
+										key={`${group}:${color?.type === 'custom' ? color.color : ''}`}
+										className="h-8 font-mono"
+										placeholder="#rrggbb"
+										defaultValue={color?.type === 'custom' ? color.color : ''}
+										onChange={(e) => setGroupColor(group, { type: 'custom', color: e.target.value }, true)}
+									/>
 								</li>
 							)
 						})}

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -1,6 +1,8 @@
 import { BmFlagMultiSelect, BmFlagSelect } from '@/components/bm-flag-picker'
+import ComboBox from '@/components/combo-box/combo-box'
 import type { ComboBoxOption } from '@/components/combo-box/combo-box'
 import ComboBoxMulti from '@/components/combo-box/combo-box-multi'
+import { LOADING } from '@/components/combo-box/constants.ts'
 import { DiscordMemberSelect, DiscordRoleSelect } from '@/components/discord-picker'
 import LayerGenerationConfigEditor from '@/components/layer-generation-config-editor'
 import LayerTableConfigEditor from '@/components/layer-table-config-editor'
@@ -409,6 +411,11 @@ function PlayerGroupingsField({ value$, reset$, onChange }: OverrideProps) {
 	const value = (useFieldValue(value$, reset$) as PlayerGroupingsValue) ?? {}
 	const groupingIds = Object.keys(value)
 	const orgFlags = BattlemetricsClient.useOrgFlags()
+	// the union across running servers -- fetched once here rather than per rule row
+	const adminGroupsQuery = useQuery(RPC.orpc.squadServer.listAdminListGroups.queryOptions({ staleTime: 60_000 }))
+	const adminGroupOptions: ComboBoxOption<string>[] | typeof LOADING = adminGroupsQuery.data
+		? adminGroupsQuery.data.map((name) => ({ value: name, label: name }))
+		: LOADING
 
 	// `quiet` skips reset$: use it for edits driven by an uncontrolled input (the group name), where re-emitting would
 	// clobber an in-flight keystroke. Structural edits leave it off so inputs re-seed after re-indexing.
@@ -457,6 +464,7 @@ function PlayerGroupingsField({ value$, reset$, onChange }: OverrideProps) {
 					value$={scopeValue(value$, id)}
 					reset$={reset$}
 					orgFlags={orgFlags}
+					adminGroupOptions={adminGroupOptions}
 					onUpdate={updateGrouping}
 					onRemove={removeGrouping}
 				/>
@@ -491,33 +499,66 @@ function RuleDropSeparator({ position, groupingId, idx }: { position: 'before' |
 }
 
 function RuleRow(
-	{ rule, idx, groupingId, usedFlags, value$, reset$, onChange, onRemove }: {
+	{ rule, idx, groupingId, usedFlags, usedAdminGroups, adminGroupOptions, value$, reset$, onReplace, onChange, onRemove }: {
 		rule: PG.GroupRule
 		idx: number
 		groupingId: string
 		usedFlags: string[]
+		usedAdminGroups: string[]
+		adminGroupOptions: ComboBoxOption<string>[] | typeof LOADING
 		value$: ValueState
 		reset$: Rx.Subject<void>
+		onReplace: (idx: number, rule: PG.GroupRule) => void
 		onChange: (idx: number, patch: Partial<PG.GroupRule>, quiet?: boolean) => void
 		onRemove: () => void
 	},
 ) {
 	const drag = DndKit.useDraggable({ type: 'grouping-rule', id: ruleDragId(groupingId, idx) }, { feedback: 'default' })
+	// switching source discards the old source's field: the variants share only `group`, and a stale `flag` sitting on an
+	// admin-list rule would be written straight back out again
+	function setSource(type: PG.GroupRuleSource) {
+		if (type === rule.type) return
+		onReplace(idx, type === 'battlemetrics' ? { type, flag: '', group: rule.group } : { type, adminGroup: '', group: rule.group })
+	}
 	return (
 		<li
 			ref={drag.ref}
 			data-dragging={drag.isDragging}
-			className="grid grid-cols-[auto_1.5rem_minmax(0,1fr)_auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md bg-background data-[dragging=true]:opacity-40"
+			className="grid grid-cols-[auto_1.5rem_7rem_minmax(0,1fr)_auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md bg-background data-[dragging=true]:opacity-40"
 		>
 			<button type="button" ref={drag.handleRef} className="cursor-grab rounded text-muted-foreground" aria-label="Drag to reorder">
 				<Icons.GripVertical className="h-4 w-4" />
 			</button>
 			<span className="text-xs tabular-nums text-muted-foreground">{idx + 1}.</span>
-			<BmFlagSelect
-				value={rule.flag || undefined}
-				exclude={usedFlags}
-				onChange={(flag) => onChange(idx, { flag })}
-			/>
+			<Select value={rule.type} onValueChange={(next) => setSource(next as PG.GroupRuleSource)}>
+				<SelectTrigger className="h-8" aria-label="Rule source">
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					{PG.GROUP_RULE_SOURCES.map((source) => <SelectItem key={source} value={source}>{PG.GROUP_RULE_SOURCE_LABELS[source]}
+					</SelectItem>)}
+				</SelectContent>
+			</Select>
+			{rule.type === 'battlemetrics'
+				? (
+					<BmFlagSelect
+						value={rule.flag || undefined}
+						exclude={usedFlags}
+						onChange={(flag) => onChange(idx, { flag })}
+					/>
+				)
+				: (
+					<ComboBox
+						title="Admin group"
+						value={rule.adminGroup || undefined}
+						options={adminGroupOptions === LOADING
+							? LOADING
+							: adminGroupOptions.filter((o) => o.value === rule.adminGroup || !usedAdminGroups.includes(o.value))}
+						onSelect={(adminGroup) => {
+							if (adminGroup) onChange(idx, { adminGroup })
+						}}
+					/>
+				)}
 			<Icons.ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
 			<TextInputField
 				value$={scopeValue(scopeValue(scopeValue(value$, 'rules'), idx), 'group')}
@@ -541,12 +582,13 @@ function RuleRow(
 }
 
 function GroupingCard(
-	{ groupingId, grouping, value$, reset$, orgFlags, onUpdate, onRemove }: {
+	{ groupingId, grouping, value$, reset$, orgFlags, adminGroupOptions, onUpdate, onRemove }: {
 		groupingId: string
 		grouping: PG.Grouping
 		value$: ValueState
 		reset$: Rx.Subject<void>
 		orgFlags: BM.PlayerFlag[] | undefined
+		adminGroupOptions: ComboBoxOption<string>[] | typeof LOADING
 		onUpdate: (id: string, fn: (g: PG.Grouping) => PG.Grouping, quiet?: boolean) => void
 		onRemove: (id: string) => void
 	},
@@ -556,7 +598,10 @@ function GroupingCard(
 	const groupNames = PG.getGroupNames(grouping).filter(Boolean)
 
 	function changeRule(idx: number, patch: Partial<PG.GroupRule>, quiet?: boolean) {
-		onUpdate(groupingId, (g) => ({ ...g, rules: g.rules.map((r, i) => i === idx ? { ...r, ...patch } : r) }), quiet)
+		onUpdate(groupingId, (g) => ({ ...g, rules: g.rules.map((r, i) => i === idx ? { ...r, ...patch } as PG.GroupRule : r) }), quiet)
+	}
+	function replaceRule(idx: number, rule: PG.GroupRule) {
+		onUpdate(groupingId, (g) => ({ ...g, rules: g.rules.map((r, i) => i === idx ? rule : r) }))
 	}
 	function addRule() {
 		onUpdate(groupingId, (g) => ({ ...g, rules: [...g.rules, { type: 'battlemetrics', flag: '', group: '' }] }))
@@ -621,9 +666,12 @@ function GroupingCard(
 								rule={rule}
 								idx={idx}
 								groupingId={groupingId}
-								usedFlags={rules.map((r) => r.flag)}
+								usedFlags={rules.flatMap((r) => r.type === 'battlemetrics' ? [r.flag] : [])}
+								usedAdminGroups={rules.flatMap((r) => r.type === 'admin-list' ? [r.adminGroup] : [])}
+								adminGroupOptions={adminGroupOptions}
 								value$={value$}
 								reset$={reset$}
+								onReplace={replaceRule}
 								onChange={changeRule}
 								onRemove={() => removeRule(idx)}
 							/>

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -498,11 +498,15 @@ function RuleDropSeparator({ position, groupingId, idx }: { position: 'before' |
 	return <li ref={drop.ref} data-over={drop.isDropTarget} className="my-0.5 h-1 rounded bg-primary data-[over=false]:invisible" />
 }
 
+// sentinel option: leaves the list and lets a name be typed instead
+const ADD_NEW_GROUP = '__add-new-group__'
+
 function RuleRow(
-	{ rule, idx, groupingId, usedFlags, usedAdminGroups, adminGroupOptions, value$, reset$, onReplace, onChange, onRemove }: {
+	{ rule, idx, groupingId, groupNames, usedFlags, usedAdminGroups, adminGroupOptions, value$, reset$, onReplace, onChange, onRemove }: {
 		rule: PG.GroupRule
 		idx: number
 		groupingId: string
+		groupNames: string[]
 		usedFlags: string[]
 		usedAdminGroups: string[]
 		adminGroupOptions: ComboBoxOption<string>[] | typeof LOADING
@@ -514,6 +518,11 @@ function RuleRow(
 	},
 ) {
 	const drag = DndKit.useDraggable({ type: 'grouping-rule', id: ruleDragId(groupingId, idx) }, { feedback: 'default' })
+	// Several rules feeding one group is the norm, so once the grouping names any group, picking from the list is the
+	// common case and typing is the exception. Which mode a row is in has to be sticky, never derived from whether the
+	// name exists yet: group names come from the rules themselves, so a half-typed name is already an "existing" group
+	// and the field would turn into a combo box under the keystroke that created it.
+	const [namingNewGroup, setNamingNewGroup] = React.useState(groupNames.length === 0)
 	// switching source discards the old source's field: the variants share only `group`, and a stale `flag` sitting on an
 	// admin-list rule would be written straight back out again
 	function setSource(type: PG.GroupRuleSource) {
@@ -560,13 +569,46 @@ function RuleRow(
 					/>
 				)}
 			<Icons.ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-			<TextInputField
-				value$={scopeValue(scopeValue(scopeValue(value$, 'rules'), idx), 'group')}
-				reset$={reset$}
-				onChange={(next) => onChange(idx, { group: (next as string) ?? '' }, true)}
-				numeric={false}
-				placeholder="Group name"
-			/>
+			{namingNewGroup
+				? (
+					<div className="flex min-w-0 items-center gap-1">
+						<TextInputField
+							value$={scopeValue(scopeValue(scopeValue(value$, 'rules'), idx), 'group')}
+							reset$={reset$}
+							onChange={(next) => onChange(idx, { group: (next as string) ?? '' }, true)}
+							numeric={false}
+							placeholder="Group name"
+						/>
+						{groupNames.length > 0 && (
+							<Button
+								type="button"
+								size="icon"
+								variant="ghost"
+								className="h-6 w-6 shrink-0"
+								title="Pick an existing group instead"
+								aria-label="Pick an existing group instead"
+								onClick={() => setNamingNewGroup(false)}
+							>
+								<Icons.List className="h-4 w-4" />
+							</Button>
+						)}
+					</div>
+				)
+				: (
+					<ComboBox
+						title="Group"
+						value={rule.group || undefined}
+						options={[
+							...groupNames.map((name): ComboBoxOption<string> => ({ value: name, label: name })),
+							{ value: ADD_NEW_GROUP, label: <span className="text-muted-foreground">Add new group...</span>, keywords: ['new'] },
+						]}
+						onSelect={(next) => {
+							if (!next) return
+							if (next === ADD_NEW_GROUP) setNamingNewGroup(true)
+							else onChange(idx, { group: next })
+						}}
+					/>
+				)}
 			<Button
 				type="button"
 				size="icon"
@@ -666,6 +708,7 @@ function GroupingCard(
 								rule={rule}
 								idx={idx}
 								groupingId={groupingId}
+								groupNames={groupNames}
 								usedFlags={rules.flatMap((r) => r.type === 'battlemetrics' ? [r.flag] : [])}
 								usedAdminGroups={rules.flatMap((r) => r.type === 'admin-list' ? [r.adminGroup] : [])}
 								adminGroupOptions={adminGroupOptions}

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -41,6 +41,7 @@ import * as RPC from '@/orpc.client'
 import * as RBAC from '@/rbac.models'
 import * as BattlemetricsClient from '@/systems/battlemetrics.client'
 import * as ConfigClient from '@/systems/config.client'
+import * as DndKit from '@/systems/dndkit.client'
 import * as SettingsClient from '@/systems/settings.client'
 import * as UsersClient from '@/systems/users.client'
 import { useQuery } from '@tanstack/react-query'
@@ -370,6 +371,18 @@ function FlagMultiSelectField({ value$, reset$, onChange }: OverrideProps) {
 
 type PlayerGroupingsValue = Record<string, PG.Grouping | undefined>
 
+// Drag ids must be unique across every grouping card mounted at once, and a rule has nothing of its own to be named by
+// (its position IS its priority), so grouping + index identifies it. JSON-encoded because a grouping id is free text
+// and could contain whatever delimiter we picked.
+function ruleDragId(groupingId: string, idx: number): string {
+	return JSON.stringify([groupingId, idx])
+}
+
+function parseRuleDragId(id: string): { groupingId: string; idx: number } {
+	const [groupingId, idx] = JSON.parse(id) as [string, number]
+	return { groupingId, idx }
+}
+
 // A group's color defaults to a reference to the first of its flags that has one, so picking flags is usually all an
 // operator has to do and the color keeps tracking battlemetrics afterwards. An entry that already exists is left alone.
 // Half-finished rules must not leave an entry behind: a placeholder written before a flag is picked would count as
@@ -468,6 +481,65 @@ function PlayerGroupingsField({ value$, reset$, onChange }: OverrideProps) {
 	)
 }
 
+// a thin gap between/around rows that highlights while a rule is dragged over it (invisible but layout-occupying otherwise)
+function RuleDropSeparator({ position, groupingId, idx }: { position: 'before' | 'after'; groupingId: string; idx: number }) {
+	const drop = DndKit.useDroppable({
+		type: 'relative-to-drag-item',
+		slots: [{ position, dragItem: { type: 'grouping-rule', id: ruleDragId(groupingId, idx) } }],
+	})
+	return <li ref={drop.ref} data-over={drop.isDropTarget} className="my-0.5 h-1 rounded bg-primary data-[over=false]:invisible" />
+}
+
+function RuleRow(
+	{ rule, idx, groupingId, usedFlags, value$, reset$, onChange, onRemove }: {
+		rule: PG.GroupRule
+		idx: number
+		groupingId: string
+		usedFlags: string[]
+		value$: ValueState
+		reset$: Rx.Subject<void>
+		onChange: (idx: number, patch: Partial<PG.GroupRule>, quiet?: boolean) => void
+		onRemove: () => void
+	},
+) {
+	const drag = DndKit.useDraggable({ type: 'grouping-rule', id: ruleDragId(groupingId, idx) }, { feedback: 'default' })
+	return (
+		<li
+			ref={drag.ref}
+			data-dragging={drag.isDragging}
+			className="grid grid-cols-[auto_1.5rem_minmax(0,1fr)_auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md bg-background data-[dragging=true]:opacity-40"
+		>
+			<button type="button" ref={drag.handleRef} className="cursor-grab rounded text-muted-foreground" aria-label="Drag to reorder">
+				<Icons.GripVertical className="h-4 w-4" />
+			</button>
+			<span className="text-xs tabular-nums text-muted-foreground">{idx + 1}.</span>
+			<BmFlagSelect
+				value={rule.flag || undefined}
+				exclude={usedFlags}
+				onChange={(flag) => onChange(idx, { flag })}
+			/>
+			<Icons.ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+			<TextInputField
+				value$={scopeValue(scopeValue(scopeValue(value$, 'rules'), idx), 'group')}
+				reset$={reset$}
+				onChange={(next) => onChange(idx, { group: (next as string) ?? '' }, true)}
+				numeric={false}
+				placeholder="Group name"
+			/>
+			<Button
+				type="button"
+				size="icon"
+				variant="ghost"
+				className="h-6 w-6 text-destructive"
+				aria-label="Remove rule"
+				onClick={onRemove}
+			>
+				<Icons.X className="h-4 w-4" />
+			</Button>
+		</li>
+	)
+}
+
 function GroupingCard(
 	{ groupingId, grouping, value$, reset$, orgFlags, onUpdate, onRemove }: {
 		groupingId: string
@@ -492,21 +564,31 @@ function GroupingCard(
 	function removeRule(idx: number) {
 		onUpdate(groupingId, (g) => ({ ...g, rules: g.rules.filter((_, i) => i !== idx) }))
 	}
-	function moveRule(idx: number, delta: number) {
-		onUpdate(groupingId, (g) => {
-			const target = idx + delta
-			if (target < 0 || target >= g.rules.length) return g
-			const next = [...g.rules]
-			const moved = next[idx]
-			next[idx] = next[target]
-			next[target] = moved
-			return { ...g, rules: next }
-		})
-	}
 	// `quiet` for the custom-color text field only, so an in-flight keystroke is not clobbered
 	function setGroupColor(group: string, color: PG.GroupColor, quiet?: boolean) {
 		onUpdate(groupingId, (g) => ({ ...g, groups: { ...g.groups, [group]: { color } } }), quiet)
 	}
+
+	// drag-to-reorder via the shared dnd-kit provider (see dndkit.client), matching the layer-table column editor. The
+	// handler is registered once and reads the latest state off a ref; every grouping card registers one, so a drop
+	// belonging to another card's list has to be ignored.
+	const stateRef = React.useRef({ groupingId, onUpdate })
+	stateRef.current = { groupingId, onUpdate }
+	DndKit.useDragEnd(React.useCallback((evt) => {
+		const { active, over } = evt
+		if (active.type !== 'grouping-rule' || !over) return
+		const slot = over.slots.find((s) => s.dragItem.type === 'grouping-rule')
+		if (!slot) return
+		// the separators only ever register before/after; 'on' would mean dropping onto a rule itself, which reorders nothing
+		const position = slot.position
+		if (position === 'on') return
+		const from = parseRuleDragId(active.id)
+		// find() can't narrow the element, so the id is still the union's string | number here
+		const to = parseRuleDragId(String(slot.dragItem.id))
+		const { groupingId, onUpdate } = stateRef.current
+		if (from.groupingId !== groupingId || to.groupingId !== groupingId) return
+		onUpdate(groupingId, (g) => ({ ...g, rules: PG.moveRule(g.rules, from.idx, to.idx, position) }))
+	}, []))
 
 	return (
 		<div className="space-y-3 rounded-md border p-3">
@@ -526,62 +608,28 @@ function GroupingCard(
 
 			<div className="space-y-1.5">
 				<Label className="text-xs text-muted-foreground">Rules</Label>
-				<p className="text-xs text-muted-foreground">A player joins the group of the first rule whose flag they carry.</p>
+				<p className="text-xs text-muted-foreground">
+					A player joins the group of the first rule whose flag they carry. Drag to reorder; priority is top to bottom.
+				</p>
 				{rules.length === 0 && <p className="text-xs text-muted-foreground">No rules yet.</p>}
-				<ol className="space-y-1">
+				<ol>
 					{rules.map((rule, idx) => (
 						// oxlint-disable-next-line no-array-index-key
-						<li key={idx} className="grid grid-cols-[1.5rem_minmax(0,1fr)_auto_minmax(0,1fr)_auto_auto] items-center gap-2">
-							<span className="text-xs tabular-nums text-muted-foreground">{idx + 1}</span>
-							<BmFlagSelect
-								value={rule.flag || undefined}
-								exclude={rules.map((r) => r.flag)}
-								onChange={(flag) => changeRule(idx, { flag })}
-							/>
-							<Icons.ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-							<TextInputField
-								value$={scopeValue(scopeValue(scopeValue(value$, 'rules'), idx), 'group')}
+						<React.Fragment key={idx}>
+							<RuleDropSeparator position="before" groupingId={groupingId} idx={idx} />
+							<RuleRow
+								rule={rule}
+								idx={idx}
+								groupingId={groupingId}
+								usedFlags={rules.map((r) => r.flag)}
+								value$={value$}
 								reset$={reset$}
-								onChange={(next) => changeRule(idx, { group: (next as string) ?? '' }, true)}
-								numeric={false}
-								placeholder="Group name"
+								onChange={changeRule}
+								onRemove={() => removeRule(idx)}
 							/>
-							<div className="flex">
-								<Button
-									type="button"
-									size="icon"
-									variant="ghost"
-									className="h-6 w-6"
-									disabled={idx === 0}
-									aria-label="Raise priority"
-									onClick={() => moveRule(idx, -1)}
-								>
-									<Icons.ChevronUp className="h-4 w-4" />
-								</Button>
-								<Button
-									type="button"
-									size="icon"
-									variant="ghost"
-									className="h-6 w-6"
-									disabled={idx === rules.length - 1}
-									aria-label="Lower priority"
-									onClick={() => moveRule(idx, 1)}
-								>
-									<Icons.ChevronDown className="h-4 w-4" />
-								</Button>
-							</div>
-							<Button
-								type="button"
-								size="icon"
-								variant="ghost"
-								className="h-6 w-6 text-destructive"
-								aria-label="Remove rule"
-								onClick={() => removeRule(idx)}
-							>
-								<Icons.X className="h-4 w-4" />
-							</Button>
-						</li>
+						</React.Fragment>
 					))}
+					{rules.length > 0 && <RuleDropSeparator position="after" groupingId={groupingId} idx={rules.length - 1} />}
 				</ol>
 				<Button type="button" variant="outline" size="sm" onClick={addRule}>
 					<Icons.Plus className="mr-1 h-4 w-4" />Add rule

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -731,7 +731,7 @@ function GroupingCard(
 				<details>
 					<summary className="cursor-pointer text-xs text-muted-foreground">Colors ({groupNames.length})</summary>
 					<p className="mt-1 text-xs text-muted-foreground">
-						Following a flag keeps the color in step with battlemetrics; a custom color stays put.
+						Following a flag keeps the color in step with battlemetrics.
 					</p>
 					<ul className="mt-1.5 space-y-1">
 						{groupNames.map((group) => {

--- a/src/components/teams-panel.tsx
+++ b/src/components/teams-panel.tsx
@@ -7,10 +7,10 @@ import * as MapUtils from '@/lib/map'
 import * as StrUtils from '@/lib/string'
 import { cn } from '@/lib/utils.ts'
 import * as ZusUtils from '@/lib/zustand'
-import * as BM from '@/models/battlemetrics.models'
 import { WINDOW_ID } from '@/models/draggable-windows.models'
 import * as L from '@/models/layer'
 import * as MH from '@/models/match-history.models'
+import * as PG from '@/models/player-groupings.models'
 import * as SM from '@/models/squad.models'
 import * as TeamsPanelModels from '@/models/teams-panel.models'
 
@@ -102,7 +102,7 @@ export default function TeamsPanel(props: { className?: string; stores: SquadSer
 		if (secondaryFilterState === 'ADMIN') setAdminsOnly(true)
 	}, [secondaryFilterState])
 	const [roleFilter, setRoleFilter] = React.useState<string | null>(null)
-	const [groupingFilter, setGroupingFilter] = React.useState<string | null>(null)
+	const [groupFilter, setGroupFilter] = React.useState<string | null>(null)
 	const [squadFilterA, setSquadFilterA] = React.useState<string | null>(null)
 	const [squadFilterB, setSquadFilterB] = React.useState<string | null>(null)
 	const [squadFilterCombined, setSquadFilterCombined] = React.useState<string | null>(null)
@@ -125,13 +125,13 @@ export default function TeamsPanel(props: { className?: string; stores: SquadSer
 		SettingsClient.PublicSettingsStore,
 		TeamsPanelModels.Sel.playersForTeam('B'),
 	)
-	// filter options are drawn from both teams so the shared role/grouping filters offer every value
+	// filter options are drawn from both teams so the shared role/group filters offer every value
 	const availableRoles = React.useMemo(
 		() => [...new Set([...allPlayersA, ...allPlayersB].map(p => p.role).filter((r): r is string => r != null))].sort(),
 		[allPlayersA, allPlayersB],
 	)
-	const availableGroupings = React.useMemo(
-		() => [...new Set([...allPlayersA, ...allPlayersB].map(p => p.grouping).filter((g): g is string => g != null))].sort(),
+	const availableGroups = React.useMemo(
+		() => [...new Set([...allPlayersA, ...allPlayersB].map(p => p.group).filter((g): g is string => g != null))].sort(),
 		[allPlayersA, allPlayersB],
 	)
 	const resetAll = () => {
@@ -139,7 +139,7 @@ export default function TeamsPanel(props: { className?: string; stores: SquadSer
 		setSearchQuery('')
 		setAdminsOnly(false)
 		setRoleFilter(null)
-		setGroupingFilter(null)
+		setGroupFilter(null)
 		setSquadFilterA(null)
 		setSquadFilterB(null)
 		setSquadFilterCombined(null)
@@ -152,8 +152,8 @@ export default function TeamsPanel(props: { className?: string; stores: SquadSer
 			filters: {
 				role: roleFilter,
 				setRole: setRoleFilter,
-				grouping: groupingFilter,
-				setGrouping: setGroupingFilter,
+				group: groupFilter,
+				setGroup: setGroupFilter,
 				squad: squadFilterA,
 				setSquad: setSquadFilterA,
 			},
@@ -164,8 +164,8 @@ export default function TeamsPanel(props: { className?: string; stores: SquadSer
 			filters: {
 				role: roleFilter,
 				setRole: setRoleFilter,
-				grouping: groupingFilter,
-				setGrouping: setGroupingFilter,
+				group: groupFilter,
+				setGroup: setGroupFilter,
 				squad: squadFilterB,
 				setSquad: setSquadFilterB,
 			},
@@ -176,8 +176,8 @@ export default function TeamsPanel(props: { className?: string; stores: SquadSer
 	const filtersC: PlayerFilters = {
 		role: roleFilter,
 		setRole: setRoleFilter,
-		grouping: groupingFilter,
-		setGrouping: setGroupingFilter,
+		group: groupFilter,
+		setGroup: setGroupFilter,
 		squad: squadFilterCombined,
 		setSquad: setSquadFilterCombined,
 	}
@@ -303,7 +303,7 @@ export default function TeamsPanel(props: { className?: string; stores: SquadSer
 									sorting={teamPanes[teamId].sorting}
 									setSorting={teamPanes[teamId].setSorting}
 									availableRoles={availableRoles}
-									availableGroupings={availableGroupings}
+									availableGroups={availableGroups}
 									hideSpoilers={hideSpoilers}
 									className={i === 1 ? 'pl-1' : undefined}
 									stores={props.stores}
@@ -320,7 +320,7 @@ export default function TeamsPanel(props: { className?: string; stores: SquadSer
 							sorting={sortingCombined}
 							setSorting={setSortingCombined}
 							availableRoles={availableRoles}
-							availableGroupings={availableGroupings}
+							availableGroups={availableGroups}
 							hideSpoilers={hideSpoilers}
 							stores={props.stores}
 						/>
@@ -359,12 +359,12 @@ function TeamPlayerCounts(props: { leftTeam: MH.NormedTeamId; rightTeam: MH.Norm
 
 function ControlPanel() {
 	const config = ZusUtils.useStore(SettingsClient.PublicSettingsStore)
-	const playerFlagGroupings = config?.playerFlagGroupings
-	const groupingModeIds = React.useMemo(
-		() => playerFlagGroupings ? BM.getGroupingModeIds(playerFlagGroupings) : [],
-		[playerFlagGroupings],
+	const playerGroupings = config?.playerGroupings
+	const groupingIds = React.useMemo(
+		() => playerGroupings ? PG.getGroupingIds(playerGroupings) : [],
+		[playerGroupings],
 	)
-	const activeModeId = ZusUtils.useStore(BattlemetricsClient.Store, BattlemetricsClient.Sel.activeGroupingModeId(groupingModeIds))
+	const activeGroupingId = ZusUtils.useStore(BattlemetricsClient.Store, BattlemetricsClient.Sel.activeGroupingId(groupingIds))
 	// distinct players with an active timeout; the expiry check trims rows the server hasn't swept yet
 	const timedOutCount = new Set(
 		TimeoutsClient.useActiveTimeouts()
@@ -390,15 +390,18 @@ function ControlPanel() {
 					</Button>
 				)}
 			/>
-			{groupingModeIds.length > 0 && (
+			{groupingIds.length > 0 && (
 				<>
-					<span className="text-sm text-muted-foreground">Group by</span>
-					<Select value={activeModeId ?? ''} onValueChange={(value) => BattlemetricsClient.Actions.setSelectedModeId(value || null)}>
+					<span className="text-sm text-muted-foreground">Grouping</span>
+					<Select
+						value={activeGroupingId ?? ''}
+						onValueChange={(value) => BattlemetricsClient.Actions.setSelectedGroupingId(value || null)}
+					>
 						<SelectTrigger className="h-7 w-auto text-sm">
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>
-							{groupingModeIds.map(id => <SelectItem key={id} value={id}>{id}</SelectItem>)}
+							{groupingIds.map(id => <SelectItem key={id} value={id}>{id}</SelectItem>)}
 						</SelectContent>
 					</Select>
 				</>
@@ -423,7 +426,7 @@ function SelectOrSpinner({ playerId, checked, onCheckedChange, stores }: {
 	)
 }
 
-// shift+click anywhere in the squad/grouping cell selects the squad/grouping members
+// shift+click anywhere in the squad/group cell selects the squad/group members
 function shiftClickCellProps(
 	columnId: string,
 	player: TeamsPanelModels.EnrichedPlayer,
@@ -454,15 +457,15 @@ function shiftClickCellProps(
 			},
 		}
 	}
-	if (columnId === 'grouping' && player.grouping) {
-		const grouping = player.grouping
+	if (columnId === 'group' && player.group) {
+		const group = player.group
 		return {
-			title: 'Shift+click: select teammates in this grouping. Shift+Ctrl+click: both teams',
+			title: 'Shift+click: select teammates in this group. Shift+Ctrl+click: both teams',
 			onClickCapture: e => {
 				if (!e.shiftKey) return
 				e.preventDefault()
 				e.stopPropagation()
-				SquadServerFrame.Actions.selectGrouping(stores, grouping, e.ctrlKey ? undefined : player.teamId ?? undefined)
+				SquadServerFrame.Actions.selectGroup(stores, group, e.ctrlKey ? undefined : player.teamId ?? undefined)
 			},
 		}
 	}
@@ -472,8 +475,8 @@ function shiftClickCellProps(
 type PlayerFilters = {
 	role: string | null
 	setRole: (v: string | null) => void
-	grouping: string | null
-	setGrouping: (v: string | null) => void
+	group: string | null
+	setGroup: (v: string | null) => void
 	squad: string | null
 	setSquad: (v: string | null) => void
 }
@@ -483,10 +486,10 @@ type SetSorting = React.Dispatch<React.SetStateAction<SortingState>>
 // shared across both table variants; each variant extends it with its squad-lookup shape
 type BasePlayerTableMeta = {
 	matchId: number
-	groupingColorByLabel: Map<string, string>
+	groupColorByName: Map<string, string>
 	filters: PlayerFilters
 	availableRoles: string[]
-	availableGroupings: string[]
+	availableGroups: string[]
 	stores: SquadServerFrame.KeyProp
 	statsSort: StatsSortState
 	// SLM was restarted mid-match, so combat stats are incomplete -- surfaced as a disclaimer on the stats header
@@ -521,7 +524,7 @@ type SquadGroupInfo = {
 	faction: { label: string; color: string } | null
 }
 
-const FILTERED_COLUMN_IDS = ['role', 'grouping', 'squad']
+const FILTERED_COLUMN_IDS = ['role', 'group', 'squad']
 
 // middle-click on a header resets that column's sort and filter
 function headerResetProps(
@@ -542,14 +545,14 @@ function headerResetProps(
 			if (e.button !== 1) return
 			column.clearSorting()
 			if (column.id === 'role') filters.setRole(null)
-			if (column.id === 'grouping') filters.setGrouping(null)
+			if (column.id === 'group') filters.setGroup(null)
 			if (column.id === 'squad') filters.setSquad(null)
 		},
 	}
 }
 
 const FILTER_ALL = '__all__'
-// sentinel filter value matching players with no grouping ("Other") or no squad ("Unassigned")
+// sentinel filter value matching players with no group ("Other") or no squad ("Unassigned")
 const FILTER_NONE = '__none__'
 
 function ColumnFilterSelect({ value, onChange, options, triggerClassName }: {
@@ -769,32 +772,32 @@ function nameColumn<T extends TeamsPanelModels.EnrichedPlayer>(helper: ColumnHel
 	})
 }
 
-function groupingColumn<T extends TeamsPanelModels.EnrichedPlayer>(helper: ColumnHelper<T>) {
-	return helper.accessor(row => row.grouping ?? '', {
-		id: 'grouping',
+function groupColumn<T extends TeamsPanelModels.EnrichedPlayer>(helper: ColumnHelper<T>) {
+	return helper.accessor(row => row.group ?? '', {
+		id: 'group',
 		header: ({ table }) => {
-			const { filters, availableGroupings } = table.options.meta as BasePlayerTableMeta
+			const { filters, availableGroups } = table.options.meta as BasePlayerTableMeta
 			return (
 				<span className="flex flex-col items-start max-w-24">
-					Grouping
+					Group
 					<ColumnFilterSelect
-						value={filters.grouping}
-						onChange={filters.setGrouping}
-						options={[...availableGroupings.map(g => ({ value: g, label: g })), { value: FILTER_NONE, label: 'Other' }]}
+						value={filters.group}
+						onChange={filters.setGroup}
+						options={[...availableGroups.map(g => ({ value: g, label: g })), { value: FILTER_NONE, label: PG.UNGROUPED_LABEL }]}
 						triggerClassName="max-w-24"
 					/>
 				</span>
 			)
 		},
 		cell: ({ row, table }) => {
-			const label = row.original.grouping
-			if (!label) return null
-			const { groupingColorByLabel } = table.options.meta as BasePlayerTableMeta
-			const color = groupingColorByLabel.get(label)
+			const group = row.original.group
+			if (!group) return null
+			const { groupColorByName } = table.options.meta as BasePlayerTableMeta
+			const color = groupColorByName.get(group)
 			return (
 				<span className="flex items-center gap-1 max-w-24">
 					{color && <span className="w-2 h-2 rounded-sm shrink-0" style={{ backgroundColor: color }} />}
-					<span className="truncate" title={label}>{label}</span>
+					<span className="truncate" title={group}>{group}</span>
 				</span>
 			)
 		},
@@ -1002,7 +1005,7 @@ const teamPlayerColumns: ColumnDef<TeamsPanelModels.EnrichedPlayer, any>[] = [
 		cell: selectColumnCell,
 	}),
 	nameColumn(playerColumnHelper),
-	groupingColumn(playerColumnHelper),
+	groupColumn(playerColumnHelper),
 	squadColumn<TeamsPanelModels.EnrichedPlayer, TeamPlayerTableMeta>(playerColumnHelper, {
 		getSquad: (player, meta) => meta.squads.find(s => s.squadId === player.squadId),
 		squadLabel: squad => squad.squadName === 'Command Squad' ? `CMD(${squad.squadId})` : String(squad.squadId),
@@ -1059,7 +1062,7 @@ const combinedPlayerColumns: ColumnDef<CombinedPlayer, any>[] = [
 		},
 	}),
 	nameColumn(combinedColumnHelper),
-	groupingColumn(combinedColumnHelper),
+	groupColumn(combinedColumnHelper),
 	squadColumn<CombinedPlayer, CombinedTableMeta>(combinedColumnHelper, {
 		getSquad: (player, meta) =>
 			meta.squadsWithTeam.find(({ squad: s, normedTeam }) => s.squadId === player.squadId && normedTeam === player.normedTeam)?.squad,
@@ -1090,28 +1093,23 @@ const matchesTeamSquadFilter = (player: TeamsPanelModels.EnrichedPlayer, squadFi
 const matchesCombinedSquadFilter = (player: CombinedPlayer, squadFilter: string) =>
 	squadFilter === FILTER_NONE ? player.squadId === null : squadFilter === `${player.normedTeam}:${player.squadId}`
 
-function useGroupingColorByLabel(): Map<string, string> {
+function useGroupColorByName(): Map<string, string> {
 	const config = ZusUtils.useStore(SettingsClient.PublicSettingsStore)
-	const orgFlags = BattlemetricsClient.useOrgFlags()
-	const modeIds = React.useMemo(() => BM.getGroupingModeIds(config?.playerFlagGroupings ?? BM.EMPTY_PLAYER_FLAG_GROUPINGS), [config])
-	const activeModeId = ZusUtils.useStore(BattlemetricsClient.Store, BattlemetricsClient.Sel.activeGroupingModeId(modeIds))
+	const playerGroupings = config?.playerGroupings
+	const groupingIds = React.useMemo(() => playerGroupings ? PG.getGroupingIds(playerGroupings) : [], [playerGroupings])
+	const activeGroupingId = ZusUtils.useStore(BattlemetricsClient.Store, BattlemetricsClient.Sel.activeGroupingId(groupingIds))
 	return React.useMemo(() => {
-		const playerFlagGroupings = config?.playerFlagGroupings ?? BM.EMPTY_PLAYER_FLAG_GROUPINGS
-		if (!activeModeId) return new Map<string, string>()
-		const modeGroupings = playerFlagGroupings.groupings.filter(g => g.modeIds.includes(activeModeId))
-		const flagColorById = new Map<string, string>()
-		for (const flag of orgFlags ?? []) {
-			if (flag.color) flagColorById.set(flag.id, flag.color)
-		}
 		const result = new Map<string, string>()
-		for (const group of modeGroupings) {
-			result.set(group.label, flagColorById.get(group.color) ?? group.color)
+		const grouping = activeGroupingId ? playerGroupings?.[activeGroupingId] : undefined
+		if (!grouping) return result
+		for (const group of PG.getGroupNames(grouping)) {
+			result.set(group, PG.getGroupColor(grouping, group))
 		}
 		return result
-	}, [config, orgFlags, activeModeId])
+	}, [playerGroupings, activeGroupingId])
 }
 
-// Applies search + role/grouping/squad/admin filters, then the "show selected" toggle. squad matching
+// Applies search + role/group/squad/admin filters, then the "show selected" toggle. squad matching
 // differs between variants, so the predicate is passed in (must be a stable module-level reference).
 function useDisplayedPlayers<T extends TeamsPanelModels.EnrichedPlayer>(
 	players: T[],
@@ -1129,8 +1127,8 @@ function useDisplayedPlayers<T extends TeamsPanelModels.EnrichedPlayer>(
 			result = players.filter((_, i) => matched.has(i))
 		}
 		if (filters.role !== null) result = result.filter(p => p.role === filters.role)
-		if (filters.grouping !== null) {
-			result = result.filter(p => filters.grouping === FILTER_NONE ? p.grouping == null : p.grouping === filters.grouping)
+		if (filters.group !== null) {
+			result = result.filter(p => filters.group === FILTER_NONE ? p.group == null : p.group === filters.group)
 		}
 		if (filters.squad !== null) result = result.filter(p => matchesSquadFilter(p, filters.squad!))
 		if (adminsOnly) result = result.filter(p => p.isAdmin)
@@ -1436,7 +1434,7 @@ function TeamPlayerTable(
 		sorting: SortingState
 		setSorting: React.Dispatch<React.SetStateAction<SortingState>>
 		availableRoles: string[]
-		availableGroupings: string[]
+		availableGroups: string[]
 		hideSpoilers: boolean
 		className?: string
 		stores: SquadServerFrame.KeyProp
@@ -1445,7 +1443,7 @@ function TeamPlayerTable(
 	const rowSelection = ZusUtils.useStore(props.stores.squadServer!, SquadServerFrame.Sel.playerSelection)
 	const match = MatchHistoryClient.useCurrentMatch(props.stores.squadServer!.serverId)
 	const matchId = match?.historyEntryId ?? 0
-	const groupingColorByLabel = useGroupingColorByLabel()
+	const groupColorByName = useGroupColorByName()
 
 	const players = ZusUtils.useStore(
 		props.stores.squadServer!,
@@ -1493,10 +1491,10 @@ function TeamPlayerTable(
 		matchId,
 		teamId: MH.getDenormedTeamId(props.teamId, match?.ordinal ?? 0),
 		squads,
-		groupingColorByLabel,
+		groupColorByName,
 		filters: props.filters,
 		availableRoles: props.availableRoles,
-		availableGroupings: props.availableGroupings,
+		availableGroups: props.availableGroups,
 		stores: props.stores,
 		statsMayBeInaccurate,
 	} satisfies Omit<TeamPlayerTableMeta, 'statsSort'>
@@ -1526,7 +1524,7 @@ function CombinedPlayerTable(
 		sorting: SortingState
 		setSorting: React.Dispatch<React.SetStateAction<SortingState>>
 		availableRoles: string[]
-		availableGroupings: string[]
+		availableGroups: string[]
 		hideSpoilers: boolean
 		className?: string
 		stores: SquadServerFrame.KeyProp
@@ -1535,7 +1533,7 @@ function CombinedPlayerTable(
 	const rowSelection = ZusUtils.useStore(props.stores.squadServer!, SquadServerFrame.Sel.playerSelection)
 	const match = MatchHistoryClient.useCurrentMatch(props.stores.squadServer!.serverId)
 	const matchId = match?.historyEntryId ?? 0
-	const groupingColorByLabel = useGroupingColorByLabel()
+	const groupColorByName = useGroupColorByName()
 
 	const playersA = ZusUtils.useStore(
 		props.stores.squadServer!,
@@ -1639,10 +1637,10 @@ function CombinedPlayerTable(
 	const meta = {
 		matchId,
 		squadsWithTeam,
-		groupingColorByLabel,
+		groupColorByName,
 		filters: props.filters,
 		availableRoles: props.availableRoles,
-		availableGroupings: props.availableGroupings,
+		availableGroups: props.availableGroups,
 		getFaction,
 		getTeamColor,
 		stores: props.stores,

--- a/src/components/teams-panel.tsx
+++ b/src/components/teams-panel.tsx
@@ -1095,6 +1095,7 @@ const matchesCombinedSquadFilter = (player: CombinedPlayer, squadFilter: string)
 
 function useGroupColorByName(): Map<string, string> {
 	const config = ZusUtils.useStore(SettingsClient.PublicSettingsStore)
+	const orgFlags = BattlemetricsClient.useOrgFlags()
 	const playerGroupings = config?.playerGroupings
 	const groupingIds = React.useMemo(() => playerGroupings ? PG.getGroupingIds(playerGroupings) : [], [playerGroupings])
 	const activeGroupingId = ZusUtils.useStore(BattlemetricsClient.Store, BattlemetricsClient.Sel.activeGroupingId(groupingIds))
@@ -1103,10 +1104,10 @@ function useGroupColorByName(): Map<string, string> {
 		const grouping = activeGroupingId ? playerGroupings?.[activeGroupingId] : undefined
 		if (!grouping) return result
 		for (const group of PG.getGroupNames(grouping)) {
-			result.set(group, PG.getGroupColor(grouping, group))
+			result.set(group, PG.getGroupColor(grouping, group, orgFlags))
 		}
 		return result
-	}, [playerGroupings, activeGroupingId])
+	}, [playerGroupings, activeGroupingId, orgFlags])
 }
 
 // Applies search + role/group/squad/admin filters, then the "show selected" toggle. squad matching

--- a/src/frames/squad-server.frame.ts
+++ b/src/frames/squad-server.frame.ts
@@ -267,11 +267,11 @@ export namespace Actions {
 		)
 	}
 
-	export function selectGrouping(stores: KeyProp, grouping: string, teamId?: SM.TeamId) {
+	export function selectGroup(stores: KeyProp, group: string, teamId?: SM.TeamId) {
 		const enriched = getEnrichedPlayers(stores)
 		selectPlayers(
 			stores,
-			enriched.filter(p => p.grouping === grouping && (teamId == null || p.teamId === teamId)).map(p => SM.PlayerIds.getPlayerId(p.ids)),
+			enriched.filter(p => p.group === group && (teamId == null || p.teamId === teamId)).map(p => SM.PlayerIds.getPlayerId(p.ids)),
 		)
 	}
 

--- a/src/lib/settings-groups.ts
+++ b/src/lib/settings-groups.ts
@@ -23,7 +23,7 @@ export const GLOBAL_SETTINGS_GROUPS: SettingsGroup[] = [
 		label: 'Squad Server',
 		keys: ['squadServer', 'fogOffDelay', 'postRollAnnouncementsTimeout', 'balanceTriggerLevels'],
 	},
-	{ slug: 'players', label: 'Players & Flags', keys: ['playerFlagGroupings', 'playerFlagsRequiringNote'] },
+	{ slug: 'players', label: 'Players & Flags', keys: ['playerGroupings', 'playerFlagsRequiringNote'] },
 	// rbac stays ungrouped: its own section header already reads "Permissions & Roles"
 ]
 
@@ -39,8 +39,8 @@ export const TOC_LEAF_PATHS: ReadonlySet<string> = new Set([
 	'layerGeneration',
 	'queue.mainPool',
 	'queue.generationPool',
-	// the whole playerFlagGroupings subtree renders as one bespoke editor (modes + groupings), so it emits no per-subkey anchors
-	'playerFlagGroupings',
+	// the whole playerGroupings subtree renders as one bespoke editor, so it emits no per-subkey anchors
+	'playerGroupings',
 	// the whole rbac subtree renders as one consolidated per-role editor, so it emits no per-subkey anchors
 	'rbac',
 ])

--- a/src/migrations/0081_player_groupings_by_grouping_id.ts
+++ b/src/migrations/0081_player_groupings_by_grouping_id.ts
@@ -1,0 +1,96 @@
+import type { MigrationDriver } from '@/server/migrate'
+
+// Replaces `playerFlagGroupings` with `playerGroupings`, keyed by grouping id. Before:
+//   playerFlagGroupings: { modeIds: string[], groupings: { label, modeIds, associations: Record<flagId, number>, color }[] }
+// After:
+//   playerGroupings: Record<groupingId, { rules: { type: 'battlemetrics', flag, group }[], groups: Record<group, { color }> }>
+//
+// The old "display mode" is now the grouping itself, so each mode becomes one record entry holding only the groupings that
+// referenced it. Numeric `associations` priorities are flattened into `rules` -- ordered across every grouping in the mode,
+// which is how priority was compared before -- so array position now carries the priority.
+//
+// Without this migration the reshaped GlobalSettingsSchema fails to validate on load, which would reset EVERY global
+// setting to defaults.
+//
+// `settings` is stored superjson-wrapped ({ json, meta }) in a drizzle json(text) column; we parse the TEXT, mutate the
+// plain `.json` payload and write it back. All reshaped values are plain strings/arrays/objects, so the superjson `meta`
+// (which only tags non-JSON types) never references them and is left untouched. Shapes are inlined per the
+// frozen-in-time migration rule.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const DEFAULT_GROUP_COLOR = '#888888'
+
+export async function up(db: MigrationDriver): Promise<void> {
+	const row = db.prepare(`SELECT settings FROM globalSettings WHERE id = 1`).get() as { settings: string } | undefined
+	if (!row?.settings) return
+
+	const wrapper = JSON.parse(row.settings) as { json?: any; meta?: any }
+	const json = wrapper?.json
+	if (!json || typeof json !== 'object') return
+
+	const old = json.playerFlagGroupings
+	// idempotent: nothing to do once the key is gone, and the old value is always the { modeIds, groupings } object
+	if (!old || typeof old !== 'object' || Array.isArray(old)) {
+		if ('playerFlagGroupings' in json) {
+			delete json.playerFlagGroupings
+			db.prepare(`UPDATE globalSettings SET settings = ? WHERE id = 1`).run(JSON.stringify(wrapper))
+		}
+		return
+	}
+
+	const oldGroupings: any[] = Array.isArray(old.groupings) ? old.groupings : []
+
+	// a grouping's mode may not have made it into the declared list, so take the union rather than trusting `modeIds`
+	const groupingIds: string[] = []
+	for (const modeId of [...(Array.isArray(old.modeIds) ? old.modeIds : []), ...oldGroupings.flatMap(g => g?.modeIds ?? [])]) {
+		const id = String(modeId)
+		if (id && !groupingIds.includes(id)) groupingIds.push(id)
+	}
+
+	// `color` used to mean either a flag id (take that flag's color) or a literal CSS color. A flag id can't be resolved
+	// here (no BattleMetrics access from a migration), so those fall back to the neutral default and get re-picked by hand.
+	const unresolvedColorGroups: string[] = []
+
+	const playerGroupings: Record<string, { rules: any[]; groups: Record<string, { color: string }> }> = {}
+	for (const groupingId of groupingIds) {
+		const mine = oldGroupings.filter(g => (g?.modeIds ?? []).map(String).includes(groupingId))
+
+		const flattened: { group: string; flag: string; priority: number }[] = []
+		const groups: Record<string, { color: string }> = {}
+		for (const g of mine) {
+			const group = typeof g?.label === 'string' ? g.label.trim() : ''
+			// the new rule schema requires a group name; an unlabelled grouping could never be told apart in the UI anyway
+			if (!group) continue
+
+			const rawColor = typeof g?.color === 'string' ? g.color : ''
+			if (rawColor && UUID_RE.test(rawColor)) {
+				groups[group] = { color: DEFAULT_GROUP_COLOR }
+				unresolvedColorGroups.push(`${groupingId}/${group}`)
+			} else {
+				groups[group] = { color: rawColor || DEFAULT_GROUP_COLOR }
+			}
+
+			for (const [flag, priority] of Object.entries(g?.associations ?? {})) {
+				flattened.push({ group, flag, priority: typeof priority === 'number' ? priority : 0 })
+			}
+		}
+
+		flattened.sort((a, b) => a.priority - b.priority)
+		playerGroupings[groupingId] = {
+			rules: flattened.map(({ flag, group }) => ({ type: 'battlemetrics', flag, group })),
+			groups,
+		}
+	}
+
+	delete json.playerFlagGroupings
+	json.playerGroupings = playerGroupings
+	db.prepare(`UPDATE globalSettings SET settings = ? WHERE id = 1`).run(JSON.stringify(wrapper))
+
+	if (unresolvedColorGroups.length > 0) {
+		console.warn(
+			`0081: these groups took their color from a flag, which cannot be resolved offline, so they were set to `
+				+ `${DEFAULT_GROUP_COLOR}. Under Settings > Players & Flags > Player groupings, the reset button next to each group `
+				+ `(Colors section) takes the color back from its flag: ${unresolvedColorGroups.join(', ')}`,
+		)
+	}
+}

--- a/src/migrations/0081_player_groupings_by_grouping_id.ts
+++ b/src/migrations/0081_player_groupings_by_grouping_id.ts
@@ -3,11 +3,18 @@ import type { MigrationDriver } from '@/server/migrate'
 // Replaces `playerFlagGroupings` with `playerGroupings`, keyed by grouping id. Before:
 //   playerFlagGroupings: { modeIds: string[], groupings: { label, modeIds, associations: Record<flagId, number>, color }[] }
 // After:
-//   playerGroupings: Record<groupingId, { rules: { type: 'battlemetrics', flag, group }[], groups: Record<group, { color }> }>
+//   playerGroupings: Record<groupingId, {
+//     rules: { type: 'battlemetrics', flag, group }[],
+//     groups: Record<group, { color: { type: 'flag', flag } | { type: 'custom', color } }>
+//   }>
 //
 // The old "display mode" is now the grouping itself, so each mode becomes one record entry holding only the groupings that
 // referenced it. Numeric `associations` priorities are flattened into `rules` -- ordered across every grouping in the mode,
 // which is how priority was compared before -- so array position now carries the priority.
+//
+// The old `color` was one string meaning either a flag id (take that flag's color) or a literal CSS color, told apart by
+// looking for a UUID. Both meanings survive as the two variants of the new tagged color, so the same UUID test decides
+// which variant to write and nothing is lost.
 //
 // Without this migration the reshaped GlobalSettingsSchema fails to validate on load, which would reset EVERY global
 // setting to defaults.
@@ -47,27 +54,24 @@ export async function up(db: MigrationDriver): Promise<void> {
 		if (id && !groupingIds.includes(id)) groupingIds.push(id)
 	}
 
-	// `color` used to mean either a flag id (take that flag's color) or a literal CSS color. A flag id can't be resolved
-	// here (no BattleMetrics access from a migration), so those fall back to the neutral default and get re-picked by hand.
-	const unresolvedColorGroups: string[] = []
+	type Color = { type: 'flag'; flag: string } | { type: 'custom'; color: string }
 
-	const playerGroupings: Record<string, { rules: any[]; groups: Record<string, { color: string }> }> = {}
+	const playerGroupings: Record<string, { rules: any[]; groups: Record<string, { color: Color }> }> = {}
 	for (const groupingId of groupingIds) {
 		const mine = oldGroupings.filter(g => (g?.modeIds ?? []).map(String).includes(groupingId))
 
 		const flattened: { group: string; flag: string; priority: number }[] = []
-		const groups: Record<string, { color: string }> = {}
+		const groups: Record<string, { color: Color }> = {}
 		for (const g of mine) {
 			const group = typeof g?.label === 'string' ? g.label.trim() : ''
 			// the new rule schema requires a group name; an unlabelled grouping could never be told apart in the UI anyway
 			if (!group) continue
 
 			const rawColor = typeof g?.color === 'string' ? g.color : ''
-			if (rawColor && UUID_RE.test(rawColor)) {
-				groups[group] = { color: DEFAULT_GROUP_COLOR }
-				unresolvedColorGroups.push(`${groupingId}/${group}`)
-			} else {
-				groups[group] = { color: rawColor || DEFAULT_GROUP_COLOR }
+			groups[group] = {
+				color: UUID_RE.test(rawColor)
+					? { type: 'flag', flag: rawColor }
+					: { type: 'custom', color: rawColor || DEFAULT_GROUP_COLOR },
 			}
 
 			for (const [flag, priority] of Object.entries(g?.associations ?? {})) {
@@ -85,12 +89,4 @@ export async function up(db: MigrationDriver): Promise<void> {
 	delete json.playerFlagGroupings
 	json.playerGroupings = playerGroupings
 	db.prepare(`UPDATE globalSettings SET settings = ? WHERE id = 1`).run(JSON.stringify(wrapper))
-
-	if (unresolvedColorGroups.length > 0) {
-		console.warn(
-			`0081: these groups took their color from a flag, which cannot be resolved offline, so they were set to `
-				+ `${DEFAULT_GROUP_COLOR}. Under Settings > Players & Flags > Player groupings, the reset button next to each group `
-				+ `(Colors section) takes the color back from its flag: ${unresolvedColorGroups.join(', ')}`,
-		)
-	}
 }

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -30,6 +30,7 @@ import * as m0077 from './0077_sftp_tuning_into_connection'
 import * as m0078 from './0078_admin_list_sources_per_server'
 import * as m0079 from './0079_connection_modes'
 import * as m0080 from './0080_command_aliases'
+import * as m0081 from './0081_player_groupings_by_grouping_id'
 
 export const tsMigrations: TsMigration[] = [
 	{ name: '0062_filter_nodes_operator_model', up: m0062.up },
@@ -51,4 +52,5 @@ export const tsMigrations: TsMigration[] = [
 	{ name: '0078_admin_list_sources_per_server', up: m0078.up },
 	{ name: '0079_connection_modes', up: m0079.up },
 	{ name: '0080_command_aliases', up: m0080.up },
+	{ name: '0081_player_groupings_by_grouping_id', up: m0081.up },
 ]

--- a/src/models/battlemetrics.models.ts
+++ b/src/models/battlemetrics.models.ts
@@ -144,58 +144,6 @@ export type PlayerProfile = {
 
 export type PublicPlayerBmData = Record<string, PlayerFlagsAndProfile>
 export type PlayerBmDataUpdate = { playerId: string; data: PlayerFlagsAndProfile }
-// a single grouping: assigns players to a labelled/colored bucket (by the flags in `associations`, priority-ordered)
-// within the display modes it belongs to.
-export const PlayerFlagGroupingSchema = z.object({
-	label: z.string(),
-	modeIds: z.array(z.string()).prefault([]),
-	associations: z.record(z.uuid(), z.number()),
-	color: z.string(),
-})
-export type PlayerFlagGrouping = z.infer<typeof PlayerFlagGroupingSchema>
-
-// `modeIds` are the display modes declared upfront; each grouping's own `modeIds` reference this list.
-export const PlayerFlagGroupingsSchema = z.object({
-	modeIds: z.array(z.string()).prefault([]),
-	groupings: z.array(PlayerFlagGroupingSchema).prefault([]),
-})
-export type PlayerFlagGroupings = z.infer<typeof PlayerFlagGroupingsSchema>
-
-export const EMPTY_PLAYER_FLAG_GROUPINGS: PlayerFlagGroupings = { modeIds: [], groupings: [] }
-
-export function getGroupingModeIds(groupings: PlayerFlagGroupings): string[] {
-	return groupings.modeIds
-}
-
-export function resolvePlayerFlagGroups(
-	players: [SM.PlayerId, PlayerFlag[]][],
-	groupings: PlayerFlagGroupings,
-	modeId: string | null | undefined,
-) {
-	const groups: Map<SM.PlayerId, string> = new Map()
-	if (!modeId) return groups
-
-	const modeGroupings = groupings.groupings.filter(g => g.modeIds.includes(modeId))
-	const associations: [string, string, number][] = []
-	for (const group of modeGroupings) {
-		for (const [id, priority] of Object.entries(group.associations)) {
-			associations.push([group.label, id, priority])
-		}
-	}
-	associations.sort((a, b) => a[2] - b[2])
-
-	for (const [playerId, playerFlags] of players) {
-		for (const [label, flagId] of associations) {
-			if (playerFlags.some(f => f.id === flagId)) {
-				groups.set(playerId, label)
-				break
-			}
-		}
-	}
-
-	return groups
-}
-
 export function resolveFlags(flagIds: string[], orgFlags: PlayerFlag[]): PlayerFlag[] {
 	return flagIds.flatMap((id) => {
 		const flag = orgFlags.find((f) => f.id === id)
@@ -211,7 +159,7 @@ export const UpdatePlayerFlagsInputSchema = z.object({
 export type UpdatePlayerFlagsInput = z.infer<typeof UpdatePlayerFlagsInputSchema>
 
 export type StoreState = {
-	selectedModeId: string | null
+	selectedGroupingId: string | null
 	slsOnly: boolean
 	orgFlags: PlayerFlag[]
 }

--- a/src/models/chat.models.test.ts
+++ b/src/models/chat.models.test.ts
@@ -11,6 +11,7 @@ function makePlayer(eos: string, opts: Partial<SM.Player> = {}): SM.Player {
 		squadId: null,
 		isLeader: false,
 		isAdmin: false,
+		adminGroups: [],
 		role: 'Rifleman_01',
 		...opts,
 	}

--- a/src/models/dndkit.models.ts
+++ b/src/models/dndkit.models.ts
@@ -24,8 +24,9 @@ export type DragItem = {
 	type: 'layer-generation-column'
 	id: string
 } | {
-	// a flag in an ordered BattleMetrics flag list, e.g. the player flag color hierarchy (id = flag id)
-	type: 'bm-flag'
+	// a rule row in a player grouping's ordered rule list. A rule has no id of its own and its order is its priority,
+	// so it's identified by grouping + position -- see ruleDragId (settings-form), which owns the encoding.
+	type: 'grouping-rule'
 	id: string
 }
 

--- a/src/models/pending-events.models.test.ts
+++ b/src/models/pending-events.models.test.ts
@@ -84,6 +84,7 @@ function makePlayer(eos: string, teamId: SM.TeamId, opts: Partial<SM.Player> = {
 		squadId: null,
 		isLeader: false,
 		isAdmin: false,
+		adminGroups: [],
 		role: 'Rifleman_01',
 		...opts,
 	}

--- a/src/models/pending-events.models.ts
+++ b/src/models/pending-events.models.ts
@@ -1030,6 +1030,8 @@ async function* processPendingEvent(
 				squadId: null,
 				isLeader: false,
 				isAdmin: state.admins.has(SM.PlayerIds.getPlayerId(events.PLAYER_CONNECTED.playerIds)),
+				// the log stream carries no admin-list membership; the next RCON teams poll fills both this and isAdmin in
+				adminGroups: [],
 				role: 'unknown',
 			}
 
@@ -1393,6 +1395,7 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 				squadId: null,
 				isLeader: false,
 				isAdmin: nextPlayer.isAdmin,
+				adminGroups: nextPlayer.adminGroups,
 				role: nextPlayer.role,
 			},
 			...base,

--- a/src/models/player-groupings.models.test.ts
+++ b/src/models/player-groupings.models.test.ts
@@ -10,6 +10,15 @@ function rule(flagId: string, group: string): PG.GroupRule {
 	return { type: 'battlemetrics', flag: flagId, group }
 }
 
+function adminRule(adminGroup: string, group: string): PG.GroupRule {
+	return { type: 'admin-list', adminGroup, group }
+}
+
+// a player carrying the given flags and no admin-list membership
+function withFlags(...ids: string[]): PG.PlayerFacts {
+	return { flags: ids.map((id) => flag(id)), adminGroups: [] }
+}
+
 const GROUPING: PG.Grouping = {
 	rules: [rule('f-hq', 'HQ'), rule('f-mod', 'HQ'), rule('f-regular', 'Regulars')],
 	groups: { HQ: { color: { type: 'flag', flag: 'f-hq' } }, Regulars: { color: { type: 'custom', color: '#00ff00' } } },
@@ -19,21 +28,44 @@ const ORG_FLAGS = [flag('f-hq', '#ff0000'), flag('f-mod', '#0000ff'), flag('f-re
 
 describe('resolveGroup', () => {
 	it('assigns the group of the first matching rule', () => {
-		expect(PG.resolveGroup(GROUPING, [flag('f-regular')])).toBe('Regulars')
-		expect(PG.resolveGroup(GROUPING, [flag('f-mod')])).toBe('HQ')
+		expect(PG.resolveGroup(GROUPING, withFlags('f-regular'))).toBe('Regulars')
+		expect(PG.resolveGroup(GROUPING, withFlags('f-mod'))).toBe('HQ')
 	})
 
 	it('rule order decides priority when a player matches several rules', () => {
 		// carries both: HQ wins because its rule sits higher, regardless of the flags' own order
-		expect(PG.resolveGroup(GROUPING, [flag('f-regular'), flag('f-hq')])).toBe('HQ')
+		expect(PG.resolveGroup(GROUPING, withFlags('f-regular', 'f-hq'))).toBe('HQ')
 
 		const reordered: PG.Grouping = { ...GROUPING, rules: [...GROUPING.rules].reverse() }
-		expect(PG.resolveGroup(reordered, [flag('f-regular'), flag('f-hq')])).toBe('Regulars')
+		expect(PG.resolveGroup(reordered, withFlags('f-regular', 'f-hq'))).toBe('Regulars')
 	})
 
 	it('leaves a player ungrouped when no rule matches', () => {
-		expect(PG.resolveGroup(GROUPING, [flag('f-unknown')])).toBeUndefined()
-		expect(PG.resolveGroup(GROUPING, [])).toBeUndefined()
+		expect(PG.resolveGroup(GROUPING, withFlags('f-unknown'))).toBeUndefined()
+		expect(PG.resolveGroup(GROUPING, withFlags())).toBeUndefined()
+	})
+
+	it('matches admin-list group membership', () => {
+		const g: PG.Grouping = { rules: [adminRule('Admins', 'Staff'), adminRule('Whitelist', 'Members')], groups: {} }
+		expect(PG.resolveGroup(g, { flags: [], adminGroups: ['Whitelist'] })).toBe('Members')
+		// a player in several admin groups takes the higher rule, same as flags
+		expect(PG.resolveGroup(g, { flags: [], adminGroups: ['Whitelist', 'Admins'] })).toBe('Staff')
+		expect(PG.resolveGroup(g, { flags: [], adminGroups: ['Cameraman'] })).toBeUndefined()
+	})
+
+	// the whole point of the source discriminator: one grouping can mix them, and priority is still just rule order
+	it('mixes sources in one priority order', () => {
+		const g: PG.Grouping = { rules: [adminRule('Admins', 'Staff'), rule('f-regular', 'Regulars')], groups: {} }
+		const both: PG.PlayerFacts = { flags: [flag('f-regular')], adminGroups: ['Admins'] }
+		expect(PG.resolveGroup(g, both)).toBe('Staff')
+		const flipped: PG.Grouping = { ...g, rules: [...g.rules].reverse() }
+		expect(PG.resolveGroup(flipped, both)).toBe('Regulars')
+	})
+
+	// a rule only ever reads its own source's facts
+	it('does not match an admin group against a flag of the same name', () => {
+		const g: PG.Grouping = { rules: [adminRule('Whitelist', 'Members')], groups: {} }
+		expect(PG.resolveGroup(g, { flags: [flag('Whitelist')], adminGroups: [] })).toBeUndefined()
 	})
 })
 
@@ -102,6 +134,21 @@ describe('getGroupFlags', () => {
 	it('skips rules with no flag picked yet', () => {
 		expect(PG.getGroupFlags({ rules: [rule('', 'HQ'), rule('f-hq', 'HQ')], groups: {} }, 'HQ')).toEqual(['f-hq'])
 	})
+
+	// an admin list carries no colors, so such a group has nothing to follow and takes a custom color instead
+	it('offers nothing for a group defined only by admin-list rules', () => {
+		const g: PG.Grouping = { rules: [adminRule('Whitelist', 'Members')], groups: {} }
+		expect(PG.getGroupFlags(g, 'Members')).toEqual([])
+		expect(PG.defaultGroupColor(g, 'Members', ORG_FLAGS)).toBeUndefined()
+		expect(PG.getGroupColor(g, 'Members', ORG_FLAGS)).toBe(PG.DEFAULT_GROUP_COLOR)
+	})
+
+	// a group fed by both sources can still follow its flag
+	it('offers only the flag rules of a mixed group', () => {
+		const g: PG.Grouping = { rules: [adminRule('Admins', 'Staff'), rule('f-hq', 'Staff')], groups: {} }
+		expect(PG.getGroupFlags(g, 'Staff')).toEqual(['f-hq'])
+		expect(PG.defaultGroupColor(g, 'Staff', ORG_FLAGS)).toEqual({ type: 'flag', flag: 'f-hq' })
+	})
 })
 
 describe('getGroupColor', () => {
@@ -145,10 +192,10 @@ describe('resolvePlayerGroups', () => {
 	}
 
 	it('resolves every player under the named grouping only', () => {
-		const players: [string, BM.PlayerFlag[]][] = [
-			['p1', [flag('f-hq')]],
-			['p2', [flag('f-regular')]],
-			['p3', [flag('f-nothing')]],
+		const players: [string, PG.PlayerFacts][] = [
+			['p1', withFlags('f-hq')],
+			['p2', withFlags('f-regular')],
+			['p3', withFlags('f-nothing')],
 		]
 		expect(PG.resolvePlayerGroups(players, groupings, 'admin')).toEqual(new Map([['p1', 'HQ'], ['p2', 'Regulars']]))
 		// the same roster buckets differently under another grouping -- that is the point of having several
@@ -156,7 +203,7 @@ describe('resolvePlayerGroups', () => {
 	})
 
 	it('groups nobody for a missing or unset grouping', () => {
-		const players: [string, BM.PlayerFlag[]][] = [['p1', [flag('f-hq')]]]
+		const players: [string, PG.PlayerFacts][] = [['p1', withFlags('f-hq')]]
 		expect(PG.resolvePlayerGroups(players, groupings, 'deleted').size).toBe(0)
 		expect(PG.resolvePlayerGroups(players, groupings, null).size).toBe(0)
 	})
@@ -170,6 +217,14 @@ describe('PlayerGroupingsSchema', () => {
 
 	it('rejects a rule with no group, which could never be told apart in the UI', () => {
 		expect(PG.PlayerGroupingsSchema.safeParse({ admin: { rules: [rule('f-hq', '')] } }).success).toBe(false)
+	})
+
+	it('takes admin-list rules and keeps the sources apart', () => {
+		const parsed = PG.PlayerGroupingsSchema.parse({ a: { rules: [adminRule('Whitelist', 'Members'), rule('f-hq', 'HQ')] } })
+		expect(parsed.a.rules).toEqual([adminRule('Whitelist', 'Members'), rule('f-hq', 'HQ')])
+		// each variant carries only its own source field
+		expect(PG.PlayerGroupingsSchema.safeParse({ a: { rules: [{ type: 'admin-list', flag: 'f-hq', group: 'HQ' }] } }).success).toBe(false)
+		expect(PG.PlayerGroupingsSchema.safeParse({ a: { rules: [{ type: 'admin-list', adminGroup: '', group: 'HQ' }] } }).success).toBe(false)
 	})
 
 	it('takes both color variants and rejects an untagged one', () => {

--- a/src/models/player-groupings.models.test.ts
+++ b/src/models/player-groupings.models.test.ts
@@ -1,0 +1,90 @@
+import type * as BM from '@/models/battlemetrics.models'
+import * as PG from '@/models/player-groupings.models'
+import { describe, expect, it } from 'vitest'
+
+function flag(id: string): BM.PlayerFlag {
+	return { id, name: id, color: null, description: null, icon: null }
+}
+
+function rule(flagId: string, group: string): PG.GroupRule {
+	return { type: 'battlemetrics', flag: flagId, group }
+}
+
+const GROUPING: PG.Grouping = {
+	rules: [rule('f-hq', 'HQ'), rule('f-mod', 'HQ'), rule('f-regular', 'Regulars')],
+	groups: { HQ: { color: '#ff0000' }, Regulars: { color: '#00ff00' } },
+}
+
+describe('resolveGroup', () => {
+	it('assigns the group of the first matching rule', () => {
+		expect(PG.resolveGroup(GROUPING, [flag('f-regular')])).toBe('Regulars')
+		expect(PG.resolveGroup(GROUPING, [flag('f-mod')])).toBe('HQ')
+	})
+
+	it('rule order decides priority when a player matches several rules', () => {
+		// carries both: HQ wins because its rule sits higher, regardless of the flags' own order
+		expect(PG.resolveGroup(GROUPING, [flag('f-regular'), flag('f-hq')])).toBe('HQ')
+
+		const reordered: PG.Grouping = { ...GROUPING, rules: [...GROUPING.rules].reverse() }
+		expect(PG.resolveGroup(reordered, [flag('f-regular'), flag('f-hq')])).toBe('Regulars')
+	})
+
+	it('leaves a player ungrouped when no rule matches', () => {
+		expect(PG.resolveGroup(GROUPING, [flag('f-unknown')])).toBeUndefined()
+		expect(PG.resolveGroup(GROUPING, [])).toBeUndefined()
+	})
+})
+
+describe('getGroupNames', () => {
+	it('dedupes by first appearance so the order is the groups own priority', () => {
+		expect(PG.getGroupNames(GROUPING)).toEqual(['HQ', 'Regulars'])
+	})
+
+	// membership comes from the rules alone, so a stale `groups` entry must not invent a group
+	it('ignores groups no rule names', () => {
+		const stale: PG.Grouping = { rules: [rule('f-hq', 'HQ')], groups: { HQ: { color: '#fff' }, Gone: { color: '#000' } } }
+		expect(PG.getGroupNames(stale)).toEqual(['HQ'])
+	})
+})
+
+describe('getGroupColor', () => {
+	it('reads the configured color, falling back when the group has no entry', () => {
+		expect(PG.getGroupColor(GROUPING, 'HQ')).toBe('#ff0000')
+		expect(PG.getGroupColor({ rules: GROUPING.rules, groups: {} }, 'HQ')).toBe(PG.DEFAULT_GROUP_COLOR)
+	})
+})
+
+describe('resolvePlayerGroups', () => {
+	const groupings: PG.PlayerGroupings = {
+		admin: GROUPING,
+		watchlist: { rules: [rule('f-regular', 'Watched')], groups: {} },
+	}
+
+	it('resolves every player under the named grouping only', () => {
+		const players: [string, BM.PlayerFlag[]][] = [
+			['p1', [flag('f-hq')]],
+			['p2', [flag('f-regular')]],
+			['p3', [flag('f-nothing')]],
+		]
+		expect(PG.resolvePlayerGroups(players, groupings, 'admin')).toEqual(new Map([['p1', 'HQ'], ['p2', 'Regulars']]))
+		// the same roster buckets differently under another grouping -- that is the point of having several
+		expect(PG.resolvePlayerGroups(players, groupings, 'watchlist')).toEqual(new Map([['p2', 'Watched']]))
+	})
+
+	it('groups nobody for a missing or unset grouping', () => {
+		const players: [string, BM.PlayerFlag[]][] = [['p1', [flag('f-hq')]]]
+		expect(PG.resolvePlayerGroups(players, groupings, 'deleted').size).toBe(0)
+		expect(PG.resolvePlayerGroups(players, groupings, null).size).toBe(0)
+	})
+})
+
+describe('PlayerGroupingsSchema', () => {
+	it('accepts the record shape and fills in the halves of a grouping', () => {
+		const parsed = PG.PlayerGroupingsSchema.parse({ admin: { rules: [rule('f-hq', 'HQ')] } })
+		expect(parsed.admin).toEqual({ rules: [rule('f-hq', 'HQ')], groups: {} })
+	})
+
+	it('rejects a rule with no group, which could never be told apart in the UI', () => {
+		expect(PG.PlayerGroupingsSchema.safeParse({ admin: { rules: [rule('f-hq', '')] } }).success).toBe(false)
+	})
+})

--- a/src/models/player-groupings.models.test.ts
+++ b/src/models/player-groupings.models.test.ts
@@ -52,6 +52,46 @@ describe('getGroupNames', () => {
 	})
 })
 
+describe('moveRule', () => {
+	const rules = [rule('a', 'A'), rule('b', 'B'), rule('c', 'C'), rule('d', 'D')]
+	const flags = (rs: PG.GroupRule[]) => rs.map((r) => r.type === 'battlemetrics' ? r.flag : '')
+
+	it('moves a rule up, before and after the target', () => {
+		expect(flags(PG.moveRule(rules, 2, 0, 'before'))).toEqual(['c', 'a', 'b', 'd'])
+		expect(flags(PG.moveRule(rules, 2, 0, 'after'))).toEqual(['a', 'c', 'b', 'd'])
+	})
+
+	// moving down is where naive index math goes wrong: pulling the dragged rule out shifts every later index down one
+	it('moves a rule down, before and after the target', () => {
+		expect(flags(PG.moveRule(rules, 0, 2, 'after'))).toEqual(['b', 'c', 'a', 'd'])
+		expect(flags(PG.moveRule(rules, 0, 2, 'before'))).toEqual(['b', 'a', 'c', 'd'])
+	})
+
+	it('moves a rule to either end', () => {
+		expect(flags(PG.moveRule(rules, 3, 0, 'before'))).toEqual(['d', 'a', 'b', 'c'])
+		expect(flags(PG.moveRule(rules, 0, 3, 'after'))).toEqual(['b', 'c', 'd', 'a'])
+	})
+
+	it('is a no-op when dropped on itself or out of range', () => {
+		expect(PG.moveRule(rules, 1, 1, 'before')).toBe(rules)
+		expect(PG.moveRule(rules, 1, 1, 'after')).toBe(rules)
+		expect(PG.moveRule(rules, 9, 0, 'before')).toBe(rules)
+		expect(PG.moveRule(rules, 0, 9, 'before')).toBe(rules)
+	})
+
+	it('never drops or duplicates a rule', () => {
+		for (const from of [0, 1, 2, 3]) {
+			for (const to of [0, 1, 2, 3]) {
+				for (const position of ['before', 'after'] as const) {
+					const next = PG.moveRule(rules, from, to, position)
+					expect(next).toHaveLength(rules.length)
+					expect([...flags(next)].sort()).toEqual(['a', 'b', 'c', 'd'])
+				}
+			}
+		}
+	})
+})
+
 describe('getGroupFlags', () => {
 	// the colour picker offers these, so a group must never be offered another group's flag
 	it('lists only the flags of rules naming that group, deduped and in order', () => {

--- a/src/models/player-groupings.models.test.ts
+++ b/src/models/player-groupings.models.test.ts
@@ -2,8 +2,8 @@ import type * as BM from '@/models/battlemetrics.models'
 import * as PG from '@/models/player-groupings.models'
 import { describe, expect, it } from 'vitest'
 
-function flag(id: string): BM.PlayerFlag {
-	return { id, name: id, color: null, description: null, icon: null }
+function flag(id: string, color: string | null = null): BM.PlayerFlag {
+	return { id, name: id, color, description: null, icon: null }
 }
 
 function rule(flagId: string, group: string): PG.GroupRule {
@@ -12,8 +12,10 @@ function rule(flagId: string, group: string): PG.GroupRule {
 
 const GROUPING: PG.Grouping = {
 	rules: [rule('f-hq', 'HQ'), rule('f-mod', 'HQ'), rule('f-regular', 'Regulars')],
-	groups: { HQ: { color: '#ff0000' }, Regulars: { color: '#00ff00' } },
+	groups: { HQ: { color: { type: 'flag', flag: 'f-hq' } }, Regulars: { color: { type: 'custom', color: '#00ff00' } } },
 }
+
+const ORG_FLAGS = [flag('f-hq', '#ff0000'), flag('f-mod', '#0000ff'), flag('f-regular', '#123456')]
 
 describe('resolveGroup', () => {
 	it('assigns the group of the first matching rule', () => {
@@ -42,15 +44,57 @@ describe('getGroupNames', () => {
 
 	// membership comes from the rules alone, so a stale `groups` entry must not invent a group
 	it('ignores groups no rule names', () => {
-		const stale: PG.Grouping = { rules: [rule('f-hq', 'HQ')], groups: { HQ: { color: '#fff' }, Gone: { color: '#000' } } }
+		const stale: PG.Grouping = {
+			rules: [rule('f-hq', 'HQ')],
+			groups: { HQ: { color: { type: 'custom', color: '#fff' } }, Gone: { color: { type: 'custom', color: '#000' } } },
+		}
 		expect(PG.getGroupNames(stale)).toEqual(['HQ'])
 	})
 })
 
+describe('getGroupFlags', () => {
+	// the colour picker offers these, so a group must never be offered another group's flag
+	it('lists only the flags of rules naming that group, deduped and in order', () => {
+		expect(PG.getGroupFlags(GROUPING, 'HQ')).toEqual(['f-hq', 'f-mod'])
+		expect(PG.getGroupFlags(GROUPING, 'Regulars')).toEqual(['f-regular'])
+	})
+
+	it('skips rules with no flag picked yet', () => {
+		expect(PG.getGroupFlags({ rules: [rule('', 'HQ'), rule('f-hq', 'HQ')], groups: {} }, 'HQ')).toEqual(['f-hq'])
+	})
+})
+
 describe('getGroupColor', () => {
-	it('reads the configured color, falling back when the group has no entry', () => {
-		expect(PG.getGroupColor(GROUPING, 'HQ')).toBe('#ff0000')
-		expect(PG.getGroupColor({ rules: GROUPING.rules, groups: {} }, 'HQ')).toBe(PG.DEFAULT_GROUP_COLOR)
+	it('follows the flag reference rather than a stored copy', () => {
+		expect(PG.getGroupColor(GROUPING, 'HQ', ORG_FLAGS)).toBe('#ff0000')
+		// the whole point: recolouring the flag in battlemetrics moves the group with it, no settings edit
+		const recoloured = [flag('f-hq', '#abcdef'), ...ORG_FLAGS.slice(1)]
+		expect(PG.getGroupColor(GROUPING, 'HQ', recoloured)).toBe('#abcdef')
+	})
+
+	it('leaves a custom color pinned when its flags change', () => {
+		const recoloured = [flag('f-regular', '#abcdef')]
+		expect(PG.getGroupColor(GROUPING, 'Regulars', recoloured)).toBe('#00ff00')
+	})
+
+	it('falls back for a missing entry, an unknown flag, or a flag with no color', () => {
+		expect(PG.getGroupColor({ rules: GROUPING.rules, groups: {} }, 'HQ', ORG_FLAGS)).toBe(PG.DEFAULT_GROUP_COLOR)
+		expect(PG.getGroupColor(GROUPING, 'HQ', [])).toBe(PG.DEFAULT_GROUP_COLOR)
+		expect(PG.getGroupColor(GROUPING, 'HQ', [flag('f-hq', null)])).toBe(PG.DEFAULT_GROUP_COLOR)
+	})
+})
+
+describe('defaultGroupColor', () => {
+	it('references the first flag of the group that has a color', () => {
+		expect(PG.defaultGroupColor(GROUPING, 'HQ', ORG_FLAGS)).toEqual({ type: 'flag', flag: 'f-hq' })
+		// f-hq carries no color here, so the next flag of the group supplies it
+		expect(PG.defaultGroupColor(GROUPING, 'HQ', [flag('f-hq', null), flag('f-mod', '#0000ff')]))
+			.toEqual({ type: 'flag', flag: 'f-mod' })
+	})
+
+	// callers leave the entry out entirely, so the fallback covers it and a later flag pick can still seed it
+	it('is undefined when no flag of the group offers a color', () => {
+		expect(PG.defaultGroupColor(GROUPING, 'HQ', [])).toBeUndefined()
 	})
 })
 
@@ -86,5 +130,12 @@ describe('PlayerGroupingsSchema', () => {
 
 	it('rejects a rule with no group, which could never be told apart in the UI', () => {
 		expect(PG.PlayerGroupingsSchema.safeParse({ admin: { rules: [rule('f-hq', '')] } }).success).toBe(false)
+	})
+
+	it('takes both color variants and rejects an untagged one', () => {
+		const groups = { HQ: { color: { type: 'flag', flag: 'f-hq' } }, Other: { color: { type: 'custom', color: '#fff' } } }
+		expect(PG.PlayerGroupingsSchema.safeParse({ admin: { rules: [rule('f-hq', 'HQ')], groups } }).success).toBe(true)
+		// the old shape stored a bare string that meant either variant; it must not parse as one of them by accident
+		expect(PG.PlayerGroupingsSchema.safeParse({ admin: { rules: [], groups: { HQ: { color: '#fff' } } } }).success).toBe(false)
 	})
 })

--- a/src/models/player-groupings.models.ts
+++ b/src/models/player-groupings.models.ts
@@ -92,6 +92,20 @@ export function getGroupColor(grouping: Grouping, group: string, orgFlags: BM.Pl
 	return resolveGroupColor(grouping.groups[group]?.color, orgFlags)
 }
 
+// Moves the rule at `from` to sit before/after the rule currently at `to`, which is how a drag-to-reorder drop reads.
+// The target is resolved by identity before the move, so pulling the dragged rule out of the list can't shift the
+// insertion point out from under us. A no-op drop (onto itself) returns the same rules.
+export function moveRule(rules: GroupRule[], from: number, to: number, position: 'before' | 'after'): GroupRule[] {
+	const moved = rules[from]
+	const target = rules[to]
+	if (!moved || !target) return rules
+	const without = rules.filter((_, i) => i !== from)
+	let insertAt = without.indexOf(target)
+	if (insertAt < 0) return rules
+	if (position === 'after') insertAt += 1
+	return [...without.slice(0, insertAt), moved, ...without.slice(insertAt)]
+}
+
 // the color a group takes when nothing is configured for it: the first of its own flags that has one
 export function defaultGroupColor(grouping: Grouping, group: string, orgFlags: BM.PlayerFlag[] | undefined): GroupColor | undefined {
 	for (const flag of getGroupFlags(grouping, group)) {

--- a/src/models/player-groupings.models.ts
+++ b/src/models/player-groupings.models.ts
@@ -3,16 +3,39 @@ import type * as BM from '@/models/battlemetrics.models'
 import type * as SM from '@/models/squad.models'
 import { z } from 'zod'
 
-// A rule assigns players matching one source-specific attribute to a group. Battlemetrics flags are the only
-// source today; the discriminator is what lets another source be added without reshaping a grouping.
+// A rule assigns players matching one source-specific attribute to a group. Sources are independent: rules from
+// different ones sit in the same priority order and a grouping may mix them freely.
 export const GroupRuleSchema = z.discriminatedUnion('type', [
+	// a flag on the player's battlemetrics profile
 	z.object({
 		type: z.literal('battlemetrics'),
 		flag: z.string(),
 		group: z.string().trim().min(1),
 	}),
+	// membership of a group in the server's admin list (`Group=<adminGroup>:<perms>`). Not every admin-list group makes
+	// its members admins -- a reserve-slot group like Whitelist is exactly the sort of thing worth grouping on.
+	z.object({
+		type: z.literal('admin-list'),
+		adminGroup: z.string().trim().min(1),
+		group: z.string().trim().min(1),
+	}),
 ])
 export type GroupRule = z.infer<typeof GroupRuleSchema>
+export type GroupRuleSource = GroupRule['type']
+
+export const GROUP_RULE_SOURCES: GroupRuleSource[] = ['battlemetrics', 'admin-list']
+
+export const GROUP_RULE_SOURCE_LABELS: Record<GroupRuleSource, string> = {
+	'battlemetrics': 'BM flag',
+	'admin-list': 'Admin group',
+}
+
+// What a rule matches against. Sourced per player and per server: the admin list is the server's own, so the same
+// grouping can put a player in different groups on different servers, which is the point of it being server config.
+export type PlayerFacts = {
+	flags: BM.PlayerFlag[]
+	adminGroups: string[]
+}
 
 // A group's color either follows one of its own flags -- so a recolour in battlemetrics reaches the UI without anyone
 // editing settings -- or is pinned to a literal. The `flag` variant stores only the reference, never a copy of the color.
@@ -65,10 +88,12 @@ export function getGroupNames(grouping: Grouping): string[] {
 }
 
 // The flags a group's color may follow: those of the rules that put players in it. A group's look should come from
-// something that actually defines it, so flags belonging to other groups are not offered.
+// something that actually defines it, so flags belonging to other groups are not offered. A group defined only by
+// admin-list rules has none, and takes a custom color instead -- an admin list carries no colors to follow.
 export function getGroupFlags(grouping: Grouping, group: string): string[] {
 	const flags: string[] = []
 	for (const rule of grouping.rules) {
+		if (rule.type !== 'battlemetrics') continue
 		if (rule.group === group && rule.flag && !flags.includes(rule.flag)) flags.push(rule.flag)
 	}
 	return flags
@@ -114,25 +139,27 @@ export function defaultGroupColor(grouping: Grouping, group: string, orgFlags: B
 	return undefined
 }
 
-function matchesRule(rule: GroupRule, flags: BM.PlayerFlag[]): boolean {
+function matchesRule(rule: GroupRule, facts: PlayerFacts): boolean {
 	switch (rule.type) {
 		case 'battlemetrics':
-			return flags.some(f => f.id === rule.flag)
+			return facts.flags.some(f => f.id === rule.flag)
+		case 'admin-list':
+			return facts.adminGroups.includes(rule.adminGroup)
 		default:
-			return assertNever(rule.type)
+			return assertNever(rule)
 	}
 }
 
 // the group a player belongs to under `grouping`, or undefined when no rule matches
-export function resolveGroup(grouping: Grouping, flags: BM.PlayerFlag[]): string | undefined {
+export function resolveGroup(grouping: Grouping, facts: PlayerFacts): string | undefined {
 	for (const rule of grouping.rules) {
-		if (matchesRule(rule, flags)) return rule.group
+		if (matchesRule(rule, facts)) return rule.group
 	}
 	return undefined
 }
 
 export function resolvePlayerGroups(
-	players: [SM.PlayerId, BM.PlayerFlag[]][],
+	players: [SM.PlayerId, PlayerFacts][],
 	groupings: PlayerGroupings,
 	groupingId: string | null | undefined,
 ): Map<SM.PlayerId, string> {
@@ -141,8 +168,8 @@ export function resolvePlayerGroups(
 	const grouping = groupings[groupingId]
 	if (!grouping) return groups
 
-	for (const [playerId, flags] of players) {
-		const group = resolveGroup(grouping, flags)
+	for (const [playerId, facts] of players) {
+		const group = resolveGroup(grouping, facts)
 		if (group !== undefined) groups.set(playerId, group)
 	}
 	return groups

--- a/src/models/player-groupings.models.ts
+++ b/src/models/player-groupings.models.ts
@@ -14,9 +14,17 @@ export const GroupRuleSchema = z.discriminatedUnion('type', [
 ])
 export type GroupRule = z.infer<typeof GroupRuleSchema>
 
+// A group's color either follows one of its own flags -- so a recolour in battlemetrics reaches the UI without anyone
+// editing settings -- or is pinned to a literal. The `flag` variant stores only the reference, never a copy of the color.
+export const GroupColorSchema = z.discriminatedUnion('type', [
+	z.object({ type: z.literal('flag'), flag: z.string() }),
+	z.object({ type: z.literal('custom'), color: z.string() }),
+])
+export type GroupColor = z.infer<typeof GroupColorSchema>
+
 // Presentation for a group. Group membership comes from the rules, so nothing here can affect who lands where.
 export const GroupSchema = z.object({
-	color: z.string(),
+	color: GroupColorSchema,
 })
 export type Group = z.infer<typeof GroupSchema>
 
@@ -56,8 +64,40 @@ export function getGroupNames(grouping: Grouping): string[] {
 	return names
 }
 
-export function getGroupColor(grouping: Grouping, group: string): string {
-	return grouping.groups[group]?.color ?? DEFAULT_GROUP_COLOR
+// The flags a group's color may follow: those of the rules that put players in it. A group's look should come from
+// something that actually defines it, so flags belonging to other groups are not offered.
+export function getGroupFlags(grouping: Grouping, group: string): string[] {
+	const flags: string[] = []
+	for (const rule of grouping.rules) {
+		if (rule.group === group && rule.flag && !flags.includes(rule.flag)) flags.push(rule.flag)
+	}
+	return flags
+}
+
+// The one place the flag-color reference is followed. Falls back when the flag is gone from the org or carries no
+// color of its own, so a stale reference degrades to the default rather than breaking the render.
+export function resolveGroupColor(color: GroupColor | undefined, orgFlags: BM.PlayerFlag[] | undefined): string {
+	if (!color) return DEFAULT_GROUP_COLOR
+	switch (color.type) {
+		case 'flag':
+			return orgFlags?.find(f => f.id === color.flag)?.color ?? DEFAULT_GROUP_COLOR
+		case 'custom':
+			return color.color
+		default:
+			return assertNever(color)
+	}
+}
+
+export function getGroupColor(grouping: Grouping, group: string, orgFlags: BM.PlayerFlag[] | undefined): string {
+	return resolveGroupColor(grouping.groups[group]?.color, orgFlags)
+}
+
+// the color a group takes when nothing is configured for it: the first of its own flags that has one
+export function defaultGroupColor(grouping: Grouping, group: string, orgFlags: BM.PlayerFlag[] | undefined): GroupColor | undefined {
+	for (const flag of getGroupFlags(grouping, group)) {
+		if (orgFlags?.find(f => f.id === flag)?.color) return { type: 'flag', flag }
+	}
+	return undefined
 }
 
 function matchesRule(rule: GroupRule, flags: BM.PlayerFlag[]): boolean {

--- a/src/models/player-groupings.models.ts
+++ b/src/models/player-groupings.models.ts
@@ -1,0 +1,95 @@
+import { assertNever } from '@/lib/type-guards'
+import type * as BM from '@/models/battlemetrics.models'
+import type * as SM from '@/models/squad.models'
+import { z } from 'zod'
+
+// A rule assigns players matching one source-specific attribute to a group. Battlemetrics flags are the only
+// source today; the discriminator is what lets another source be added without reshaping a grouping.
+export const GroupRuleSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal('battlemetrics'),
+		flag: z.string(),
+		group: z.string().trim().min(1),
+	}),
+])
+export type GroupRule = z.infer<typeof GroupRuleSchema>
+
+// Presentation for a group. Group membership comes from the rules, so nothing here can affect who lands where.
+export const GroupSchema = z.object({
+	color: z.string(),
+})
+export type Group = z.infer<typeof GroupSchema>
+
+// One named way of bucketing players: an ordered rule list plus presentation for the groups those rules name.
+// Rule order is priority order, highest first -- a player takes the group of the first rule they match.
+export const GroupingSchema = z.object({
+	rules: z.array(GroupRuleSchema).prefault([]),
+	groups: z.record(z.string(), GroupSchema).prefault({}),
+})
+export type Grouping = z.infer<typeof GroupingSchema>
+
+export const GroupingIdSchema = z.string().trim().min(1)
+
+export const PlayerGroupingsSchema = z.record(GroupingIdSchema, GroupingSchema)
+export type PlayerGroupings = z.infer<typeof PlayerGroupingsSchema>
+
+export const EMPTY_PLAYER_GROUPINGS: PlayerGroupings = {}
+
+export const EMPTY_GROUPING: Grouping = { rules: [], groups: {} }
+
+// shown for players no rule matched
+export const UNGROUPED_LABEL = 'Other'
+
+export const DEFAULT_GROUP_COLOR = '#888888'
+
+export function getGroupingIds(groupings: PlayerGroupings): string[] {
+	return Object.keys(groupings)
+}
+
+// The groups a grouping can assign, in priority order. Derived from the rules rather than the `groups` map so the
+// two can never disagree about which groups exist; `groups` only decides how they look.
+export function getGroupNames(grouping: Grouping): string[] {
+	const names: string[] = []
+	for (const rule of grouping.rules) {
+		if (!names.includes(rule.group)) names.push(rule.group)
+	}
+	return names
+}
+
+export function getGroupColor(grouping: Grouping, group: string): string {
+	return grouping.groups[group]?.color ?? DEFAULT_GROUP_COLOR
+}
+
+function matchesRule(rule: GroupRule, flags: BM.PlayerFlag[]): boolean {
+	switch (rule.type) {
+		case 'battlemetrics':
+			return flags.some(f => f.id === rule.flag)
+		default:
+			return assertNever(rule.type)
+	}
+}
+
+// the group a player belongs to under `grouping`, or undefined when no rule matches
+export function resolveGroup(grouping: Grouping, flags: BM.PlayerFlag[]): string | undefined {
+	for (const rule of grouping.rules) {
+		if (matchesRule(rule, flags)) return rule.group
+	}
+	return undefined
+}
+
+export function resolvePlayerGroups(
+	players: [SM.PlayerId, BM.PlayerFlag[]][],
+	groupings: PlayerGroupings,
+	groupingId: string | null | undefined,
+): Map<SM.PlayerId, string> {
+	const groups: Map<SM.PlayerId, string> = new Map()
+	if (!groupingId) return groups
+	const grouping = groupings[groupingId]
+	if (!grouping) return groups
+
+	for (const [playerId, flags] of players) {
+		const group = resolveGroup(grouping, flags)
+		if (group !== undefined) groups.set(playerId, group)
+	}
+	return groups
+}

--- a/src/models/settings.models.ts
+++ b/src/models/settings.models.ts
@@ -3,7 +3,6 @@ import * as Obj from '@/lib/object'
 import { BasicStrNoWhitespace, HumanTime, ParsableBigIntSchema } from '@/lib/zod'
 import * as AAR from '@/models/admin-action-reasons.models.ts'
 import * as BAL from '@/models/balance-triggers.models.ts'
-import * as BM from '@/models/battlemetrics.models.ts'
 import * as CHAT from '@/models/chat.models.ts'
 import * as CMD from '@/models/command.models.ts'
 import * as CB from '@/models/constraint-builders'
@@ -11,6 +10,7 @@ import * as F from '@/models/filter.models'
 import * as LP from '@/models/labeled-presets.models'
 import * as LC from '@/models/layer-columns'
 import * as LQY from '@/models/layer-queries.models'
+import * as PG from '@/models/player-groupings.models'
 import * as SM from '@/models/squad.models'
 import * as RBAC from '@/rbac.models'
 import { z } from 'zod'
@@ -196,8 +196,8 @@ export const GlobalSettingsSchema = z.object({
 	playerFlagsRequiringNote: z.array(z.uuid()).prefault([]).describe(
 		"Flags (by id) that require a reason to be given when added, which is included in the note posted to the player's BattleMetrics profile",
 	),
-	playerFlagGroupings: BM.PlayerFlagGroupingsSchema.prefault(BM.EMPTY_PLAYER_FLAG_GROUPINGS).describe(
-		'Groups players into labelled/colored buckets by their flags, per display mode. Modes are declared upfront and selected in the players panel.',
+	playerGroupings: PG.PlayerGroupingsSchema.prefault(PG.EMPTY_PLAYER_GROUPINGS).describe(
+		'Named ways of sorting players into coloured groups. Each grouping is an ordered list of rules assigning a group to players with a given flag, highest priority first; the players panel and activity charts pick which grouping to show.',
 	),
 	navLinks: NavLinkSchema.optional().describe('Global links to display in the navbar dropdown menu'),
 	warnOnSlmStart: z.boolean().prefault(false).describe('Warn all in-game admins when SLM starts or restarts.'),

--- a/src/models/squad.models.ts
+++ b/src/models/squad.models.ts
@@ -396,6 +396,10 @@ export const PlayerSchema = z.object({
 	squadId: z.number().nullable(),
 	isLeader: z.boolean(),
 	isAdmin: z.boolean(),
+	// the admin list groups this player is in. `isAdmin` only reflects the groups holding an admin-identifying
+	// permission, so this is a superset of it: a reserve-slot group like Whitelist appears here and not there.
+	// Prefaulted because events persisted before this field existed carry players without it.
+	adminGroups: z.array(z.string()).prefault([]),
 	role: z.string(),
 })
 
@@ -403,15 +407,16 @@ export type Player = z.infer<typeof PlayerSchema>
 export const PlayerIdSchema = z.string()
 export type PlayerId = EosId
 
-// The part of a player that stays meaningful once they disconnect: who they are, and whether they're an admin.
+// The part of a player that stays meaningful once they disconnect: who they are, and what the admin list says about
+// them (both of which are properties of the person, not of the session).
 // Everything tied to participation in a match rather than to the live roster (combat stats, resolving the author of
 // an event that has since scrolled past their disconnect) hangs off a list of these instead of `Player`, so it
 // survives a player dropping and rejoining mid-match. `Player` is assignable to it.
-export const RecentPlayerSchema = PlayerSchema.pick({ ids: true, isAdmin: true })
+export const RecentPlayerSchema = PlayerSchema.pick({ ids: true, isAdmin: true, adminGroups: true })
 export type RecentPlayer = z.infer<typeof RecentPlayerSchema>
 
 export function toRecentPlayer(player: RecentPlayer): RecentPlayer {
-	return { ids: { ...player.ids }, isAdmin: player.isAdmin }
+	return { ids: { ...player.ids }, isAdmin: player.isAdmin, adminGroups: [...player.adminGroups] }
 }
 
 // A roster is "settled" when every player has been assigned to a team -- i.e. no one is still loading / unassigned.

--- a/src/models/teams-panel.models.ts
+++ b/src/models/teams-panel.models.ts
@@ -4,12 +4,13 @@ import * as RSel from '@/lib/reselect'
 import * as BM from '@/models/battlemetrics.models'
 import type * as CHAT from '@/models/chat.models'
 import type * as MH from '@/models/match-history.models'
+import * as PG from '@/models/player-groupings.models'
 import * as SM from '@/models/squad.models'
 import type { PublicSettings } from '@/systems/settings.server'
 
 export type EnrichedPlayer = SM.Player & {
 	bmProfile: Omit<BM.PlayerFlagsAndProfile, 'playerIds'> | undefined
-	grouping?: string
+	group?: string
 	stats: CHAT.PlayerStats | undefined
 }
 
@@ -22,7 +23,7 @@ export namespace Sel {
 		settings: PublicSettings | undefined,
 	]
 	// Enriched players across both teams. Shared by call sites that need the whole roster (e.g. the
-	// grouping/selection actions) so the enrichment logic lives in one place.
+	// group/selection actions) so the enrichment logic lives in one place.
 	export const allEnrichedPlayers = RSel.createDeepSelector(
 		[
 			(...args: Inputs) => playersForTeam('A')(...args),
@@ -37,16 +38,16 @@ export namespace Sel {
 				(...[store, currentMatch]: Inputs) => ChatPrt.Sel.playersForTeam(teamId)(store, currentMatch),
 				(...[store]: Inputs) => ChatPrt.Sel.chatState(store).playerStats,
 				(...[, , bmData]: Inputs) => bmData,
-				(...[, , , bmStore]: Inputs) => bmStore.selectedModeId,
+				(...[, , , bmStore]: Inputs) => bmStore.selectedGroupingId,
 				(...[, , , bmStore]: Inputs) => bmStore.orgFlags,
-				(...[, , , , settings]: Inputs) => settings?.playerFlagGroupings,
+				(...[, , , , settings]: Inputs) => settings?.playerGroupings,
 			],
-			(players, playerStats, bmData, selectedModeId, orgFlags, groupings) => {
-				const playerFlagGroupings = groupings ?? BM.EMPTY_PLAYER_FLAG_GROUPINGS
-				const modeIds = BM.getGroupingModeIds(playerFlagGroupings)
-				const activeModeId = selectedModeId !== null && modeIds.includes(selectedModeId)
-					? selectedModeId
-					: modeIds[0] ?? null
+			(players, playerStats, bmData, selectedGroupingId, orgFlags, settingsGroupings) => {
+				const playerGroupings = settingsGroupings ?? PG.EMPTY_PLAYER_GROUPINGS
+				const groupingIds = PG.getGroupingIds(playerGroupings)
+				const activeGroupingId = selectedGroupingId !== null && groupingIds.includes(selectedGroupingId)
+					? selectedGroupingId
+					: groupingIds[0] ?? null
 
 				const playerFlagPairs: [SM.PlayerId, BM.PlayerFlag[]][] = players
 					.filter(p => p.ids.eos != null)
@@ -56,9 +57,7 @@ export namespace Sel {
 						const flags = BM.resolveFlags(flagIds, orgFlags)
 						return [eosId, flags]
 					})
-				const allGroups = activeModeId !== null
-					? BM.resolvePlayerFlagGroups(playerFlagPairs, playerFlagGroupings, activeModeId)
-					: new Map<SM.PlayerId, string>()
+				const allGroups = PG.resolvePlayerGroups(playerFlagPairs, playerGroupings, activeGroupingId)
 
 				return players.map((p): EnrichedPlayer => {
 					const playerId = SM.PlayerIds.getPlayerId(p.ids)
@@ -66,7 +65,7 @@ export namespace Sel {
 					return {
 						...p,
 						bmProfile: profile ? Obj.omit(profile, ['playerIds']) : undefined,
-						grouping: allGroups.get(playerId),
+						group: allGroups.get(playerId),
 						stats: playerStats[playerId],
 					}
 				})

--- a/src/models/teams-panel.models.ts
+++ b/src/models/teams-panel.models.ts
@@ -51,15 +51,14 @@ export namespace Sel {
 					? selectedGroupingId
 					: groupingIds[0] ?? null
 
-				const playerFlagPairs: [SM.PlayerId, BM.PlayerFlag[]][] = players
+				const playerFacts: [SM.PlayerId, PG.PlayerFacts][] = players
 					.filter(p => p.ids.eos != null)
 					.map(p => {
 						const eosId = p.ids.eos!
 						const flagIds = bmData[eosId]?.flagIds ?? []
-						const flags = BM.resolveFlags(flagIds, orgFlags)
-						return [eosId, flags]
+						return [eosId, { flags: BM.resolveFlags(flagIds, orgFlags), adminGroups: p.adminGroups }]
 					})
-				const allGroups = PG.resolvePlayerGroups(playerFlagPairs, playerGroupings, activeGroupingId)
+				const allGroups = PG.resolvePlayerGroups(playerFacts, playerGroupings, activeGroupingId)
 
 				return players.map((p): EnrichedPlayer => {
 					const playerId = SM.PlayerIds.getPlayerId(p.ids)

--- a/src/systems/battlemetrics.client.ts
+++ b/src/systems/battlemetrics.client.ts
@@ -67,6 +67,7 @@ export function usePlayerProfile(playerId: string) {
 // the color of the group this player falls into under the active grouping, or null when nothing matches
 export function usePlayerGroupColor(playerId: string): string | null {
 	const flags = usePlayerFlags(playerId)
+	const orgFlags = useOrgFlags()
 	const config = ZusUtils.useStore(SettingsClient.PublicSettingsStore)
 	const playerGroupings = config?.playerGroupings
 	const groupingIds = playerGroupings ? PG.getGroupingIds(playerGroupings) : []
@@ -76,7 +77,7 @@ export function usePlayerGroupColor(playerId: string): string | null {
 	const grouping = playerGroupings[activeGroupingId]
 	if (!grouping) return null
 	const group = PG.resolveGroup(grouping, flags)
-	return group === undefined ? null : PG.getGroupColor(grouping, group)
+	return group === undefined ? null : PG.getGroupColor(grouping, group, orgFlags)
 }
 
 export function setup() {

--- a/src/systems/battlemetrics.client.ts
+++ b/src/systems/battlemetrics.client.ts
@@ -1,5 +1,6 @@
 import * as ZusUtils from '@/lib/zustand'
 import * as BM from '@/models/battlemetrics.models'
+import * as PG from '@/models/player-groupings.models'
 import * as RPC from '@/orpc.client'
 import * as SettingsClient from '@/systems/settings.client'
 import * as ReactRx from '@react-rxjs/core'
@@ -8,22 +9,22 @@ import * as Rx from 'rxjs'
 import * as Zus from 'zustand'
 
 export const Store = Zus.createStore<BM.StoreState>(() => ({
-	selectedModeId: null,
+	selectedGroupingId: null,
 	slsOnly: false,
 	orgFlags: [],
 }))
 
 export namespace Sel {
-	// resolves the active grouping mode: the selected one if still configured, else the first configured
-	export const activeGroupingModeId = (groupingModeIds: string[]) => (state: BM.StoreState) =>
-		state.selectedModeId !== null && groupingModeIds.includes(state.selectedModeId)
-			? state.selectedModeId
-			: groupingModeIds[0] ?? null
+	// resolves the active grouping: the selected one if still configured, else the first configured
+	export const activeGroupingId = (groupingIds: string[]) => (state: BM.StoreState) =>
+		state.selectedGroupingId !== null && groupingIds.includes(state.selectedGroupingId)
+			? state.selectedGroupingId
+			: groupingIds[0] ?? null
 }
 
 export namespace Actions {
-	export function setSelectedModeId(id: string | null) {
-		Store.setState({ selectedModeId: id })
+	export function setSelectedGroupingId(id: string | null) {
+		Store.setState({ selectedGroupingId: id })
 	}
 	export function setSlsOnly(v: boolean) {
 		Store.setState({ slsOnly: v })
@@ -63,43 +64,19 @@ export function usePlayerProfile(playerId: string) {
 	return profile
 }
 
-export function useGroupedPlayerFlagColor(playerId: string): string | null {
+// the color of the group this player falls into under the active grouping, or null when nothing matches
+export function usePlayerGroupColor(playerId: string): string | null {
 	const flags = usePlayerFlags(playerId)
-	const orgFlags = useOrgFlags()
 	const config = ZusUtils.useStore(SettingsClient.PublicSettingsStore)
-	const selectedModeId = ZusUtils.useStore(Store, s => s.selectedModeId)
+	const playerGroupings = config?.playerGroupings
+	const groupingIds = playerGroupings ? PG.getGroupingIds(playerGroupings) : []
+	const activeGroupingId = ZusUtils.useStore(Store, Sel.activeGroupingId(groupingIds))
 
-	if (!flags || flags.length === 0) return null
-
-	const playerFlagGroupings = config?.playerFlagGroupings
-	if (!playerFlagGroupings || !orgFlags) return null
-
-	const modeIds = BM.getGroupingModeIds(playerFlagGroupings)
-	const activeModeId = selectedModeId !== null && modeIds.includes(selectedModeId)
-		? selectedModeId
-		: modeIds[0] ?? null
-	if (activeModeId === null) return null
-
-	const modeGroupings = playerFlagGroupings.groupings.filter(g => g.modeIds.includes(activeModeId))
-
-	const flagColorById = new Map<string, string>()
-	for (const flag of orgFlags) {
-		if (flag.color) flagColorById.set(flag.id, flag.color)
-	}
-
-	const associations: [string, string, number][] = []
-	for (const group of modeGroupings) {
-		for (const [flagId, priority] of Object.entries(group.associations)) {
-			associations.push([group.color, flagId, priority])
-		}
-	}
-	associations.sort((a, b) => a[2] - b[2])
-	for (const [groupColor, flagId] of associations) {
-		if (flags.some(f => f.id === flagId)) {
-			return flagColorById.get(groupColor) ?? groupColor
-		}
-	}
-	return null
+	if (!flags || flags.length === 0 || !playerGroupings || activeGroupingId === null) return null
+	const grouping = playerGroupings[activeGroupingId]
+	if (!grouping) return null
+	const group = PG.resolveGroup(grouping, flags)
+	return group === undefined ? null : PG.getGroupColor(grouping, group)
 }
 
 export function setup() {

--- a/src/systems/battlemetrics.client.ts
+++ b/src/systems/battlemetrics.client.ts
@@ -64,8 +64,9 @@ export function usePlayerProfile(playerId: string) {
 	return profile
 }
 
-// the color of the group this player falls into under the active grouping, or null when nothing matches
-export function usePlayerGroupColor(playerId: string): string | null {
+// the color of the group this player falls into under the active grouping, or null when nothing matches. `adminGroups`
+// comes from the player rather than being looked up here: the admin list is per-server and this hook has no server.
+export function usePlayerGroupColor(playerId: string, adminGroups: string[]): string | null {
 	const flags = usePlayerFlags(playerId)
 	const orgFlags = useOrgFlags()
 	const config = ZusUtils.useStore(SettingsClient.PublicSettingsStore)
@@ -73,10 +74,10 @@ export function usePlayerGroupColor(playerId: string): string | null {
 	const groupingIds = playerGroupings ? PG.getGroupingIds(playerGroupings) : []
 	const activeGroupingId = ZusUtils.useStore(Store, Sel.activeGroupingId(groupingIds))
 
-	if (!flags || flags.length === 0 || !playerGroupings || activeGroupingId === null) return null
+	if (!playerGroupings || activeGroupingId === null) return null
 	const grouping = playerGroupings[activeGroupingId]
 	if (!grouping) return null
-	const group = PG.resolveGroup(grouping, flags)
+	const group = PG.resolveGroup(grouping, { flags: flags ?? [], adminGroups })
 	return group === undefined ? null : PG.getGroupColor(grouping, group, orgFlags)
 }
 

--- a/src/systems/settings.server.ts
+++ b/src/systems/settings.server.ts
@@ -473,7 +473,7 @@ export type PublicSettings = {
 	commandAliases: SETTINGS.GlobalSettings['commandAliases']
 	vote: { voteDuration: number; voteDisplayProps: SETTINGS.GlobalSettings['vote']['voteDisplayProps'] }
 	servers: ServerEntry[]
-	playerFlagGroupings: SETTINGS.GlobalSettings['playerFlagGroupings']
+	playerGroupings: SETTINGS.GlobalSettings['playerGroupings']
 	squadServer: { tickRateThresholds: SETTINGS.GlobalSettings['squadServer']['tickRateThresholds'] }
 	adminActionReasons: SETTINGS.GlobalSettings['adminActionReasons']
 	requireReasonFor: SETTINGS.GlobalSettings['requireReasonFor']
@@ -493,7 +493,7 @@ function buildPublicSettings(): PublicSettings {
 			voteDisplayProps: GLOBAL_SETTINGS.vote.voteDisplayProps,
 		},
 		servers: listServerEntries(),
-		playerFlagGroupings: GLOBAL_SETTINGS.playerFlagGroupings,
+		playerGroupings: GLOBAL_SETTINGS.playerGroupings,
 		squadServer: { tickRateThresholds: GLOBAL_SETTINGS.squadServer.tickRateThresholds },
 		adminActionReasons: GLOBAL_SETTINGS.adminActionReasons,
 		requireReasonFor: GLOBAL_SETTINGS.requireReasonFor,

--- a/src/systems/squad-rcon.server.ts
+++ b/src/systems/squad-rcon.server.ts
@@ -167,9 +167,11 @@ async function fetchPlayers(ctx: C.Rcon & C.AdminList & CS.AbortSignal) {
 		data.ids = ids
 
 		data.isAdmin = false
+		data.adminGroups = []
 		if (data.ids.steam) {
 			const adminList = await ctx.adminList.get(ctx, { ttl: Infinity })
 			data.isAdmin = adminList.admins.has(data.ids.steam)
+			data.adminGroups = [...(adminList.players.get(data.ids.steam) ?? [])]
 		} else {
 			log.info('parsed player info data without steam id: %o', data)
 		}

--- a/src/systems/squad-server.server.ts
+++ b/src/systems/squad-server.server.ts
@@ -142,6 +142,24 @@ export type MatchHistoryState = {
 } & Parts<USR.UserPart>
 
 export const orpcRouter = {
+	// The admin-list group names known to any running server, for the player-groupings editor to offer. Player groupings are
+	// global config while an admin list is per-server, so this is the union across servers rather than one server's list: a
+	// grouping naming a group only some servers define simply matches nobody on the others.
+	listAdminListGroups: orpcBase.handler(async () => {
+		const baseCtx = getBaseCtx()
+		const names = new Set<string>()
+		for (const slice of globalState.slices.values()) {
+			try {
+				const adminList = await slice.adminList.get({ ...baseCtx, ...slice }, { ttl: Infinity })
+				for (const group of adminList.groups.keys()) names.add(group)
+			} catch (err) {
+				// one unreachable admin list must not deny the editor every other server's groups
+				log.warn(err, 'Failed to read an admin list while listing groups')
+			}
+		}
+		return [...names].sort()
+	}),
+
 	// which servers currently have a live slice. This is runtime state, not registry config: a server can be enabled and
 	// non-broken yet have no slice (still booting, or torn down by a fatal resource error), and everything served per-server
 	// needs one. The client gates the dashboard on this so it renders "unavailable" instead of hanging on silent streams.


### PR DESCRIPTION
## What

Restructures `playerFlagGroupings` into `playerGroupings`, keyed by grouping id:

```ts
playerGroupings: Record<GroupingId, {
  rules:  { type: 'battlemetrics', flag, group }[]   // priority order, first match wins
  groups: Record<GroupName, { color: { type: 'flag', flag } | { type: 'custom', color } }>
}>
```

## Nouns

The old model had a "display mode" list plus per-grouping `modeIds` pointing back at it, which modelled one idea twice. A mode *was* a grouping: migrating real config produced exactly `Admin` and `Watchlist`. So **mode** is gone, each record entry **is** a grouping, and what a player gets assigned is a **group**.

- `EnrichedPlayer.grouping` -> `.group`; column header "Grouping" -> "Group"; `selectGrouping` -> `selectGroup`
- the panel's "Group by" select is now labelled "Grouping" and lists grouping ids

## Priority and sources

Priority is array position rather than the numeric `associations` map. Rules carry a `type` discriminator so a future source other than battlemetrics flags can slot in. The set of groups is derived from the rules, so `groups` can never disagree about which groups exist -- it only supplies color.

## Color

A group's color **follows its flag's color in battlemetrics**: `{type:'flag', flag}` stores a reference and resolves live, so a recolour there reaches the UI with no settings edit. `{type:'custom', color}` pins a literal instead.

This is the same indirection the old `color: string` had, without the ambiguity that made it a problem -- that field meant "flag id OR css color", told apart by sniffing for a UUID at four separate call sites. The variants are explicit now and `resolveGroupColor` is the only place a reference is followed.

A group may only draw its color from a flag of **its own** rules (`getGroupFlags`): a flag that doesn't define the group says nothing about how it should look. A reference to a flag the group has since lost is dropped rather than left dangling.

The editor defaults each new group to a reference to its first coloured flag, so picking flags is usually all an operator does.

**Caveat (pre-existing):** `getOrgFlags` caches org flags for the lifetime of the server process (`battlemetrics.server.ts:409`), so a battlemetrics recolour propagates on SLM restart, not instantly. Out of scope here, but worth knowing.

## Editor

One card per grouping: an ordered rule list (flag -> group name, up/down for priority) and a secondary collapsed **Colors** section, each group showing a live swatch, a flag picker limited to that group's flags, and a custom-color field.

## Breaking

Needs migration **0081**. It is lossless: old flag-id colors become the `flag` variant and literal colors become `custom`, so nothing needs re-picking by hand.

## Verification

- migration run against a clone of the production db: `Admin` + `Watchlist` converted; Admin's three groups kept live flag references, Watchlist kept `#ef4444`/`#22c55e`
- **tracking proven end to end**: recoloured the Seeder flag in the emulated BM org, restarted, and the group's swatch followed to magenta with settings untouched
- constraint proven: a group's color picker offers only its own flags, not a sibling group's
- built a grouping from scratch in the real app, saved, round-tripped to the db as references with no color copied
- caught and fixed a bug by driving the app: an incomplete rule wrote a placeholder color entry that then blocked the derivation it stood in for
- 449 tests (17 on this model, covering first-match priority, flag-tracking vs pinned custom, and the picker constraint); `pnpm run check` and `lint` clean

Scoped to the groupings restructure only. The warn/username bug and the two flag bullets in todo.md are deliberately not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)