### PR TITLE
Unify the rbac role editor into one permissions table

### DIFF
--- a/src/components/combo-box/combo-box-multi.tsx
+++ b/src/components/combo-box/combo-box-multi.tsx
@@ -14,6 +14,9 @@ import { normalizeOptions } from './options.ts'
 export type ComboBoxMultiProps<T extends string | null = string | null> = {
 	className?: string
 	title?: string
+	// trigger text when nothing is selected; defaults to `Select...`. Use it where an empty selection has a meaning of its
+	// own (e.g. "All servers") rather than meaning nothing is chosen.
+	placeholder?: string
 	inputValue?: string
 	setInputValue?: (value: string) => void
 	values: T[]
@@ -158,7 +161,7 @@ export default function ComboBoxMulti<T extends string | null>(props: ComboBoxMu
 
 			valuesDisplay = selectionLimit ? `${displayText} (${displayValues.length}/${selectionLimit})` : displayText
 		} else {
-			valuesDisplay = 'Select...'
+			valuesDisplay = props.placeholder ?? 'Select...'
 		}
 
 		const restrictSize = props.restrictValueSize ? 25 : 100

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -1,5 +1,5 @@
 import { BmFlagMultiSelect, BmFlagOrColorSelect, FlagPriorityMap } from '@/components/bm-flag-picker'
-import ComboBox, { type ComboBoxOption } from '@/components/combo-box/combo-box'
+import ComboBox, { type ComboBoxHandle, type ComboBoxOption } from '@/components/combo-box/combo-box'
 import ComboBoxMulti from '@/components/combo-box/combo-box-multi'
 import { DiscordMemberSelect, DiscordRoleSelect } from '@/components/discord-picker'
 import LayerGenerationConfigEditor from '@/components/layer-generation-config-editor'
@@ -2106,6 +2106,13 @@ function ScopeValueRows(
 	// the not-yet-chosen row that `Add` opens. It lives here rather than in `values` so an abandoned Add can't write an
 	// empty entry back to the settings draft.
 	const [adding, setAdding] = React.useState(false)
+	// Add is one intent, so it opens the dropdown it just swapped itself out for rather than asking for a second click.
+	// Driven off the transition, not a callback ref: the imperative handle is rebuilt whenever the popover's own `open`
+	// changes, which would re-fire a ref callback and reopen a box the user had just dismissed.
+	const pendingRef = React.useRef<ComboBoxHandle>(null)
+	React.useEffect(() => {
+		if (adding) pendingRef.current?.focus()
+	}, [adding])
 	const normalized: ComboBoxOption<string>[] = options.map((o) => (typeof o === 'string' ? { value: o } : o))
 	const selected = new Set(values)
 	const exhausted = normalized.every((o) => selected.has(o.value))
@@ -2147,6 +2154,7 @@ function ScopeValueRows(
 				? (
 					<div className="flex items-center gap-1">
 						<ComboBox
+							ref={pendingRef}
 							title={title}
 							className={boxClass}
 							placeholder={`Select ${title}...`}

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -2139,34 +2139,42 @@ function ScopeValueRows(
 					</Button>
 				</div>
 			))}
-			{adding && (
-				<div className="flex items-center gap-1">
-					<ComboBox
-						title={title}
-						className={boxClass}
-						placeholder={`Select ${title}...`}
-						value={undefined}
-						options={optionsFor()}
-						onSelect={(next) => {
-							if (next) onChange([...values, next])
-							setAdding(false)
-						}}
-					/>
-					<Button
-						type="button"
-						size="icon"
-						variant="ghost"
-						className="h-8 w-8 shrink-0 text-destructive"
-						onClick={() => setAdding(false)}
-					>
-						<Icons.X className="h-4 w-4" />
+			{
+				/* Add swaps itself out for the empty dropdown rather than sitting disabled above it, so the control you clicked is
+			    the control you then pick from. It comes back once the pick lands (or the X cancels). */
+			}
+			{adding
+				? (
+					<div className="flex items-center gap-1">
+						<ComboBox
+							title={title}
+							className={boxClass}
+							placeholder={`Select ${title}...`}
+							value={undefined}
+							options={optionsFor()}
+							onSelect={(next) => {
+								if (next) onChange([...values, next])
+								setAdding(false)
+							}}
+						/>
+						<Button
+							type="button"
+							size="icon"
+							variant="ghost"
+							className="h-8 w-8 shrink-0 text-destructive"
+							onClick={() => setAdding(false)}
+						>
+							<Icons.X className="h-4 w-4" />
+						</Button>
+					</div>
+				)
+				: (
+					// exhausted is a different story from adding: the button stays, disabled, to say there's nothing left to pick
+					<Button type="button" size="sm" variant="outline" className="h-7" disabled={exhausted} onClick={() => setAdding(true)}>
+						<Icons.Plus className="mr-1 h-3.5 w-3.5" />
+						Add {title}
 					</Button>
-				</div>
-			)}
-			<Button type="button" size="sm" variant="outline" className="h-7" disabled={adding || exhausted} onClick={() => setAdding(true)}>
-				<Icons.Plus className="mr-1 h-3.5 w-3.5" />
-				Add {title}
-			</Button>
+				)}
 		</div>
 	)
 }

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -1955,15 +1955,24 @@ function RolePermissionsTable(
 									<PermScopeCell row={row} timeout$={timeout$} reset$={reset$} onPatch={patchRow} />
 								</TableCell>
 								<TableCell className="align-top">
-									<Button
-										type="button"
-										size="icon"
-										variant="ghost"
-										className="h-8 w-8 text-destructive"
-										onClick={() => setRows(rows.filter((r) => r.id !== row.id))}
-									>
-										<Icons.X className="h-4 w-4" />
-									</Button>
+									{
+										/* a trash can, not an X: the scope cell's own X drops a single scope value, and the two end up close
+									    enough that reusing the icon for "remove the whole permission" would be a trap */
+									}
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<Button
+												type="button"
+												size="icon"
+												variant="ghost"
+												className="h-8 w-8 text-destructive"
+												onClick={() => setRows(rows.filter((r) => r.id !== row.id))}
+											>
+												<Icons.Trash2 className="h-4 w-4" />
+											</Button>
+										</TooltipTrigger>
+										<TooltipContent>Remove this permission</TooltipContent>
+									</Tooltip>
 								</TableCell>
 							</TableRow>
 						)
@@ -2021,7 +2030,7 @@ function PermScopeCell(
 
 		case 'global-settings-write':
 			return (
-				<ScopeMultiSelect
+				<ScopeValueRows
 					title="setting path"
 					mono
 					emptyLabel="All settings"
@@ -2033,7 +2042,7 @@ function PermScopeCell(
 
 		case 'server-settings':
 			return (
-				<ScopeMultiSelect
+				<ScopeValueRows
 					title="server"
 					emptyLabel="All servers"
 					values={row.serverIds ?? []}
@@ -2044,15 +2053,16 @@ function PermScopeCell(
 
 		case 'server-settings-write':
 			return (
-				<div className="space-y-1">
-					<ScopeMultiSelect
+				// two independent lists in one cell, so they get more room between them than the rows within each
+				<div className="space-y-3">
+					<ScopeValueRows
 						title="server"
 						emptyLabel="All servers"
 						values={row.serverIds ?? []}
 						options={serverOptionsFor(servers, row.serverIds ?? [])}
 						onChange={(serverIds) => onPatch(row.id, { serverIds })}
 					/>
-					<ScopeMultiSelect
+					<ScopeValueRows
 						title="setting path"
 						mono
 						emptyLabel="All non-sensitive settings"
@@ -2079,26 +2089,85 @@ function serverOptionsFor(servers: { id: string; displayName: string }[], select
 	return [...unknown, ...known]
 }
 
-function ScopeMultiSelect(
+// One dropdown per selected value rather than a single multi-select: the values here are long (dotted setting paths,
+// `Display Name (server-id)`) and a combined trigger could only show them comma-joined and ellipsed, which truncated
+// exactly the tail that distinguishes them.
+function ScopeValueRows(
 	{ title, values, options, onChange, emptyLabel, mono }: {
 		title: string
 		values: string[]
 		options: (ComboBoxOption<string> | string)[]
 		onChange: (next: string[]) => void
-		// an empty scope means unrestricted, which reads as a bug unless the control says so
+		// an empty scope means unrestricted, which reads as a bug unless it's spelled out
 		emptyLabel: string
 		mono?: boolean
 	},
 ) {
+	// the not-yet-chosen row that `Add` opens. It lives here rather than in `values` so an abandoned Add can't write an
+	// empty entry back to the settings draft.
+	const [adding, setAdding] = React.useState(false)
+	const normalized: ComboBoxOption<string>[] = options.map((o) => (typeof o === 'string' ? { value: o } : o))
+	const selected = new Set(values)
+	const exhausted = normalized.every((o) => selected.has(o.value))
+
+	// a value already used in a sibling row would be a no-op grant, so only the row holding it may keep it
+	function optionsFor(own?: string): ComboBoxOption<string>[] {
+		return normalized.map((o) => (o.value !== own && selected.has(o.value) ? { ...o, disabled: true } : o))
+	}
+	const boxClass = cn('w-full max-w-[22rem]', mono && 'font-mono')
+
 	return (
-		<ComboBoxMulti
-			title={title}
-			emptyLabel={emptyLabel}
-			className={cn('w-full max-w-[24rem]', mono && 'font-mono')}
-			values={values}
-			options={options}
-			onSelect={(next) => onChange(typeof next === 'function' ? next(values) : next)}
-		/>
+		<div className="space-y-1">
+			{values.length === 0 && !adding && <p className="text-xs leading-8 text-muted-foreground">{emptyLabel}</p>}
+			{values.map((value, idx) => (
+				<div key={value} className="flex items-center gap-1">
+					<ComboBox
+						title={title}
+						className={boxClass}
+						value={value}
+						options={optionsFor(value)}
+						onSelect={(next) => next && onChange(values.map((v, i) => (i === idx ? next : v)))}
+					/>
+					<Button
+						type="button"
+						size="icon"
+						variant="ghost"
+						className="h-8 w-8 shrink-0 text-destructive"
+						onClick={() => onChange(values.filter((_, i) => i !== idx))}
+					>
+						<Icons.X className="h-4 w-4" />
+					</Button>
+				</div>
+			))}
+			{adding && (
+				<div className="flex items-center gap-1">
+					<ComboBox
+						title={title}
+						className={boxClass}
+						placeholder={`Select ${title}...`}
+						value={undefined}
+						options={optionsFor()}
+						onSelect={(next) => {
+							if (next) onChange([...values, next])
+							setAdding(false)
+						}}
+					/>
+					<Button
+						type="button"
+						size="icon"
+						variant="ghost"
+						className="h-8 w-8 shrink-0 text-destructive"
+						onClick={() => setAdding(false)}
+					>
+						<Icons.X className="h-4 w-4" />
+					</Button>
+				</div>
+			)}
+			<Button type="button" size="sm" variant="outline" className="h-7" disabled={adding || exhausted} onClick={() => setAdding(true)}>
+				<Icons.Plus className="mr-1 h-3.5 w-3.5" />
+				Add {title}
+			</Button>
+		</div>
 	)
 }
 

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -1,5 +1,5 @@
 import { BmFlagMultiSelect, BmFlagOrColorSelect, FlagPriorityMap } from '@/components/bm-flag-picker'
-import type { ComboBoxOption } from '@/components/combo-box/combo-box'
+import ComboBox, { type ComboBoxOption } from '@/components/combo-box/combo-box'
 import ComboBoxMulti from '@/components/combo-box/combo-box-multi'
 import { DiscordMemberSelect, DiscordRoleSelect } from '@/components/discord-picker'
 import LayerGenerationConfigEditor from '@/components/layer-generation-config-editor'
@@ -27,6 +27,7 @@ import { HIDDEN_GLOBAL_SETTINGS_KEYS, splitByGroups } from '@/lib/settings-group
 import { humanize, settingLabel } from '@/lib/settings-labels'
 import * as SettingsNav from '@/lib/settings-nav'
 import * as Templating from '@/lib/templating'
+import { assertNever } from '@/lib/type-guards'
 import { cn } from '@/lib/utils'
 import * as ZusUtils from '@/lib/zustand'
 import * as AAR from '@/models/admin-action-reasons.models'
@@ -34,6 +35,7 @@ import type * as BM from '@/models/battlemetrics.models'
 import * as CMD from '@/models/command.models'
 import type * as LP from '@/models/labeled-presets.models'
 import * as LC from '@/models/layer-columns'
+import * as PermRows from '@/models/rbac-perm-rows'
 import * as SETTINGS from '@/models/settings.models'
 import type * as SM from '@/models/squad.models'
 import * as RPC from '@/orpc.client'
@@ -161,53 +163,6 @@ function emptyValue(node: Node): unknown {
 }
 
 // granted permissions include the "*" wildcard; denials are stored with a "!" prefix but edited without it in a separate select
-function permOption(p: string): ComboBoxOption<string> {
-	const def = RBAC.PERMISSION_DEFINITION[p as keyof typeof RBAC.PERMISSION_DEFINITION]
-	return { value: p, description: def?.description }
-}
-const GRANT_PERM_OPTIONS: ComboBoxOption<string>[] = [
-	{ value: '*', description: 'Grants every permission (full access to everything)' },
-	...RBAC.ROLE_GRANTABLE_PERMISSION_TYPE.options.map(permOption),
-]
-const DENY_PERM_OPTIONS: ComboBoxOption<string>[] = RBAC.ROLE_GRANTABLE_PERMISSION_TYPE.options.map(permOption)
-
-// editor for a role's permission expression list: granted perms and denied perms (!-prefixed) in two separate selects
-function PermissionExpressionEditor({ value, onChange }: { value: string[] | undefined; onChange: (v: string[]) => void }) {
-	const all = value ?? []
-	const granted = all.filter((v) => !v.startsWith('!'))
-	const denied = all.filter((v) => v.startsWith('!')).map((v) => v.slice(1))
-
-	function setGranted(next: string[]) {
-		onChange([...next, ...denied.map((p) => `!${p}`)])
-	}
-	function setDenied(next: string[]) {
-		onChange([...granted, ...next.map((p) => `!${p}`)])
-	}
-
-	return (
-		<div className="space-y-2">
-			<div className="space-y-1">
-				<label className="text-xs text-muted-foreground">Granted</label>
-				<ComboBoxMulti
-					title="Permission"
-					values={granted}
-					options={GRANT_PERM_OPTIONS}
-					onSelect={(next) => setGranted(typeof next === 'function' ? next(granted) : next)}
-				/>
-			</div>
-			<div className="space-y-1">
-				<label className="text-xs text-muted-foreground">Denied (takes precedence)</label>
-				<ComboBoxMulti
-					title="Denied permission"
-					values={denied}
-					options={DENY_PERM_OPTIONS}
-					onSelect={(next) => setDenied(typeof next === 'function' ? next(denied) : next)}
-				/>
-			</div>
-		</div>
-	)
-}
-
 // -------- rbac cross-field wiring --------
 
 // the draft's custom message variables (rbac-style sibling read), so the reason preview can render templates
@@ -1664,19 +1619,11 @@ function serverGrantPathOptions(): string[] {
 // right. This mirrors the persisted shape, where each role is one object under `roles[roleId]` holding its permissions,
 // timeout cap, settings grants and assignments.
 
-const SERVER_GRANT_ACCESS_OPTIONS = ['read', 'write', 'write-sensitive'] as const
 const VALID_ROLE_ID = /^[a-z0-9-]{3,32}$/
 
-type ServerGrant = { access: string; serverIds?: string[]; paths?: string[] }
-type RoleAssignmentsValue = { discordRoleIds?: (string | number)[]; discordUserIds?: (string | number)[]; everyMember?: boolean }
-type RoleConfig = {
-	permissions?: string[]
-	maxTimeout?: string
-	globalSettingsGrants?: string[]
-	serverSettingsGrants?: ServerGrant[]
-	assignments?: RoleAssignmentsValue
-}
-type RbacValue = { roles?: Record<string, RoleConfig> }
+type RoleAssignmentsValue = PermRows.RoleAssignmentsValue
+type RoleConfig = PermRows.RoleConfig
+type RbacValue = PermRows.RbacValue
 
 // apply `fn` to the whole rbac object, then poke reset$ so any uncontrolled inputs (the timeout duration field) re-read.
 // `quiet` skips reset$ for edits driven by an uncontrolled input, where re-emitting would clobber an in-flight keystroke.
@@ -1861,9 +1808,8 @@ function RoleDetail(
 ) {
 	const [renaming, setRenaming] = React.useState(false)
 	const cfg = rbac.roles?.[roleId] ?? {}
-	// scoped value-state for the timeout duration field so it can reuse the uncontrolled TextInputField
+	// scoped value-state for the timeout duration cell so it can reuse the uncontrolled TextInputField
 	const timeout$ = React.useMemo(() => scopeValue(scopeValue(scopeValue(value$, 'roles'), roleId), 'maxTimeout'), [value$, roleId])
-	const hasTimeout = cfg.maxTimeout !== undefined
 
 	return (
 		<div className="min-w-0 space-y-4 rounded-md border p-3">
@@ -1908,67 +1854,10 @@ function RoleDetail(
 			</div>
 
 			<RoleSubsection
-				title="Global Permissions"
-				description="Global-scope permissions. Settings permissions granted here are unrestricted (all servers / all settings); use the grants below to restrict them."
+				title="Permissions"
+				description="Everything this role may do. Each row is one permission; its Scope narrows the permission to specific servers, settings or a duration cap. Leave a scope empty to grant it unrestricted."
 			>
-				<PermissionExpressionEditor
-					value={cfg.permissions}
-					onChange={(v) => update((r) => withRoleConfig(r, roleId, (c) => ({ ...c, permissions: v })))}
-				/>
-			</RoleSubsection>
-
-			<RoleSubsection
-				title="Kick timeouts"
-				description="The maximum kick-timeout duration this role may issue (e.g. 2h). Super users/roles are unlimited."
-			>
-				<div className="flex items-center gap-3">
-					<div className="flex items-center gap-2">
-						<Switch
-							checked={hasTimeout}
-							onCheckedChange={(on) =>
-								update((r) => withRoleConfig(r, roleId, (c) => setRoleField(c, 'maxTimeout', on ? '1h' : undefined)))}
-						/>
-						<span className="text-sm">May issue kick timeouts</span>
-					</div>
-					{hasTimeout && (
-						<div className="w-32">
-							<TextInputField
-								value$={timeout$}
-								reset$={reset$}
-								onChange={(v) =>
-									update((r) => withRoleConfig(r, roleId, (c) => setRoleField(c, 'maxTimeout', (v as string) || '1h')), true)}
-								numeric={false}
-								placeholder="2h"
-							/>
-						</div>
-					)}
-				</div>
-			</RoleSubsection>
-
-			<RoleSubsection
-				title="Global settings grants"
-				description='Dotted setting paths this role may edit (e.g. "vote.voteDuration", or "vote" for the whole section). Any grant also lets the role view global settings.'
-			>
-				<ComboBoxMulti
-					title="setting path"
-					className="w-full max-w-[28rem] font-mono"
-					values={cfg.globalSettingsGrants ?? []}
-					options={globalGrantPathOptions()}
-					onSelect={(next) =>
-						update((r) =>
-							withRoleConfig(r, roleId, (c) => {
-								const resolved = typeof next === 'function' ? next(c.globalSettingsGrants ?? []) : next
-								return setRoleField(c, 'globalSettingsGrants', resolved)
-							})
-						)}
-				/>
-			</RoleSubsection>
-
-			<RoleSubsection
-				title="Server settings grants"
-				description="Per-server restricted read/write grants. Any grant also lets the role view the server's non-sensitive settings."
-			>
-				<RoleServerGrantsEditor roleId={roleId} grants={cfg.serverSettingsGrants ?? []} update={update} />
+				<RolePermissionsTable roleId={roleId} cfg={cfg} timeout$={timeout$} reset$={reset$} update={update} />
 			</RoleSubsection>
 
 			<RoleSubsection title="Assignments" description="Which Discord roles, users, or members are granted this role.">
@@ -1978,87 +1867,238 @@ function RoleDetail(
 	)
 }
 
-function RoleServerGrantsEditor(
-	{ roleId, grants, update }: { roleId: string; grants: ServerGrant[]; update: RbacUpdate },
+// one row = one permission the role holds. The five persisted fields are projected to rows on read and distributed back
+// on write by PermRows, so this component only ever deals in rows.
+function RolePermissionsTable(
+	{ roleId, cfg, timeout$, reset$, update }: {
+		roleId: string
+		cfg: RoleConfig
+		timeout$: ValueState
+		reset$: Rx.Subject<void>
+		update: RbacUpdate
+	},
+) {
+	const rows = PermRows.rowsFromConfig(cfg)
+
+	// `quiet` is threaded through for the timeout duration cell, whose uncontrolled input would be clobbered by a reset$
+	function setRows(next: PermRows.PermRow[], quiet?: boolean) {
+		update((r) => withRoleConfig(r, roleId, (c) => PermRows.configFromRows(c, next)), quiet)
+	}
+	function patchRow(id: string, patch: Partial<PermRows.PermRow>, quiet?: boolean) {
+		setRows(rows.map((row) => (row.id === id ? { ...row, ...patch } : row)), quiet)
+	}
+
+	const wildcarded = rows.some((r) => r.type === PermRows.ALL_PERMISSIONS && r.effect === 'allow')
+
+	// a second row of the same permission only means something when it can carry different scope args; the rest would
+	// just collapse on save, so offering them is a lie
+	const addOptions: ComboBoxOption<string>[] = PermRows.ADDABLE_TYPES.map((type) => {
+		const repeatable = PermRows.rowScope(type) === 'server-settings' || PermRows.rowScope(type) === 'server-settings-write'
+		const taken = !repeatable && rows.some((r) => r.type === type && r.effect === 'allow')
+		return { value: type, description: PermRows.permDescription(type), disabled: taken }
+	})
+
+	return (
+		<div className="space-y-2">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead className="w-[7.5rem]">Effect</TableHead>
+						<TableHead className="w-[16rem]">Permission</TableHead>
+						<TableHead>Scope</TableHead>
+						<TableHead className="w-10" />
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{rows.length === 0 && (
+						<TableRow>
+							<TableCell colSpan={4} className="text-xs text-muted-foreground">
+								This role grants nothing yet.
+							</TableCell>
+						</TableRow>
+					)}
+					{rows.map((row) => {
+						// `*` already grants every permission, so the allow rows under it are redundant. Deny still wins over it.
+						const subsumed = wildcarded && row.effect === 'allow' && row.type !== PermRows.ALL_PERMISSIONS
+						return (
+							<TableRow key={row.id} className={cn(subsumed && 'opacity-50')}>
+								<TableCell className="align-top">
+									<Select
+										value={row.effect}
+										disabled={!PermRows.canDeny(row.type)}
+										onValueChange={(v) => patchRow(row.id, { effect: v as PermRows.Effect })}
+									>
+										<SelectTrigger className="h-8">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="allow">Allow</SelectItem>
+											<SelectItem value="deny">Deny</SelectItem>
+										</SelectContent>
+									</Select>
+								</TableCell>
+								<TableCell className="align-top">
+									<div className="flex items-start gap-1">
+										<code className="text-xs leading-8">{row.type === PermRows.ALL_PERMISSIONS ? 'All permissions (*)' : row.type}</code>
+										{PermRows.permDescription(row.type) && <HelpTip text={PermRows.permDescription(row.type)!} />}
+										{subsumed && (
+											<Tooltip>
+												<TooltipTrigger asChild>
+													<Icons.Info className="mt-2 h-3 w-3 shrink-0 text-muted-foreground" />
+												</TooltipTrigger>
+												<TooltipContent>Already granted by the wildcard row above</TooltipContent>
+											</Tooltip>
+										)}
+									</div>
+								</TableCell>
+								<TableCell className="align-top">
+									<PermScopeCell row={row} timeout$={timeout$} reset$={reset$} onPatch={patchRow} />
+								</TableCell>
+								<TableCell className="align-top">
+									<Button
+										type="button"
+										size="icon"
+										variant="ghost"
+										className="h-8 w-8 text-destructive"
+										onClick={() => setRows(rows.filter((r) => r.id !== row.id))}
+									>
+										<Icons.X className="h-4 w-4" />
+									</Button>
+								</TableCell>
+							</TableRow>
+						)
+					})}
+				</TableBody>
+			</Table>
+			<ComboBox
+				title="permission"
+				placeholder="Add permission..."
+				className="w-[20rem]"
+				value={undefined}
+				options={addOptions}
+				onSelect={(type) => type && setRows([...rows, PermRows.newRow(type)])}
+			/>
+		</div>
+	)
+}
+
+// the Scope cell is a switch over the permission's scope kind, so a new permission needs no new editor: it inherits the
+// cell for whichever scope it declares in PERMISSION_DEFINITION.
+function PermScopeCell(
+	{ row, timeout$, reset$, onPatch }: {
+		row: PermRows.PermRow
+		timeout$: ValueState
+		reset$: Rx.Subject<void>
+		onPatch: (id: string, patch: Partial<PermRows.PermRow>, quiet?: boolean) => void
+	},
 ) {
 	const servers = ZusUtils.useStore(SettingsClient.PublicSettingsStore, (s) => s?.servers) ?? []
-	const serverOptions: ComboBoxOption<string>[] = servers.map((s) => ({
+
+	// a denial is unrestricted by construction: the expression grammar carries no args
+	if (row.effect === 'deny') return <span className="text-xs leading-8 text-muted-foreground">Everything</span>
+
+	const scope = PermRows.rowScope(row.type)
+	switch (scope) {
+		case 'all':
+		case 'global':
+			return <span className="text-xs leading-8 text-muted-foreground">{scope === 'all' ? 'Everything' : '—'}</span>
+
+		case 'timeout':
+			return (
+				<div className="flex items-center gap-2">
+					<span className="text-xs text-muted-foreground">up to</span>
+					<div className="w-24">
+						<TextInputField
+							value$={timeout$}
+							reset$={reset$}
+							onChange={(v) => onPatch(row.id, { maxTimeout: (v as string) || PermRows.DEFAULT_MAX_TIMEOUT }, true)}
+							numeric={false}
+							placeholder="2h"
+						/>
+					</div>
+				</div>
+			)
+
+		case 'global-settings-write':
+			return (
+				<ScopeMultiSelect
+					title="setting path"
+					mono
+					emptyLabel="All settings"
+					values={row.paths ?? []}
+					options={globalGrantPathOptions()}
+					onChange={(paths) => onPatch(row.id, { paths })}
+				/>
+			)
+
+		case 'server-settings':
+			return (
+				<ScopeMultiSelect
+					title="server"
+					emptyLabel="All servers"
+					values={row.serverIds ?? []}
+					options={serverOptionsFor(servers, row.serverIds ?? [])}
+					onChange={(serverIds) => onPatch(row.id, { serverIds })}
+				/>
+			)
+
+		case 'server-settings-write':
+			return (
+				<div className="space-y-1">
+					<ScopeMultiSelect
+						title="server"
+						emptyLabel="All servers"
+						values={row.serverIds ?? []}
+						options={serverOptionsFor(servers, row.serverIds ?? [])}
+						onChange={(serverIds) => onPatch(row.id, { serverIds })}
+					/>
+					<ScopeMultiSelect
+						title="setting path"
+						mono
+						emptyLabel="All non-sensitive settings"
+						values={row.paths ?? []}
+						options={serverGrantPathOptions()}
+						onChange={(paths) => onPatch(row.id, { paths })}
+					/>
+				</div>
+			)
+
+		default:
+			return assertNever(scope)
+	}
+}
+
+// unknown ids (a server that has since been deleted) stay selectable so opening the editor can't silently drop a grant
+function serverOptionsFor(servers: { id: string; displayName: string }[], selected: string[]): ComboBoxOption<string>[] {
+	const known: ComboBoxOption<string>[] = servers.map((s) => ({
 		value: s.id,
 		label: `${s.displayName} (${s.id})`,
 		keywords: [s.displayName],
 	}))
+	const unknown = selected.filter((id) => !servers.some((s) => s.id === id)).map((id) => ({ value: id }))
+	return [...unknown, ...known]
+}
 
-	function setGrants(next: ServerGrant[]) {
-		update((r) => withRoleConfig(r, roleId, (c) => setRoleField(c, 'serverSettingsGrants', next)))
-	}
-	function patch(idx: number, patch: Partial<ServerGrant>) {
-		setGrants(grants.map((g, i) => (i === idx ? { ...g, ...patch } : g)))
-	}
-
+function ScopeMultiSelect(
+	{ title, values, options, onChange, emptyLabel, mono }: {
+		title: string
+		values: string[]
+		options: (ComboBoxOption<string> | string)[]
+		onChange: (next: string[]) => void
+		// an empty scope means unrestricted, which reads as a bug unless the control says so
+		emptyLabel: string
+		mono?: boolean
+	},
+) {
 	return (
-		<div className="space-y-2">
-			{grants.length === 0 && <p className="text-xs text-muted-foreground">No server grants.</p>}
-			{grants.map((grant, idx) => {
-				const options = grant.serverIds?.some((id) => !servers.some((s) => s.id === id))
-					? [...grant.serverIds.filter((id) => !servers.some((s) => s.id === id)).map((id) => ({ value: id })), ...serverOptions]
-					: serverOptions
-				return (
-					// oxlint-disable-next-line no-array-index-key
-					<div key={idx} className="space-y-2 rounded-md border p-2">
-						<div className="flex items-center gap-2">
-							<Select value={grant.access} onValueChange={(v) => patch(idx, { access: v, ...(v !== 'write' ? { paths: [] } : {}) })}>
-								<SelectTrigger className="h-8 w-48">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									{SERVER_GRANT_ACCESS_OPTIONS.map((a) => <SelectItem key={a} value={a}>{a}</SelectItem>)}
-								</SelectContent>
-							</Select>
-							<Button
-								type="button"
-								size="icon"
-								variant="ghost"
-								className="ml-auto h-8 w-8 text-destructive"
-								onClick={() => setGrants(grants.filter((_, i) => i !== idx))}
-							>
-								<Icons.X className="h-4 w-4" />
-							</Button>
-						</div>
-						<div className="space-y-1">
-							<label className="text-xs text-muted-foreground">Servers (empty = all)</label>
-							<ComboBoxMulti
-								title="server"
-								className="w-full max-w-[28rem]"
-								values={grant.serverIds ?? []}
-								options={options}
-								onSelect={(next) => patch(idx, { serverIds: typeof next === 'function' ? next(grant.serverIds ?? []) : next })}
-							/>
-						</div>
-						{grant.access === 'write' && (
-							<div className="space-y-1">
-								<label className="text-xs text-muted-foreground">Setting paths (empty = all non-sensitive)</label>
-								<ComboBoxMulti
-									title="setting path"
-									className="w-full max-w-[28rem] font-mono"
-									values={grant.paths ?? []}
-									options={serverGrantPathOptions()}
-									onSelect={(next) => patch(idx, { paths: typeof next === 'function' ? next(grant.paths ?? []) : next })}
-								/>
-							</div>
-						)}
-					</div>
-				)
-			})}
-			<Button
-				type="button"
-				size="sm"
-				variant="outline"
-				onClick={() => setGrants([...grants, { access: 'write', serverIds: [], paths: [] }])}
-			>
-				<Icons.Plus className="mr-1 h-4 w-4" />
-				Add grant
-			</Button>
-		</div>
+		<ComboBoxMulti
+			title={title}
+			placeholder={emptyLabel}
+			className={cn('w-full max-w-[24rem]', mono && 'font-mono')}
+			values={values}
+			options={options}
+			onSelect={(next) => onChange(typeof next === 'function' ? next(values) : next)}
+		/>
 	)
 }
 

--- a/src/models/rbac-perm-rows.test.ts
+++ b/src/models/rbac-perm-rows.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from 'vitest'
+
+import * as PermRows from '@/models/rbac-perm-rows'
+
+// the editor renders rowsFromConfig and writes back configFromRows, so anything that survives one round trip is a config
+// the user can open and save without the meaning drifting under them.
+function roundTrip(cfg: PermRows.RoleConfig): PermRows.RoleConfig {
+	return PermRows.configFromRows(cfg, PermRows.rowsFromConfig(cfg))
+}
+
+describe('rowsFromConfig', () => {
+	test('a bare global expression is one allow row with no scope args', () => {
+		const rows = PermRows.rowsFromConfig({ permissions: ['queue:write'] })
+		expect(rows).toMatchObject([{ type: 'queue:write', effect: 'allow' }])
+		expect(rows[0].paths).toBeUndefined()
+		expect(rows[0].serverIds).toBeUndefined()
+	})
+
+	test('a !-prefixed expression becomes a deny row on the same permission', () => {
+		const rows = PermRows.rowsFromConfig({ permissions: ['!admin:restart-slm'] })
+		expect(rows).toMatchObject([{ type: 'admin:restart-slm', effect: 'deny' }])
+	})
+
+	test('allow and deny on one permission sort adjacently, allow first', () => {
+		const rows = PermRows.rowsFromConfig({ permissions: ['!queue:write', 'queue:write'] })
+		expect(rows.map((r) => r.effect)).toEqual(['allow', 'deny'])
+	})
+
+	test('a bare settings expression is an unrestricted row: empty args, not absent args', () => {
+		const [row] = PermRows.rowsFromConfig({ permissions: ['server-settings:write'] })
+		expect(row).toMatchObject({ type: 'server-settings:write', effect: 'allow', serverIds: [], paths: [] })
+	})
+
+	test('restricted grants become rows carrying their scope args', () => {
+		const rows = PermRows.rowsFromConfig({
+			globalSettingsGrants: ['vote', 'queue.mainPool'],
+			serverSettingsGrants: [{ access: 'write', serverIds: ['eu-1'], paths: ['queue'] }],
+		})
+		expect(rows).toMatchObject([
+			{ type: 'global-settings:write', effect: 'allow', paths: ['vote', 'queue.mainPool'] },
+			{ type: 'server-settings:write', effect: 'allow', serverIds: ['eu-1'], paths: ['queue'] },
+		])
+	})
+
+	test('maxTimeout becomes a timeout-players row', () => {
+		const rows = PermRows.rowsFromConfig({ maxTimeout: '2h' })
+		expect(rows).toMatchObject([{ type: 'squad-server:timeout-players', effect: 'allow', maxTimeout: '2h' }])
+	})
+
+	test('each server grant is its own row', () => {
+		const rows = PermRows.rowsFromConfig({
+			serverSettingsGrants: [
+				{ access: 'write', serverIds: ['eu-1'], paths: [] },
+				{ access: 'write', serverIds: ['us-1'], paths: ['vote'] },
+			],
+		})
+		expect(rows).toHaveLength(2)
+		expect(rows.map((r) => r.id)).toEqual([...new Set(rows.map((r) => r.id))])
+	})
+
+	test('a read grant carries no paths, since the schema rejects them there', () => {
+		const [row] = PermRows.rowsFromConfig({ serverSettingsGrants: [{ access: 'read', serverIds: ['eu-1'] }] })
+		expect(row.paths).toBeUndefined()
+	})
+
+	test('rows are ordered by permission declaration order regardless of stored order', () => {
+		const rows = PermRows.rowsFromConfig({ permissions: ['admin:restart-slm', 'queue:write', '*', 'vote:manage'] })
+		expect(rows.map((r) => r.type)).toEqual(['*', 'queue:write', 'vote:manage', 'admin:restart-slm'])
+	})
+
+	test('ids are deterministic across re-derivation of the same config', () => {
+		const cfg = {
+			permissions: ['queue:write'],
+			serverSettingsGrants: [{ access: 'write', serverIds: ['a'] }, { access: 'write', serverIds: ['b'] }],
+		}
+		expect(PermRows.rowsFromConfig(cfg).map((r) => r.id)).toEqual(PermRows.rowsFromConfig(cfg).map((r) => r.id))
+	})
+
+	test('inferred-only filters:write never becomes a row', () => {
+		expect(PermRows.ADDABLE_TYPES).not.toContain('filters:write')
+		expect(PermRows.rowsFromConfig({ permissions: ['filters:write'] })).toEqual([])
+	})
+})
+
+// the redundancy the old two-subsection UI could express but never explained: a bare grant and a restricted grant for the
+// same permission. The bare one already wins server-side, so the table shows one unrestricted row.
+describe('bare grants subsume restricted grants', () => {
+	test('a bare global-settings:write collapses the restricted path grants into one unrestricted row', () => {
+		const rows = PermRows.rowsFromConfig({ permissions: ['global-settings:write'], globalSettingsGrants: ['vote'] })
+		expect(rows).toMatchObject([{ type: 'global-settings:write', paths: [] }])
+	})
+
+	test('the collapse is semantically lossless: saving drops the dead restricted grant', () => {
+		const out = roundTrip({ permissions: ['global-settings:write'], globalSettingsGrants: ['vote'] })
+		expect(out.permissions).toEqual(['global-settings:write'])
+		expect(out.globalSettingsGrants).toEqual([])
+	})
+
+	test('a bare server-settings:write subsumes restricted server grants of the same access only', () => {
+		const rows = PermRows.rowsFromConfig({
+			permissions: ['server-settings:write'],
+			serverSettingsGrants: [
+				{ access: 'write', serverIds: ['eu-1'], paths: [] },
+				{ access: 'read', serverIds: ['us-1'] },
+			],
+		})
+		expect(rows).toMatchObject([
+			{ type: 'server-settings:read', serverIds: ['us-1'] },
+			{ type: 'server-settings:write', serverIds: [], paths: [] },
+		])
+	})
+})
+
+describe('configFromRows', () => {
+	test('empty scope args distribute to a bare expression, not a restricted grant', () => {
+		const cfg = PermRows.configFromRows({}, [{ id: 'x', type: 'global-settings:write', effect: 'allow', paths: [] }])
+		expect(cfg.permissions).toEqual(['global-settings:write'])
+		expect(cfg.globalSettingsGrants).toEqual([])
+	})
+
+	test('non-empty scope args distribute to a restricted grant, not a bare expression', () => {
+		const cfg = PermRows.configFromRows({}, [{ id: 'x', type: 'global-settings:write', effect: 'allow', paths: ['vote'] }])
+		expect(cfg.permissions).toEqual([])
+		expect(cfg.globalSettingsGrants).toEqual(['vote'])
+	})
+
+	test('a server-settings:write row with paths but no servers is still a restricted grant', () => {
+		const cfg = PermRows.configFromRows({}, [{ id: 'x', type: 'server-settings:write', effect: 'allow', serverIds: [], paths: ['vote'] }])
+		expect(cfg.permissions).toEqual([])
+		expect(cfg.serverSettingsGrants).toEqual([{ access: 'write', serverIds: [], paths: ['vote'] }])
+	})
+
+	test('a timeout row with a blank duration falls back rather than persisting an invalid empty cap', () => {
+		const cfg = PermRows.configFromRows({}, [{ id: 'x', type: 'squad-server:timeout-players', effect: 'allow', maxTimeout: '' }])
+		expect(cfg.maxTimeout).toBe(PermRows.DEFAULT_MAX_TIMEOUT)
+	})
+
+	// the lists prefault to [] in the schema, so writing them empty (rather than dropping them) is what keeps a saved
+	// draft from reading back as "1 setting changed" forever
+	test('emptying the table writes empty lists, matching what the schema reads back', () => {
+		const cfg = PermRows.configFromRows(
+			{ permissions: ['queue:write'], globalSettingsGrants: ['vote'], serverSettingsGrants: [{ access: 'read' }] },
+			[],
+		)
+		expect(cfg.permissions).toEqual([])
+		expect(cfg.globalSettingsGrants).toEqual([])
+		expect(cfg.serverSettingsGrants).toEqual([])
+	})
+
+	// maxTimeout is the exception: it's optional, and absent is the only way to say "cannot issue timeouts"
+	test('removing the timeout row drops maxTimeout rather than writing a falsy cap', () => {
+		expect(PermRows.configFromRows({ maxTimeout: '2h' }, [])).not.toHaveProperty('maxTimeout')
+	})
+
+	test('assignments are untouched: the table edits permissions only', () => {
+		const assignments = { discordRoleIds: ['123'], everyMember: true }
+		expect(PermRows.configFromRows({ assignments }, []).assignments).toEqual(assignments)
+	})
+
+	test('duplicate rows collapse instead of writing a duplicated expression', () => {
+		const cfg = PermRows.configFromRows({}, [
+			{ id: 'a', type: 'queue:write', effect: 'allow' },
+			{ id: 'b', type: 'queue:write', effect: 'allow' },
+		])
+		expect(cfg.permissions).toEqual(['queue:write'])
+	})
+})
+
+describe('round trip', () => {
+	const cases: Record<string, PermRows.RoleConfig> = {
+		'empty': {},
+		'global perms': { permissions: ['queue:write', 'vote:manage'] },
+		'wildcard': { permissions: ['*'] },
+		'allow + deny': { permissions: ['queue:write', '!admin:restart-slm'] },
+		'unrestricted settings': { permissions: ['global-settings:write', 'server-settings:write'] },
+		'restricted global settings': { globalSettingsGrants: ['vote', 'queue.mainPool'] },
+		'restricted server settings': { serverSettingsGrants: [{ access: 'write', serverIds: ['eu-1'], paths: ['vote'] }] },
+		'multiple server grants': {
+			serverSettingsGrants: [
+				{ access: 'write', serverIds: ['eu-1'], paths: ['vote'] },
+				{ access: 'read', serverIds: ['us-1'] },
+			],
+		},
+		'server grant over all servers': { serverSettingsGrants: [{ access: 'write', serverIds: [], paths: ['vote'] }] },
+		'timeout': { maxTimeout: '2h' },
+		'everything at once': {
+			permissions: ['queue:write', 'vote:manage', '!admin:restart-slm'],
+			maxTimeout: '30m',
+			globalSettingsGrants: ['vote'],
+			serverSettingsGrants: [{ access: 'write', serverIds: ['eu-1'], paths: ['queue'] }],
+			assignments: { discordRoleIds: ['123'], everyMember: false },
+		},
+	}
+
+	// Two things a round trip is allowed to change without changing meaning, both of which the schema erases on read:
+	// an absent list is the same as an empty one (`prefault([])`), and server grants are an unordered set, so listing them
+	// in permission-declaration order may reorder the array. The ordering itself is pinned below.
+	function normalized(cfg: PermRows.RoleConfig) {
+		return {
+			...cfg,
+			permissions: cfg.permissions ?? [],
+			globalSettingsGrants: cfg.globalSettingsGrants ?? [],
+			serverSettingsGrants: [...(cfg.serverSettingsGrants ?? [])].map((g) => JSON.stringify(g)).sort(),
+		}
+	}
+
+	for (const [name, cfg] of Object.entries(cases)) {
+		test(`${name} survives a round trip`, () => {
+			expect(normalized(roundTrip(cfg))).toEqual(normalized(cfg))
+		})
+
+		test(`${name} is stable under a second round trip`, () => {
+			const once = roundTrip(cfg)
+			expect(roundTrip(once)).toEqual(once)
+		})
+	}
+
+	test('a round trip reorders server grants into permission-declaration order, and leaves them there', () => {
+		const cfg = {
+			serverSettingsGrants: [
+				{ access: 'write', serverIds: ['eu-1'], paths: ['vote'] },
+				{ access: 'read', serverIds: ['us-1'] },
+			],
+		}
+		expect(roundTrip(cfg).serverSettingsGrants?.map((g) => g.access)).toEqual(['read', 'write'])
+	})
+})
+
+describe('deny affordance', () => {
+	test('every addable permission except the wildcard and the timeout cap can be denied', () => {
+		expect(PermRows.canDeny('queue:write')).toBe(true)
+		expect(PermRows.canDeny('global-settings:write')).toBe(true)
+		// `!squad-server:timeout-players` is not in the expression grammar; you drop the row instead
+		expect(PermRows.canDeny('squad-server:timeout-players')).toBe(false)
+		expect(PermRows.canDeny(PermRows.ALL_PERMISSIONS)).toBe(false)
+	})
+
+	test('rowScope covers every addable permission', () => {
+		for (const type of PermRows.ADDABLE_TYPES) expect(() => PermRows.rowScope(type)).not.toThrow()
+	})
+
+	test('a row exists for every role-grantable permission, so the table can express any config', () => {
+		for (const type of PermRows.ADDABLE_TYPES) {
+			if (!PermRows.canDeny(type)) continue
+			expect(roundTrip({ permissions: [type] }).permissions).toEqual([type])
+			expect(roundTrip({ permissions: [`!${type}`] }).permissions).toEqual([`!${type}`])
+		}
+	})
+})

--- a/src/models/rbac-perm-rows.ts
+++ b/src/models/rbac-perm-rows.ts
@@ -1,0 +1,230 @@
+import { assertNever } from '@/lib/type-guards'
+import * as RBAC from '@/rbac.models'
+
+// A role's permissions are persisted across five parallel fields (`permissions` expressions, `maxTimeout`,
+// `globalSettingsGrants`, `serverSettingsGrants`), because the expression grammar can't carry scope arguments. The editor
+// presents all of them as one flat list of rows instead: one row = one permission, held with some scope. This module is
+// the projection between the two, and it is intentionally the only place that knows the correspondence.
+//
+// The row list is a *view*: rows are derived from the config on every read and distributed back on every write, so the
+// persisted shape is untouched.
+
+export type ServerGrant = { access: string; serverIds?: string[]; paths?: string[] }
+export type RoleAssignmentsValue = { discordRoleIds?: (string | number)[]; discordUserIds?: (string | number)[]; everyMember?: boolean }
+export type RoleConfig = {
+	permissions?: string[]
+	maxTimeout?: string
+	globalSettingsGrants?: string[]
+	serverSettingsGrants?: ServerGrant[]
+	assignments?: RoleAssignmentsValue
+}
+export type RbacValue = { roles?: Record<string, RoleConfig> }
+
+export type Effect = 'allow' | 'deny'
+
+// what the row's Scope cell edits. Mirrors the permission's `scope` in PERMISSION_DEFINITION, plus `all` for the `*`
+// wildcard expression, which is a row but not a permission.
+export type RowScope =
+	| 'all'
+	| 'global'
+	| 'timeout'
+	| 'global-settings-write'
+	| 'server-settings'
+	| 'server-settings-write'
+
+export type PermRow = {
+	// deterministic: rows are re-derived from the config on every render, so this must not be random
+	id: string
+	type: string
+	effect: Effect
+	// scope args; which of these the row uses is decided by `rowScope(type)`. Empty array = unrestricted ("all").
+	serverIds?: string[]
+	paths?: string[]
+	maxTimeout?: string
+}
+
+export const ALL_PERMISSIONS = '*'
+// matches the duration the old kick-timeout switch seeded on enable
+export const DEFAULT_MAX_TIMEOUT = '1h'
+
+// permissions the table can add. `filters:write` is absent on purpose: it's granted by the inferred filter-owner /
+// filter-contributor roles, never by a role definition.
+export const ADDABLE_TYPES: string[] = [
+	ALL_PERMISSIONS,
+	...RBAC.ROLE_GRANTABLE_PERMISSION_TYPE.options,
+	// not role-grantable as an expression (it rides `maxTimeout`), but it is a row
+	'squad-server:timeout-players',
+]
+
+// declaration order in PERMISSION_DEFINITION, so the table lists permissions in the same order every time regardless of
+// how they happen to be stored
+const TYPE_ORDER = [ALL_PERMISSIONS, ...Object.keys(RBAC.PERMISSION_DEFINITION)]
+
+export function rowScope(type: string): RowScope {
+	if (type === ALL_PERMISSIONS) return 'all'
+	const def = RBAC.PERMISSION_DEFINITION[type as keyof typeof RBAC.PERMISSION_DEFINITION]
+	if (!def) throw new Error(`unknown permission type: ${type}`)
+	const scope = def.scope
+	if (scope === 'filter') throw new Error(`${type} is inferred-only and cannot be a role permission row`)
+	return scope
+}
+
+export function permDescription(type: string): string | undefined {
+	if (type === ALL_PERMISSIONS) return 'Grants every permission (full access to everything)'
+	return RBAC.PERMISSION_DEFINITION[type as keyof typeof RBAC.PERMISSION_DEFINITION]?.description
+}
+
+// `!squad-server:timeout-players` isn't in the expression grammar, and negating a "up to N" cap is meaningless anyway:
+// to remove the ability you drop the row. `*` denies nothing.
+export function canDeny(type: string): boolean {
+	return type !== ALL_PERMISSIONS && RBAC.isRoleGrantablePermissionType(type as RBAC.RolePermissionExpression)
+}
+
+function serverAccessOf(type: string): string {
+	return type.slice('server-settings:'.length)
+}
+
+// the scope args a row starts with. Empty arrays mean unrestricted, matching what a bare expression grants.
+function emptyArgs(type: string): Partial<PermRow> {
+	const scope = rowScope(type)
+	switch (scope) {
+		case 'all':
+		case 'global':
+			return {}
+		case 'timeout':
+			return { maxTimeout: DEFAULT_MAX_TIMEOUT }
+		case 'global-settings-write':
+			return { paths: [] }
+		case 'server-settings':
+			return { serverIds: [] }
+		case 'server-settings-write':
+			return { serverIds: [], paths: [] }
+		default:
+			return assertNever(scope)
+	}
+}
+
+export function newRow(type: string, effect: Effect = 'allow'): PermRow {
+	return { id: '', type, effect, ...(effect === 'deny' ? {} : emptyArgs(type)) }
+}
+
+// stable order + ids. Ids only have to survive re-derivation of the same config, which ordinal-within-(type,effect) does.
+function finalize(rows: PermRow[]): PermRow[] {
+	const sorted = [...rows].sort((a, b) => {
+		const ta = TYPE_ORDER.indexOf(a.type)
+		const tb = TYPE_ORDER.indexOf(b.type)
+		if (ta !== tb) return ta - tb
+		if (a.effect !== b.effect) return a.effect === 'allow' ? -1 : 1
+		return 0
+	})
+	const seen = new Map<string, number>()
+	return sorted.map((row) => {
+		const key = `${row.effect}|${row.type}`
+		const ordinal = seen.get(key) ?? 0
+		seen.set(key, ordinal + 1)
+		return { ...row, id: `${key}|${ordinal}` }
+	})
+}
+
+export function rowsFromConfig(cfg: RoleConfig): PermRow[] {
+	const rows: PermRow[] = []
+	const exprs = cfg.permissions ?? []
+	const bare = new Set(exprs.filter((p) => !p.startsWith('!')))
+
+	for (const type of bare) {
+		// a bare settings expression grants that permission unrestricted, which is an empty-args row
+		if (type === ALL_PERMISSIONS || RBAC.isRoleGrantablePermissionType(type as RBAC.RolePermissionExpression)) {
+			rows.push({ id: '', type, effect: 'allow', ...emptyArgs(type) })
+		}
+	}
+
+	// restricted grants are dead config whenever the bare (unrestricted) expression is also present -- it already grants
+	// strictly more. Collapsing to the single unrestricted row is semantically lossless and surfaces the redundancy.
+	if (!bare.has('global-settings:write') && (cfg.globalSettingsGrants?.length ?? 0) > 0) {
+		rows.push({ id: '', type: 'global-settings:write', effect: 'allow', paths: [...cfg.globalSettingsGrants!] })
+	}
+
+	for (const grant of cfg.serverSettingsGrants ?? []) {
+		const type = `server-settings:${grant.access}`
+		if (bare.has(type) || !RBAC.isRoleGrantablePermissionType(type as RBAC.RolePermissionExpression)) continue
+		rows.push({
+			id: '',
+			type,
+			effect: 'allow',
+			serverIds: [...(grant.serverIds ?? [])],
+			// paths only mean anything on a write grant; the schema rejects them elsewhere
+			...(grant.access === 'write' ? { paths: [...(grant.paths ?? [])] } : {}),
+		})
+	}
+
+	if (cfg.maxTimeout !== undefined) {
+		rows.push({ id: '', type: 'squad-server:timeout-players', effect: 'allow', maxTimeout: cfg.maxTimeout })
+	}
+
+	for (const expr of exprs) {
+		if (!expr.startsWith('!')) continue
+		const type = expr.slice(1)
+		if (RBAC.isRoleGrantablePermissionType(type as RBAC.RolePermissionExpression)) rows.push({ id: '', type, effect: 'deny' })
+	}
+
+	return finalize(rows)
+}
+
+export function configFromRows(cfg: RoleConfig, rows: PermRow[]): RoleConfig {
+	const permissions: string[] = []
+	const globalSettingsGrants: string[] = []
+	const serverSettingsGrants: ServerGrant[] = []
+	let maxTimeout: string | undefined
+
+	for (const row of rows) {
+		if (row.effect === 'deny') {
+			permissions.push(`!${row.type}`)
+			continue
+		}
+		const scope = rowScope(row.type)
+		switch (scope) {
+			case 'all':
+			case 'global':
+				permissions.push(row.type)
+				break
+			case 'timeout':
+				maxTimeout = row.maxTimeout || DEFAULT_MAX_TIMEOUT
+				break
+			case 'global-settings-write':
+				// no paths = unrestricted, which only the bare expression can express
+				if ((row.paths?.length ?? 0) === 0) permissions.push(row.type)
+				else globalSettingsGrants.push(...row.paths!)
+				break
+			case 'server-settings':
+				if ((row.serverIds?.length ?? 0) === 0) permissions.push(row.type)
+				else serverSettingsGrants.push({ access: serverAccessOf(row.type), serverIds: [...row.serverIds!] })
+				break
+			case 'server-settings-write':
+				if ((row.serverIds?.length ?? 0) === 0 && (row.paths?.length ?? 0) === 0) permissions.push(row.type)
+				else {
+					serverSettingsGrants.push({
+						access: 'write',
+						serverIds: [...(row.serverIds ?? [])],
+						paths: [...(row.paths ?? [])],
+					})
+				}
+				break
+			default:
+				assertNever(scope)
+		}
+	}
+
+	// the three lists are written even when empty, because their schemas prefault to []: dropping them would leave the
+	// editor's draft permanently one "change" away from the document it just saved.
+	const next: RoleConfig = {
+		...cfg,
+		permissions: [...new Set(permissions)],
+		globalSettingsGrants: [...new Set(globalSettingsGrants)],
+		serverSettingsGrants,
+	}
+	// maxTimeout is genuinely optional though: absent means the role cannot issue timeouts at all, so an absent row has to
+	// drop the field rather than write a falsy cap.
+	if (maxTimeout === undefined) delete next.maxTimeout
+	else next.maxTimeout = maxTimeout
+	return next
+}


### PR DESCRIPTION
A role's permissions were spread across four editors -- a pair of permission-expression combo boxes, a kick-timeout switch, a global settings path picker, and a stack of server-grant cards -- because the expression grammar can't carry scope arguments, so anything scoped got its own persisted field and its own bespoke UI.

They now render as **one table per role**: one row per permission, with an Effect cell, the permission, and a Scope cell that narrows it.

| | before | after |
|---|---|---|
| granted / denied | two combo boxes | `Effect` column, allow and deny adjacent |
| kick timeout | switch + duration field | a row, scope reads `up to 2h` |
| global settings grants | its own path picker | a row, scope is the path list |
| server settings grants | stack of cards w/ access dropdown | one row per grant; access **is** the permission named |

## Why it's more than tidying

The Scope cell is a switch over the permission's `scope` in `PERMISSION_DEFINITION` (`assertNever`-guarded), so a **new permission inherits an editor** from whichever scope it declares rather than needing one written for it. That wasn't true before.

It also can no longer express the redundancy the old UI hid: a bare (unrestricted) grant *plus* a restricted grant for the same permission, in two different subsections, where the bare one silently won. Same row now, so you pick paths or you leave it empty for "all".

## Approach: view-only, no migration

The persisted shape is **untouched** -- no migration, nothing server-side moves. `src/models/rbac-perm-rows.ts` projects the five fields to rows on read and distributes them back on write. It lives in its own module (not the `.tsx`) so it's unit testable: 48 tests covering round-trip and idempotency over every config shape.

Notable projection rules, all pinned by tests:
- empty scope args -> the bare expression (unrestricted); non-empty -> the restricted grant. Narrowing a scope moves the grant between persisted fields on its own.
- `maxTimeout` is dropped when its row is removed (absent = cannot issue timeouts), but the three lists are written even when empty, because their schemas `prefault([])` -- dropping them left the draft permanently one "change" away from the doc it just saved.
- `filters:write` stays out (inferred-only via `filter-owner`/`filter-contributor`); `squad-server:timeout-players` can't be denied (`!`-form isn't in the grammar).
- server grants are an unordered set, so a save normalises their order to permission-declaration order.

## Verified

Driven end-to-end on the worktree dev instance, not just tests: added a permission, narrowed its scope, saved, and confirmed against the DB that `permissions` dropped the bare `server-settings:write` and `serverSettingsGrants` gained `{access:"write", serverIds:["tt-scrim-2"], paths:[]}`, with `maxTimeout` / `globalSettingsGrants` / `assignments` untouched. The prefault bug above was found this way.

`pnpm run check` clean, `pnpm run lint:fix` clean, 502 tests pass.

> [!NOTE]
> Merged `origin/main`: it added `emptyLabel` to `ComboBoxMulti` for the matchup operators, which is the same affordance this branch had added as `placeholder`. Dropped ours and used theirs -- the shared component now has **zero diff** against main.

Dev server: http://localhost:3151/settings#setting:rbac (slot 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)