### PR TITLE
Drop the last references to the removed SQL filter backend

### DIFF
--- a/src/components/filter-card.tsx
+++ b/src/components/filter-card.tsx
@@ -411,7 +411,6 @@ export function LeafFilterNode(props: NodeProps) {
 	)
 
 	if (F.isCompNode(node)) {
-		// team-generic columns (Alliance/Faction/Unit) are selectable only within a team scope
 		return (
 			<NodeWrapper path={nodePath} className="flex items-center space-x-1" nodeId={props.nodeId}>
 				<CompNodeConfig nodeId={props.nodeId} stores={props.stores} node={node} />

--- a/src/models/filter.models.ts
+++ b/src/models/filter.models.ts
@@ -7,7 +7,6 @@ import { createId } from '@/lib/id'
 import * as Obj from '@/lib/object'
 import * as Sparse from '@/lib/sparse-tree'
 import { assertNever } from '@/lib/type-guards'
-import type { SQL } from 'drizzle-orm'
 import { z } from 'zod'
 import * as LC from './layer-columns'
 
@@ -677,7 +676,6 @@ export type FilterEntity = z.infer<typeof FilterEntitySchema>
 // -------- validation errors --------
 
 export type InvalidFilterNodeResult = { code: 'err:invalid-node'; errors: NodeValidationError[] }
-export type SQLConditionsResult = { code: 'ok'; condition: SQL } | InvalidFilterNodeResult
 
 type ErrorBase = {
 	path: string[]
@@ -695,7 +693,8 @@ export type NodeValidationError =
 		type: 'recursive-filter' | 'unknown-filter'
 		filterId: string
 	}
-	// semantic problems: incompatible arg domains, team columns outside a team scope, nested scopes, ...
+	// semantic problems: incompatible arg domains, a comparison whose subject isn't a column, null on an
+	// ordered comparison, ...
 	| ErrorBase & { type: 'invalid-node' }
 
 export type NodeValidationErrorStore = {

--- a/src/models/layer-engine.ts
+++ b/src/models/layer-engine.ts
@@ -70,8 +70,7 @@ export type LowerResult = { code: 'ok'; ir: Ir } | F.InvalidFilterNodeResult
 export type LowerCtx = CS.Filters & CS.EffectiveColumnConfig & { colIndex: ColumnIndex }
 
 // Errors are collected against the node path rather than thrown, because the filter editor highlights the offending
-// node from them. This mirrors getFilterNodeSQLConditions: same error types, same paths, so the UI behaves the same
-// whichever backend produced them.
+// node from them.
 export function lowerFilterNode(ctx: LowerCtx, node: F.FilterNode, path: string[] = [], appliedFilters: string[] = []): LowerResult {
 	const errors: F.NodeValidationError[] = []
 	const ir = lowerNode(ctx, node, path, appliedFilters, errors)


### PR DESCRIPTION
Follow-up cleanup spotted while working on the matchup operators (#20). Comments and types only -- no behaviour change.

The SQL filter backend is gone; the wasm/IR path in `layer-engine.ts` is the only one. Three leftovers still pointed at it:

- **`SQLConditionsResult`** (`filter.models.ts`) had no users anywhere, and was the only reason the filter model imported drizzle's `SQL` type. Both removed.
- **`lowerFilterNode`'s comment** claimed it "mirrors `getFilterNodeSQLConditions`: same error types, same paths, so the UI behaves the same whichever backend produced them." That function no longer exists, and there is no second backend to stay in step with, so the comment was explaining a constraint that no longer applies.

Two more comments described **team scopes**, which were dropped from the model in favour of expanding over the concrete `_1`/`_2` columns (`0063_filter_team_scopes_to_and_or` exists only to rescue DBs that ran the revision that emitted them):

- `filter-card.tsx` said team-generic columns "are selectable only within a team scope" -- they aren't gated on anything now.
- `filter.models.ts` offered "team columns outside a team scope, nested scopes" as examples of `invalid-node`. Neither can occur. Replaced with errors the compiler actually raises.

The `describe('migration 0063 (team scopes -> ...)')` test name keeps the term, since that migration genuinely is about team scopes.

## Verification

`pnpm run format`, `pnpm exec tsc -b --force`, `pnpm run lint` all clean; 445 unit tests pass. The `SQL` import removal is the only load-bearing change and the typecheck covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)