### PR TITLE
Fix crash on players persisted before adminGroups existed

### DIFF
--- a/src/components/player-display.tsx
+++ b/src/components/player-display.tsx
@@ -57,7 +57,7 @@ export function PlayerDisplay(
 ) {
 	const playerId = SM.PlayerIds.getPlayerId(player.ids)
 	const windowProps: PlayerDetailsWindowProps = { playerId, stores }
-	const groupColor = usePlayerGroupColor(playerId, player.adminGroups)
+	const groupColor = usePlayerGroupColor(playerId, player.adminGroups ?? [])
 
 	return (
 		<span className={cn('inline-flex items-baseline', className)}>

--- a/src/components/server-activity-charts.tsx
+++ b/src/components/server-activity-charts.tsx
@@ -275,7 +275,7 @@ export function ServerActivityCharts(props: {
 			.map(p => {
 				const eosId = p.ids.eos!
 				const flagIds = bmData[eosId]?.flagIds ?? []
-				return [eosId, { flags: orgFlags ? BM.resolveFlags(flagIds, orgFlags) : [], adminGroups: p.adminGroups }]
+				return [eosId, { flags: orgFlags ? BM.resolveFlags(flagIds, orgFlags) : [], adminGroups: p.adminGroups ?? [] }]
 			})
 
 		const playerGroups = PG.resolvePlayerGroups(playerFacts, playerGroupings, activeGroupingId)

--- a/src/models/squad.models.test.ts
+++ b/src/models/squad.models.test.ts
@@ -566,3 +566,28 @@ describe('PlayerIds.findByUsernameLoose', () => {
 		expect(SM.PlayerIds.findByUsernameLoose(players, p => p.ids, 'AAA')).toBeUndefined()
 	})
 })
+
+describe('toRecentPlayer', () => {
+	// SE.fromEventRow deserializes stored event JSON without a schema parse, so a player persisted before adminGroups
+	// existed reaches the reducer with the field simply absent. Spreading that threw "adminGroups is not iterable" and
+	// took the whole chat feed down on any RESET replaying such an event.
+	it('accepts a player persisted before adminGroups existed', () => {
+		const legacy = {
+			ids: { eos: 'e1', playerController: 'ctrl', username: 'legacy' },
+			isAdmin: true,
+			role: 'Rifleman_01',
+		} as unknown as SM.RecentPlayer
+
+		const recent = SM.toRecentPlayer(legacy)
+		expect(recent.adminGroups).toEqual([])
+		expect(recent.isAdmin).toBe(true)
+	})
+
+	it('copies admin groups rather than aliasing them', () => {
+		const groups = ['Admins']
+		const recent = SM.toRecentPlayer({ ids: { eos: 'e1', playerController: 'c', username: 'u' }, isAdmin: true, adminGroups: groups })
+		expect(recent.adminGroups).toEqual(['Admins'])
+		groups.push('Whitelist')
+		expect(recent.adminGroups).toEqual(['Admins'])
+	})
+})

--- a/src/models/squad.models.ts
+++ b/src/models/squad.models.ts
@@ -396,10 +396,13 @@ export const PlayerSchema = z.object({
 	squadId: z.number().nullable(),
 	isLeader: z.boolean(),
 	isAdmin: z.boolean(),
-	// the admin list groups this player is in. `isAdmin` only reflects the groups holding an admin-identifying
+	// The admin list groups this player is in. `isAdmin` only reflects the groups holding an admin-identifying
 	// permission, so this is a superset of it: a reserve-slot group like Whitelist appears here and not there.
-	// Prefaulted because events persisted before this field existed carry players without it.
-	adminGroups: z.array(z.string()).prefault([]),
+	//
+	// Optional, and every read must tolerate its absence: events persisted before this field existed hold players
+	// without it, and SE.fromEventRow hands stored event JSON to the client without a schema parse, so no default
+	// is ever applied to them. A prefault would only make the type claim otherwise.
+	adminGroups: z.array(z.string()).optional(),
 	role: z.string(),
 })
 
@@ -416,7 +419,7 @@ export const RecentPlayerSchema = PlayerSchema.pick({ ids: true, isAdmin: true, 
 export type RecentPlayer = z.infer<typeof RecentPlayerSchema>
 
 export function toRecentPlayer(player: RecentPlayer): RecentPlayer {
-	return { ids: { ...player.ids }, isAdmin: player.isAdmin, adminGroups: [...player.adminGroups] }
+	return { ids: { ...player.ids }, isAdmin: player.isAdmin, adminGroups: [...(player.adminGroups ?? [])] }
 }
 
 // A roster is "settled" when every player has been assigned to a team -- i.e. no one is still loading / unassigned.

--- a/src/models/teams-panel.models.ts
+++ b/src/models/teams-panel.models.ts
@@ -56,7 +56,7 @@ export namespace Sel {
 					.map(p => {
 						const eosId = p.ids.eos!
 						const flagIds = bmData[eosId]?.flagIds ?? []
-						return [eosId, { flags: BM.resolveFlags(flagIds, orgFlags), adminGroups: p.adminGroups }]
+						return [eosId, { flags: BM.resolveFlags(flagIds, orgFlags), adminGroups: p.adminGroups ?? [] }]
 					})
 				const allGroups = PG.resolvePlayerGroups(playerFacts, playerGroupings, activeGroupingId)
 


### PR DESCRIPTION
## The error

```
Uncaught TypeError: e.adminGroups is not iterable
    at toRecentPlayer (squad.models.ts:419)
    at recordRecentPlayer (chat.models.ts:88)
    ... at handleChatEvents (chat.partial.ts:46)
```

Regression from #19. `toRecentPlayer` spreads `player.adminGroups`; on a RESET that replays an event stored **before** that field existed, it's `undefined` and the whole chat feed goes down.

## Why the prefault didn't save us

I declared the field `.prefault([])` on the reasoning that "events persisted before this field existed carry players without it" — assuming they'd be parsed on the way in. They aren't. `SE.fromEventRow` (server-events.models.ts:396, under its own `// TODO Zod?`) superjson-deserializes stored event JSON straight through with no schema parse, so no default is ever applied and the type was lying about anything coming off the wire.

Not hypothetical: **19 of the last 40 RESET rows in our db have players with no `adminGroups`**, and none have it.

## Fix

Make the type honest — `adminGroups` is `.optional()`, because that is what the data is. TypeScript then flagged three more reads, each a latent crash of the same kind (`adminGroups.includes(...)` on undefined, waiting for anyone to write an admin-list rule):

- `teams-panel.models.ts` — the Group column
- `server-activity-charts.tsx` — the team breakdown
- `player-display.tsx` — the name colour

All coerce with `?? []`.

Parsing in `fromEventRow` would let the field go back to required and fix this at one place, but that TODO is a bigger change than a crash fix should carry.

## Verification

- New regression test reproduces the exact prod error (`TypeError: player.adminGroups is not iterable`) against the pre-fix code and passes after it — confirmed by reverting the fix and watching it fail.
- Drove the real app against a db clone containing those 19 legacy RESET rows: dashboard renders, no console errors.
- Forced the actual failing path (`pnpm emuctl cycle` → RCON reconnect → live RESET through `handleChatEvents`): no crash, roster renders.
- `pnpm run check`, 484 tests, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)