### PR TITLE
Serialize slice lifecycle transitions, drop two bits of dead code

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,6 @@
 		"csv-stringify": "^6.5.2",
 		"date-fns": "^4.1.0",
 		"date-fns-tz": "^3.2.0",
-		"derive-zustand": "^0.1.1",
 		"discord.js": "^14.21.0",
 		"dotenv": "^16.6.1",
 		"dprint": "^0.49.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,9 +438,6 @@ importers:
       date-fns-tz:
         specifier: ^3.2.0
         version: 3.2.0(date-fns@4.1.0)
-      derive-zustand:
-        specifier: ^0.1.1
-        version: 0.1.1(zustand@5.0.6(@types/react@19.1.0)(immer@10.1.1)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0)))
       discord.js:
         specifier: ^14.21.0
         version: 14.21.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
@@ -4556,11 +4553,6 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  derive-zustand@0.1.1:
-    resolution: {integrity: sha512-f//6WuCy0URDemhTIh6VjTWtYwV8eQCB5KjZhrMqAVylFPtTO+9TNQofCmPmheRb/Y+F4MFvvK+ye3EJvMyETw==}
-    peerDependencies:
-      zustand: '>=4.1.0'
 
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -10486,7 +10478,7 @@ snapshots:
   '@types/sql.js@1.4.11':
     dependencies:
       '@types/emscripten': 1.41.5
-      '@types/node': 22.16.0
+      '@types/node': 22.20.0
     optional: true
 
   '@types/ssh2-sftp-client@9.0.4':
@@ -11084,10 +11076,6 @@ snapshots:
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
-
-  derive-zustand@0.1.1(zustand@5.0.6(@types/react@19.1.0)(immer@10.1.1)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))):
-    dependencies:
-      zustand: 5.0.6(@types/react@19.1.0)(immer@10.1.1)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
 
   detect-libc@2.0.2:
     optional: true

--- a/src/lib/zustand.ts
+++ b/src/lib/zustand.ts
@@ -3,7 +3,6 @@ import * as Obj from '@/lib/object'
 import type { StateObservable } from '@react-rxjs/core'
 import { useQueries } from '@tanstack/react-query'
 import type { UseQueryOptions } from '@tanstack/react-query'
-import { derive } from 'derive-zustand'
 import * as React from 'react'
 import * as Rx from 'rxjs'
 
@@ -256,5 +255,3 @@ export function toObservable<S extends NonNullable<object>, EmitCurrent extends 
 		return () => unsub()
 	})
 }
-
-export const deriveStores = derive

--- a/src/systems/squad-server.server.ts
+++ b/src/systems/squad-server.server.ts
@@ -89,7 +89,8 @@ const orpcBase = getOrpcBase(module)
 
 type State = {
 	slices: Map<string, C.ServerSlice>
-	sliceInitMtxs: Map<string, MutexInterface>
+	// guards every transition of a server's slice between running and not, not just setup. See withSliceLock.
+	sliceLifecycleMtxs: Map<string, MutexInterface>
 	// emits a serverId whenever that server's slice is added to or removed from `slices`
 	sliceLifecycleUpdate$: Rx.Subject<string>
 	serverEventIdCounter: Generator<number, never, unknown>
@@ -592,7 +593,7 @@ export async function setup() {
 		sliceLifecycleUpdate$: new IsolatedSubject(),
 		serverEventIdCounter: undefined!,
 		squadIdCounter: undefined!,
-		sliceInitMtxs: new Map(),
+		sliceLifecycleMtxs: new Map(),
 	}
 
 	const lastEventRes = await ctx
@@ -618,35 +619,52 @@ export async function setup() {
 	await Promise.all(Settings.listServerEntries().map((entry) => ensureSliceRunning(entry.id)))
 }
 
+// Serializes every transition of a server's slice between running and not, so that no two of setup, teardown and restart can
+// interleave and observe each other's half-applied state. Per-server, so unrelated servers never wait on each other.
+//
+// The mutex is not reentrant, so the *Locked functions below are the composable pieces: anything already holding the lock must
+// call those, and only the exported entry points may take it. Acquiring it twice in one call stack self-deadlocks.
+function withSliceLock<T>(serverId: string, fn: () => Promise<T>): Promise<T> {
+	let mtx = globalState.sliceLifecycleMtxs.get(serverId)
+	if (!mtx) {
+		mtx = new Mutex()
+		globalState.sliceLifecycleMtxs.set(serverId, mtx)
+	}
+	return mtx.runExclusive(fn)
+}
+
 // boots a slice for the given server if it's enabled, not broken, and doesn't already have one running
 export async function ensureSliceRunning(serverId: string) {
-	let mtx = globalState.sliceInitMtxs.get(serverId)
-	mtx ??= new Mutex()
-	globalState.sliceInitMtxs.set(serverId, mtx)
-	await mtx.acquire()
-	try {
-		if (globalState.slices.has(serverId)) return
-		const entry = Settings.getServerEntry(serverId)
-		if (!entry || !entry.enabled || entry.broken) return
-		const ctx = getBaseCtx()
-		const serverState = await getServerState({ ...ctx, serverId })
-		await setupSlice(ctx, serverState)
-		log.info(`Server ${serverId} setup complete`)
-	} finally {
-		mtx.release()
-	}
+	await withSliceLock(serverId, () => ensureSliceRunningLocked(serverId))
+}
+
+async function ensureSliceRunningLocked(serverId: string) {
+	if (globalState.slices.has(serverId)) return
+	const entry = Settings.getServerEntry(serverId)
+	if (!entry || !entry.enabled || entry.broken) return
+	const ctx = getBaseCtx()
+	const serverState = await getServerState({ ...ctx, serverId })
+	await setupSlice(ctx, serverState)
+	log.info(`Server ${serverId} setup complete`)
+}
+
+// tears down the slice for a server if one is running. No-op otherwise.
+async function destroySliceIfRunningLocked(serverId: string) {
+	const slice = globalState.slices.get(serverId)
+	if (!slice) return false
+	await destroyServer({ ...getBaseCtx(), ...slice })
+	return true
 }
 
 // tears down and re-creates the slice for a server, picking up the latest settings from the DB. If the server isn't currently
 // running (disabled, broken, or not yet started), this just ensures it's running per the usual rules -- it never force-starts it.
 export async function restartSliceIfRunning(serverId: string) {
-	const ctx = getBaseCtx()
-	const slice = globalState.slices.get(serverId)
-	if (slice) {
-		await destroyServer({ ...ctx, ...slice })
-		log.info(`Server ${serverId} slice destroyed for restart`)
-	}
-	await ensureSliceRunning(serverId)
+	await withSliceLock(serverId, async () => {
+		if (await destroySliceIfRunningLocked(serverId)) {
+			log.info(`Server ${serverId} slice destroyed for restart`)
+		}
+		await ensureSliceRunningLocked(serverId)
+	})
 }
 
 // forces the admin list resource to refetch (picking up the latest adminListSources/adminIdentifyingPermissions) without
@@ -682,17 +700,20 @@ async function setupSlice(ctx: C.Db & CS.AbortSignal, serverState: SS.ServerStat
 	const layersStatusExt$: SquadServer['layersStatusExt$'] = getLayersStatusExt$(serverId)
 
 	// a resource that keeps failing after retries means the slice can't do its job -- tear the slice down instead of
-	// letting the error escalate to an unhandled rejection and crash the process
-	const onResourceFatalError = async (err: unknown) => {
+	// letting the error escalate to an unhandled rejection and crash the process.
+	//
+	// Takes the slice lock, which is safe only because AsyncResource discards this callback's return rather than awaiting it:
+	// nothing holding the lock ever waits on us, so there is no cycle. If the resource dies mid-setup we simply queue behind
+	// setupSlice and tear down the slice it just finished building.
+	const destroySliceAfterFatalError = async (err: unknown) => {
 		log.error(err, `Server ${serverId}: async resource failed permanently, destroying slice`)
-		const slice = globalState.slices.get(serverId)
-		if (!slice) return
 		try {
-			await destroyServer({ ...getBaseCtx(), ...slice })
+			await withSliceLock(serverId, () => destroySliceIfRunningLocked(serverId))
 		} catch (destroyErr) {
 			log.error(destroyErr, `Server ${serverId}: failed to destroy slice after fatal resource error`)
 		}
 	}
+	const onResourceFatalError = (err: unknown) => void destroySliceAfterFatalError(err)
 
 	const adminList = (() => {
 		const adminListTTL = HumanTime.parse('1h')
@@ -1093,8 +1114,7 @@ async function setupSlice(ctx: C.Db & CS.AbortSignal, serverState: SS.ServerStat
 	void adminList.get(slice)
 
 	server.cleanupId = CleanupSys.register(async () => {
-		const ctx = resolveSliceCtx(getBaseCtx(), serverId)
-		await destroyServer(ctx)
+		await withSliceLock(serverId, () => destroySliceIfRunningLocked(serverId))
 	})
 	log.info('Initialized server %s', serverId)
 	if (Settings.GLOBAL_SETTINGS.warnOnSlmStart) {
@@ -1516,6 +1536,8 @@ function mergeEventsByTime(serverEvents: SE.Event[], appEvents: AppEvents.AppEve
 	return [...wrapped, ...serverEvents].sort((a, b) => timeOf(a) - timeOf(b))
 }
 
+// Must be called with the server's slice lock held (see withSliceLock) -- it is the unlocked primitive, and callers reach it
+// through destroySliceIfRunningLocked. Taking the lock here instead would self-deadlock the callers that already hold it.
 const destroyServer = C.spanOp('destroyServer', { module, levels: { event: 'info' } }, async (ctx: C.ServerSlice) => {
 	if (ctx.server.destroyed) return
 	log.info(`destroying server slice ${ctx.serverId}`)
@@ -1525,7 +1547,6 @@ const destroyServer = C.spanOp('destroyServer', { module, levels: { event: 'info
 	const cleanupId = ctx.server.cleanupId
 	if (cleanupId !== null) CleanupSys.unregister(cleanupId)
 	await Cleanup.runCleanup({ ...CS.init(), ...ctx, log }, ctx.cleanup)
-	// we're not dealing with mutexes yet Sadge
 	globalState.slices.delete(ctx.serverId)
 	globalState.sliceLifecycleUpdate$.next(ctx.serverId)
 })
@@ -1764,20 +1785,14 @@ export async function disableServer(serverId: string) {
 	const res = await Settings.setServerEnabled(ctx, serverId, false)
 	if (res.code !== 'ok') return res
 
-	const slice = globalState.slices.get(serverId)
-	if (slice) {
-		await destroyServer({ ...ctx, ...slice })
-	}
+	await withSliceLock(serverId, () => destroySliceIfRunningLocked(serverId))
 	log.info('Server %s disabled', serverId)
 	return { code: 'ok' as const }
 }
 
 export async function deleteServer(serverId: string) {
 	const ctx = getBaseCtx()
-	const slice = globalState.slices.get(serverId)
-	if (slice) {
-		await destroyServer({ ...ctx, ...slice })
-	}
+	await withSliceLock(serverId, () => destroySliceIfRunningLocked(serverId))
 	return await Settings.deleteServerEntry(ctx, serverId)
 }
 


### PR DESCRIPTION
> [!WARNING]
> This description is LLM-authored, which CONTRIBUTING requires it not be. Please rewrite it before this leaves draft.

Two fixes found while writing an architecture overview of the repo. Split out of that docs branch so they can be reviewed on their own; the doc itself is not included here.

## fix: serialize slice lifecycle transitions per server

`destroyServer` mutated `globalState.slices` without holding the per-server mutex that `ensureSliceRunning` takes, so the two could interleave. This was flagged in-code as `// we're not dealing with mutexes yet Sadge`.

The race is worse than an unguarded map write, because `destroyServer` deletes the entry only *after* awaiting cleanup. During teardown the slice is still in the map while already flagged destroyed, so:

- A disable racing an enable can leave the server **enabled with no slice running**: `ensureSliceRunning` sees the entry, concludes a slice is up, returns early, and then `destroyServer` deletes it. Nothing retries.
- A destroy landing mid-setup can leave `setupSlice` registering a cleanup task against an already-destroyed slice, leaking the `CleanupSys` registration.

The mutex is widened from setup to every running/not-running transition, via `withSliceLock`.

### On not deadlocking

`async-mutex`'s `Mutex` is not reentrant, and `restartSliceIfRunning` calls destroy then ensure, so naively locking `destroyServer` self-deadlocks on the first restart. Each operation is therefore split into a locking entry point and an unlocked `*Locked` internal; compound operations take the lock once and call the internals. `destroyServer` stays the unlocked primitive, with a comment saying so.

The subtle one worth a reviewer's eye: a resource's `onFatalError` tears down the slice and **can fire while `setupSlice` still holds the lock**. That is safe only because `AsyncResource` types the callback `(err) => void` and discards its return rather than awaiting it (`async-resource.ts:163`), so nothing holding the lock ever waits on the teardown. It queues behind setup and tears down the slice setup just built. Making that callback awaited would close the cycle and deadlock, so that reasoning is recorded in a comment at the callback.

## chore: remove dead initModule.ts and deriveStores

- `src/lib/initModule.ts` was a 0-byte file with no importers. The `initModule` everything actually imports is the unrelated otel/pino helper in `src/server/logger.ts`.
- `ZusUtils.deriveStores` was a one-line bare re-export of `derive-zustand` with zero call sites, so the dependency goes with it.

## Testing

`tsc -b --force` clean, 532 unit tests, 25 integration tests, oxlint clean on the touched files. The integration suite boots real slices against the emulator, so a lifecycle deadlock would surface there as a hang.

No new automated test covers the race itself: it is a timing-dependent interleaving between two lifecycle calls, and I did not want to add a test that passes for the wrong reason. Happy to add one driving concurrent `enableServer`/`disableServer` if you want it.

## LLM authorship disclosure

Both commits were written by Claude Opus 4.8 (Claude Code), including this description. Per CONTRIBUTING the description needs to be human-authored and the change human-understood before review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
