### PR TITLE
Make the RCON cache TTLs settings, and drop them to 2s in tests

### DIFF
--- a/src/models/settings.models.ts
+++ b/src/models/settings.models.ts
@@ -242,6 +242,19 @@ export const GlobalSettingsSchema = z.object({
 	}).prefault({}),
 	squadServer: z.object({
 		logFilePollInterval: HumanTime.prefault('1s').describe('How often a local-file log source checks the log for new lines.'),
+		rconCacheTTL: z.object({
+			layersStatus: HumanTime.prefault('5s').describe(
+				'How stale the cached current/next layer may be before a read refetches it over RCON.',
+			),
+			serverInfo: HumanTime.prefault('10s').describe(
+				'How stale cached server info (player count, tick rate) may be before a read refetches it over RCON.',
+			),
+			teams: HumanTime.prefault('5s').describe(
+				'How stale the cached roster may be before a read refetches it over RCON. Also the interval at which observers poll ListPlayers.',
+			),
+		}).prefault({}).describe(
+			'How long RCON responses stay cached. Lower means fresher data and more RCON traffic; these are the dominant source of roster/status latency.',
+		),
 		tickRateThresholds: z.object({
 			good: z.number().positive().prefault(60).describe(
 				'At or above this tick rate the live server tick rate displays as good (green)',

--- a/src/systems/squad-rcon.server.ts
+++ b/src/systems/squad-rcon.server.ts
@@ -35,12 +35,13 @@ export function initSquadRcon(
 	opts?: { onFatalError?: (err: unknown) => void },
 ): SquadRcon {
 	const rcon = ctx.rcon
+	const cacheTTL = Settings.GLOBAL_SETTINGS.squadServer.rconCacheTTL
 	const layersStatus: SquadRcon['layersStatus'] = new AsyncResource<SM.LayerStatusRes, C.Rcon & CS.AbortSignal>(
 		`serverStatus`,
 		(ctx) => getLayerStatus(ctx),
 		module,
 		{
-			defaultTTL: 5000,
+			defaultTTL: cacheTTL.layersStatus,
 			retries: 4,
 			retryDelay: 1000,
 			isErrorResponse: (res: SM.LayerStatusRes) => res.code !== 'ok',
@@ -55,7 +56,7 @@ export function initSquadRcon(
 		(ctx) => getServerInfo(ctx),
 		module,
 		{
-			defaultTTL: 10_000,
+			defaultTTL: cacheTTL.serverInfo,
 			retries: 4,
 			retryDelay: 1000,
 			isErrorResponse: (res: SM.ServerInfoRes) => res.code !== 'ok',
@@ -70,7 +71,7 @@ export function initSquadRcon(
 		(ctx) => fetchTeams(ctx),
 		module,
 		{
-			defaultTTL: 5000,
+			defaultTTL: cacheTTL.teams,
 			retries: 4,
 			retryDelay: 1000,
 			isErrorResponse: (res: SM.TeamsRes) => res.code !== 'ok',

--- a/test/harness/app-fixture.ts
+++ b/test/harness/app-fixture.ts
@@ -248,6 +248,18 @@ function applyTestTimings(settings: SETTINGS.GlobalSettings) {
 	// the log tail's poll interval is also the window the event pipeline waits for the log to catch
 	// up with rcon/poll events, so a short one keeps tests responsive
 	settings.squadServer.logFilePollInterval = 250
+	// The roster TTL doubles as the ListPlayers poll interval, so it sets the floor on waitForRosterSync
+	// (which wants two polls) and dominates this suite's wall time. 2s roughly halves the suite against
+	// the shipped 5s.
+	//
+	// Do not lower these further without re-measuring: at 1s the suite got faster still but started
+	// failing about one run in three, and at 500ms it got both slower *and* flakier -- RCON is
+	// serialized, so polling faster than it drains queues commands until responses breach the 2s
+	// timeout in core-rcon and back off. The failures only appear under full-suite load, never in a
+	// single file, and they land on whichever test is unluckiest rather than a consistent one.
+	settings.squadServer.rconCacheTTL.layersStatus = 2_000
+	settings.squadServer.rconCacheTTL.serverInfo = 4_000
+	settings.squadServer.rconCacheTTL.teams = 2_000
 }
 
 export async function createAppFixture(opts: AppFixtureOptions = {}): Promise<AppFixture> {


### PR DESCRIPTION
## What

The three `AsyncResource` TTLs in `squad-rcon.server.ts` were hardcoded. They're now `globalSettings.squadServer.rconCacheTTL`, and the integration harness turns them down like it already does for every other duration that would make a test sit and wait.

The roster (`teams`) TTL is the one that matters: it doubles as the ListPlayers poll interval, so it sets the floor on `waitForRosterSync`, which wants two polls. At the shipped 5s that's a ~10s floor, paid many times across the suite.

## Result

Integration suite: **~121s -> ~74s** (39% faster), 8/8 consecutive green at the new value. Baseline measured at 4/4 green, 120-123s, on the same machine.

## Not a behaviour change for servers

The schema prefaults are exactly the values that were hardcoded (5s / 10s / 5s), and the field is additive with a prefault, so existing persisted settings parse unchanged and no migration is needed. Only the test harness overrides them.

## Why 2s and not lower

Measured, and the answer was not monotonic:

| roster TTL | wall | stability |
|---|---|---|
| 5s (shipped) | ~121s | 4/4 green |
| **2s (this PR)** | **~74s** | **8/8 green** |
| 1s | ~61s | failed ~1 run in 3 |
| 500ms | ~73s | 3 failures, slower *and* flakier |

Below ~2s it stops paying: RCON is serialized, so polling faster than the channel drains queues commands until responses breach the 2s timeout in `core-rcon.ts` and hit `retryDelay`. Past that point more polling makes the roster slower.

## One thing worth a look

Chasing the 1s flake surfaced something that may be a real race rather than a test artifact. At 1s, `teamswaps.test.ts > !swapnext holds the swap until the map rolls` failed with a force-change issued **immediately** (`expected 0, received 1`) instead of being held until the roll. It passes 5/5 in isolation and only fails under full-suite load, so it looks like a genuine timing-sensitive path in the swapnext hold logic that faster polling exposes. Not triggered at the 2s value in this PR, and not investigated further here.

Related: `EXECUTION_VERIFY_DELAY_MS = 5_000` in `teamswaps.server.ts` is commented "a swap lands within a poll cycle", i.e. it is calibrated against the 5s poll cadence. Still correct at 2s (the delay is longer than the cycle), but it means the poll interval has non-local couplings and is worth grepping for before anyone tunes it again.

## Test plan

- [x] `pnpm run check`, `pnpm run lint`, `pnpm run format`
- [x] `pnpm run test` (435 unit tests pass)
- [x] `pnpm run test:integration` x8 green at the new value; x4 green at baseline for comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)