### PR TITLE
Always resolve SLM users' displayName for display

### DIFF
--- a/src/models/users.models.ts
+++ b/src/models/users.models.ts
@@ -30,7 +30,6 @@ export type User = SchemaModels.User & {
 	nickname: string | null
 }
 export type MiniUser = {
-	username: string
 	displayName: string
 	discordId: bigint
 }
@@ -38,7 +37,6 @@ export type MiniUser = {
 // reduce down a type that's assignable to MiniUser
 export function toMiniUser(user: MiniUser): MiniUser {
 	return {
-		username: user.username,
 		displayName: user.displayName,
 		discordId: user.discordId,
 	}
@@ -46,10 +44,10 @@ export function toMiniUser(user: MiniUser): MiniUser {
 
 export type UserPart = { users: User[] }
 
-// represents a user's edit or deletion of an entity
+// represents a user's edit or deletion of an entity. Carries the actor's id, not their name: consumers resolve
+// the display name so it reflects the user's current nickname rather than whatever it was at mutation time.
 export type UserEntityMutation<K extends string | number, V> = {
-	username: string
-	displayName: string
+	userId: UserId
 	key: K
 	value: V
 	type: 'add' | 'update' | 'delete'

--- a/src/routes/_app/filters/$filterId.tsx
+++ b/src/routes/_app/filters/$filterId.tsx
@@ -99,13 +99,13 @@ function RouteComponent() {
 						case 'add':
 							break
 						case 'update': {
-							if (mutation.username === loggedInUser?.username) return
-							toast(`Filter ${mutation.value.name} was updated by ${mutation.displayName}`)
+							if (mutation.userId === loggedInUser?.discordId) return
+							toast(`Filter ${mutation.value.name} was updated by ${await UsersClient.fetchDisplayName(mutation.userId)}`)
 							break
 						}
 						case 'delete': {
-							if (mutation.username === loggedInUser?.username) return
-							toast(`Filter ${mutation.value.name} was deleted by ${mutation.displayName}`)
+							if (mutation.userId === loggedInUser?.discordId) return
+							toast(`Filter ${mutation.value.name} was deleted by ${await UsersClient.fetchDisplayName(mutation.userId)}`)
 							void rootRouter.navigate({ to: '/filters' })
 							break
 						}

--- a/src/systems/app-events.server.ts
+++ b/src/systems/app-events.server.ts
@@ -1,5 +1,6 @@
 import * as Schema from '$root/drizzle/schema'
 import * as AppEvents from '@/models/app-events.models'
+import type * as USR from '@/models/users.models'
 import type * as C from '@/server/context'
 import * as DB from '@/server/db'
 import { initModule } from '@/server/logger'
@@ -22,8 +23,8 @@ export async function persistAppEvent(ctx: C.Db, appEvent: AppEvents.AppEvent) {
 
 // set once at boot (before this instance's APP_STARTED is persisted): the user who restarted SLM, if this boot
 // followed a restart-slm command, else null. A restart is detected when the most recent APP_RESTARTED is newer than
-// the previous instance's APP_STARTED. Read by the "SLM started/restarted" admin warn.
-export let restartInfo: { userId: bigint; name: string } | null = null
+// the previous instance's APP_STARTED. Read by the "SLM started/restarted" admin warn, which resolves the display name.
+export let restartInfo: { userId: USR.UserId } | null = null
 
 export async function detectRestartAtBoot(ctx: C.Db) {
 	// the instance that ran immediately before this one (our own APP_STARTED isn't persisted yet at this point)
@@ -41,9 +42,7 @@ export async function detectRestartAtBoot(ctx: C.Db) {
 		restartInfo = null
 		return
 	}
-	const [user] = await ctx.db().select({ username: Schema.users.username, nickname: Schema.users.nickname })
-		.from(Schema.users).where(E.eq(Schema.users.discordId, restart.actorUserId)).limit(1)
-	restartInfo = { userId: restart.actorUserId, name: user?.nickname ?? user?.username ?? 'someone' }
+	restartInfo = { userId: restart.actorUserId }
 }
 
 export const router = {

--- a/src/systems/filter-entity.server.ts
+++ b/src/systems/filter-entity.server.ts
@@ -213,8 +213,7 @@ export const filtersRouter = {
 				type: 'add',
 				key: newFilterEntity.id,
 				value: newFilterEntity,
-				username: ctx.user.username,
-				displayName: ctx.user.displayName,
+				userId: ctx.user.discordId,
 			}])
 			await recordFilterChange(ctx, 'created', newFilterEntity.id, { filterName: newFilterEntity.name })
 		}
@@ -254,8 +253,7 @@ export const filtersRouter = {
 					type: 'update',
 					key: id,
 					value: res.filter,
-					username: ctx.user.username,
-					displayName: ctx.user.displayName,
+					userId: ctx.user.discordId,
 				}])
 				// the update is a partial, and a field resubmitted unchanged isn't a change worth recording
 				const changedFields = Object.keys(update).filter(
@@ -308,8 +306,7 @@ export const filtersRouter = {
 		filterMutation$.next([C.storeLinkToActiveSpan(ctx, 'event.emitter'), {
 			type: 'delete',
 			key: idToDelete,
-			username: ctx.user.username,
-			displayName: ctx.user.displayName,
+			userId: ctx.user.discordId,
 			value: res.filter,
 		}])
 		await recordFilterChange(ctx, 'deleted', idToDelete, { filterName: res.filter.name })
@@ -340,7 +337,7 @@ export async function* watchFilters(
 	}
 	for await (const [ctx, mutation] of toAsyncGenerator(filterMutation$.pipe(withAbortSignal(signal!)))) {
 		const dbUsers = await ctx.db().select().from(Schema.users).where(
-			E.or(E.eq(Schema.users.discordId, mutation.value.owner), E.eq(Schema.users.username, mutation.username)),
+			E.inArray(Schema.users.discordId, [...new Set([mutation.value.owner, mutation.userId])]),
 		)
 		const users = await Users.buildUsers(dbUsers)
 

--- a/src/systems/squad-server.server.ts
+++ b/src/systems/squad-server.server.ts
@@ -53,6 +53,7 @@ import * as Settings from '@/systems/settings.server'
 import * as SquadRcon from '@/systems/squad-rcon.server'
 import * as TeamswapsSys from '@/systems/teamswaps.server'
 import * as Timeouts from '@/systems/timeouts.server'
+import * as Users from '@/systems/users.server'
 import * as Vote from '@/systems/vote.server'
 import * as WsSessionSys from '@/systems/ws-session.server'
 import * as Orpc from '@orpc/server'
@@ -1079,7 +1080,10 @@ async function setupSlice(ctx: C.Db & CS.AbortSignal, serverState: SS.ServerStat
 	})
 	log.info('Initialized server %s', serverId)
 	if (Settings.GLOBAL_SETTINGS.warnOnSlmStart) {
-		await SquadRcon.warnAllAdmins({ ...ctx, ...slice }, Messages.WARNS.slmStarted(AppEventsSys.restartInfo?.name))
+		const restartedBy = AppEventsSys.restartInfo
+			? await Users.resolveDisplayName(ctx, AppEventsSys.restartInfo.userId, 'someone')
+			: undefined
+		await SquadRcon.warnAllAdmins({ ...ctx, ...slice }, Messages.WARNS.slmStarted(restartedBy))
 	}
 }
 
@@ -1157,11 +1161,7 @@ export async function notifyAdminsOfWebAction(
 	description?: string,
 ) {
 	if (appEvent.actor.type !== 'slm-user') return
-	const [user] = await ctx.db()
-		.select({ nickname: Schema.users.nickname, username: Schema.users.username })
-		.from(Schema.users)
-		.where(E.eq(Schema.users.discordId, appEvent.actor.userId))
-	const name = user?.nickname || user?.username || 'An admin'
+	const name = await Users.resolveDisplayName(ctx, appEvent.actor.userId)
 	await SquadRcon.warnAllAdmins(ctx, `${name} ${description ?? AppEvents.describeAppEvent(appEvent)}`)
 }
 

--- a/src/systems/teamswaps.server.ts
+++ b/src/systems/teamswaps.server.ts
@@ -1,4 +1,3 @@
-import * as Schema from '$root/drizzle/schema.ts'
 import * as Arr from '@/lib/array'
 import { isAbortError, sleep, toAsyncGenerator, withAbortSignal } from '@/lib/async'
 import { withThrownAsync } from '@/lib/error'
@@ -29,10 +28,10 @@ import * as Rbac from '@/systems/rbac.server'
 import * as SquadRcon from '@/systems/squad-rcon.server'
 import * as SquadServer from '@/systems/squad-server.server'
 import * as UserPresenceSys from '@/systems/user-presence.server'
+import * as Users from '@/systems/users.server'
 
 import { Mutex } from 'async-mutex'
 import type { MutexInterface } from 'async-mutex'
-import * as E from 'drizzle-orm'
 import * as Rx from 'rxjs'
 import { z } from 'zod'
 
@@ -83,11 +82,7 @@ async function resolveSourceName(
 	players?: { ids: SM.PlayerIds.Schema }[],
 ): Promise<string> {
 	if (source.discordId) {
-		const [user] = await ctx.db()
-			.select({ name: Schema.users.nickname, username: Schema.users.username })
-			.from(Schema.users)
-			.where(E.eq(Schema.users.discordId, source.discordId))
-		return (user?.name || user?.username) ?? 'Admin'
+		return await Users.resolveDisplayName(ctx, source.discordId, 'Admin')
 	}
 	if (source.steamId && players) {
 		const player = players.find(p => p.ids.steam === source.steamId)

--- a/src/systems/users.client.ts
+++ b/src/systems/users.client.ts
@@ -99,6 +99,15 @@ export function simulatePerms(basePerms: RBAC.TracedPermission[], simulation: Si
 	)
 }
 
+// resolves a user id to the name to show, outside of a hook (e.g. from a toast in an rx subscription). Shares the
+// cache with useUser, so an already-loaded user costs nothing.
+export async function fetchDisplayName(id: USR.UserId, fallback = 'another user') {
+	const cached = PartSys.findUser(id)
+	if (cached) return cached.displayName
+	const res = await RPC.queryClient.getQueryCache().build(RPC.queryClient, getFetchUserOptions(id)).fetch()
+	return res?.code === 'ok' ? res.user.displayName : fallback
+}
+
 export async function fetchLoggedInUser() {
 	return RPC.queryClient.getQueryCache().build(RPC.queryClient, {
 		...loggedInUserBaseQuery,

--- a/src/systems/users.server.ts
+++ b/src/systems/users.server.ts
@@ -215,3 +215,11 @@ export async function buildUser(dbUser: Schema.User): Promise<USR.User> {
 export async function buildUsers(dbUsers: Schema.User[]): Promise<USR.User[]> {
 	return Promise.all(dbUsers.map(user => buildUser(user)))
 }
+
+// the single way to turn a user id into text for display. Goes through buildUser so callers get the same name the
+// GUI shows (nickname > guild display name > global name > username), rather than each site reimplementing a subset.
+export async function resolveDisplayName(ctx: C.Db, userId: USR.UserId, fallback = 'An admin'): Promise<string> {
+	const [dbUser] = await ctx.db().select().from(Schema.users).where(E.eq(Schema.users.discordId, userId)).limit(1)
+	if (!dbUser) return fallback
+	return (await buildUser(dbUser)).displayName
+}


### PR DESCRIPTION
## What

Several sites rendered an SLM user's name by reimplementing a subset of `buildUser`'s resolution (`nickname || username`), skipping the guild display name / global name the GUI shows. The same user could appear under two different names depending on where they turned up.

Adds `Users.resolveDisplayName(ctx, userId, fallback?)` as the single id -> display text entry point, and routes the ad-hoc sites through it:

- `app-events.server.ts` `restartInfo` (SLM started/restarted warn)
- `squad-server.server.ts` `notifyAdminsOfWebAction`
- `teamswaps.server.ts` `resolveSourceName`

`restartInfo` now carries a bare `userId` instead of a baked name. That resolves the name fresh at warn time, and keeps `app-events` below `users` in the import graph (`users.server` already imports `app-events.server`, so the reverse would have been a cycle).

## Baked-in usernames removed

- `MiniUser`: dropped `username` (nothing read it; only `displayName` / `discordId` were used).
- `UserEntityMutation`: now carries `userId` instead of `username` + `displayName`. Server-side the username was only used to look the user back up, which is now an id lookup. The filter toast keyed "is this me?" off username and rendered a name snapshotted at mutation time; it now compares ids and resolves via the new `UsersClient.fetchDisplayName`.

Both types are in-memory/streamed only, so **no persisted data or migration is affected**.

Legitimate remaining `username` uses are untouched: in-game player names (a different concept), the `?login=<username>` dev bypass, `buildUser`'s own fallback, and the nickname editor.

## Verification

- `pnpm run check` clean, `pnpm run lint` clean, `pnpm run test` 444/444 pass.
- App boots on a worktree dev instance with no import-cycle crash (the main runtime risk of the new `users.server` imports).
- Filter edits flow end-to-end and are attributed to the right actor (confirmed via `appEvents.actorUserId`).
- Self-mutation suppression through the new id comparison confirmed (no toast when viewer == mutator).

Not verified end-to-end: the cross-user filter toast (`fetchDisplayName`). Staging two simultaneous identities needs two sessions and the dev `?login=` bypass only applies when no valid session exists, so one browser profile can only hold one identity at a time. Note also that dev has Discord disabled, so `buildUser` falls back to `nickname || username` locally -- the actual improvement (guild display name / global name) is only observable with Discord enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)