### PR TITLE
only execute held teamswaps on a NEW_GAME that is actually a roll

### DIFF
--- a/src/models/server-events.models.ts
+++ b/src/models/server-events.models.ts
@@ -1,5 +1,6 @@
 import type * as SchemaModels from '$root/drizzle/schema.models'
 import * as Obj from '@/lib/object'
+import { assertNever } from '@/lib/type-guards'
 import type * as CS from '@/models/context-shared'
 import type * as L from '@/models/layer'
 import type * as MH from '@/models/match-history.models'
@@ -37,6 +38,22 @@ export const NEW_GAME_META = meta({
 	players: [{ assocType: 'game-participant', path: '$.state.players[*]' }],
 	squads: ['$.state.squads[*]'],
 })
+
+// Whether a NEW_GAME marks a roll that happened while this server was watching, and so is a boundary that held
+// actions (teamswaps) should fire on. 'slm-started' is not: it means SLM has just learned about a match that was
+// already running, and treating that as a boundary applies held actions to a match mid-flight.
+export function newGameIsRoll(source: NewGame['source']): boolean {
+	switch (source) {
+		case 'server-roll':
+		case 'new-game-detected':
+		case 'rcon-reconnected':
+			return true
+		case 'slm-started':
+			return false
+		default:
+			assertNever(source)
+	}
+}
 
 // RESET carries the definitive team roster: "the roster is now exactly this". Emitted on the first teams poll after
 // a match boundary (a NEW_GAME / server roll) and on a same-match RCON reconnect.

--- a/src/systems/teamswaps.server.ts
+++ b/src/systems/teamswaps.server.ts
@@ -217,14 +217,15 @@ export function initContext(ctx: C.SquadServer & C.Db & C.ServerSliceCleanup) {
 		).subscribe(),
 	)
 
-	// Schedule teamswaps on map roll. Wait until the new match's roster has settled (every player assigned to a
-	// team) before executing the saved swaps, so they land on faithful team data. NEW_GAME is now a roster-less
-	// boundary that precedes the roster, and players load in during staging, so a fixed delay is not enough --
-	// waitForSettledRoster polls RCON until settled or a timeout. taskScheduling 'switch' aborts a pending wait if
-	// another match boundary arrives first.
+	// Schedule teamswaps on map roll. NEW_GAME is a roster-less boundary that precedes the roster, so this waits
+	// before executing, to give the new match's teams a chance to land and the swaps to be applied against faithful
+	// team data. taskScheduling 'switch' aborts a pending wait if another match boundary arrives first.
+	//
+	// Only a NEW_GAME that is actually a roll may execute: a 'slm-started' one fires this delay on boot, which is
+	// long enough to swallow swaps saved moments later and execute them against the still-current match.
 	ctx.cleanup.push(
 		ctx.server.event$.pipe(
-			Rx.filter(([, e]) => e.type === 'NEW_GAME'),
+			Rx.filter(([, e]) => e.type === 'NEW_GAME' && SE.newGameIsRoll(e.source)),
 			Rx.delay(2000),
 			C.durableSub('performTeamswaps', { module, taskScheduling: 'switch' }, async ([ctx], signal) => {
 				await dispatchOp({ ...ctx, signal }, [{ opId: TSW.createOpId(), code: 'execute-teamswaps' }])


### PR DESCRIPTION
Chases down the `!swapnext` race flagged in #21. It is a real bug, not a test artifact.

## The bug

A `NEW_GAME` is not only a map roll. SLM also synthesizes one when it starts (`slm-started`) and when RCON reconnects onto a match it has not seen before (`rcon-reconnected`), plus the sync watchdog's `new-game-detected`. `performTeamswaps` filtered on `e.type === 'NEW_GAME'` and never looked at `source`, so **every SLM boot scheduled an `execute-teamswaps` 2 seconds later**.

That matters because `execute-teamswaps` sets `pendingSwaps = savedSwaps` and fires them immediately. Any swap saved inside that 2s window is executed against the still-current match instead of being held for the roll.

It gets worse: the bogus execution leaves `swapping = true`, so the *real* roll's execution is then rejected with `err:currently-swapping` -- and since the reducer already cleared `savedSwaps`, the swaps are lost entirely.

## Evidence

From the app log of a reproducing run (roster TTL at 500ms):

```
12:39:35  emitted event: NEW_GAME {... "source":"slm-started"}
12:39:37  side effect: save { swap_count: 1 }          <- !swapnext saved
12:39:37  side effect: execute-teamswaps               <- exactly boot + 2s
12:39:37  side effect: save { swap_count: 0 }          <- savedSwaps cleared
12:39:39  emitted event: NEW_GAME {... "source":"server-roll"}
12:39:41  op was not succesful: err:currently-swapping op: execute-teamswaps
```

The held swap is consumed by the boot event, and the genuine roll is refused.

Faster polling never caused this. It only made the tests finish quickly enough to land *inside* the boot's 2 second window, which is why it looked like TTL flakiness.

## Real-world impact

Any queued `!swapnext` that gets saved (or restored from the DB) within ~2s of an SLM start, or of an RCON reconnect onto a changed match, is executed mid-match rather than held -- and the following roll then silently drops the queue. Rare in production, but user-facing and silent when it happens.

## The fix

`SE.newGameIsRoll(source)` classifies the boundary. `server-roll`, `new-game-detected` and `rcon-reconnected` all mean a roll genuinely happened on this server's watch, so held swaps should fire. `slm-started` means SLM has just learned about a match that was already running, so it must not. The `assertNever` default forces any future `NEW_GAME` source to be classified explicitly, which is a stronger guard than a test would be.

Also removed the comment above the subscription that described a `waitForSettledRoster` function which does not exist anywhere in the codebase.

## Audit of the same bug class

Checked every other `NEW_GAME` consumer. Teamswaps was the only one taking an outward action on any `NEW_GAME`:

- `squad-server.server.ts` (x3): a client state stream, a log line, and `waitForSynced` -- all state sync, correct to react on boot.
- `teamswaps.server.ts:161` (`reset-players`): state sync, correct on boot.
- `schedulePostRollTasks` (fog-off, post-roll announcements): only called from `onNewGameDuringRoll`, already scoped to genuine rolls.

## Verification

- At 500ms roster TTL, the bug reproduced on **run 1 of 1** before the fix; **4/4 green** after, with no `err:currently-swapping` in any log and the spurious boot-triggered execution gone.
- Rebased onto current main and re-verified: typecheck, lint, 454 unit tests, and 2/2 integration runs green at the shipped 2s TTL.

No schema or config change.