### PR TITLE
back the database up before migrating it, adopt that backup, and add a way to put one back

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,14 +63,10 @@ SUPER_USERS=
 # where backups are written locally.
 # BACKUPS_DIR=./data/backups
 
-# how many periodic backups to keep, locally and (if configured) on the sftp target. 0 keeps all of them.
+# how many backups to keep, locally and (if configured) on the sftp target. 0 keeps all of them. Periodic and
+# pre-migration backups share this one window, with a single exception: the most recent pre-migration backup is
+# always kept, however old it is, since it is the only thing a bad upgrade can be rolled back to.
 # BACKUPS_RETAIN_COUNT=10
-
-# how many pre-migration backups to keep in BACKUPS_DIR. One is always taken before any migration is applied,
-# whether by the app at boot or by `pnpm db:migrate:prod`, and they are retained separately from the periodic
-# ones (and never uploaded). The default keeps only the most recent, which is the database as it was before the
-# migration you last ran. 0 keeps all of them.
-# PRE_MIGRATION_BACKUPS_RETAIN_COUNT=1
 
 # server events belonging to matches that ended longer ago than this duration (e.g. 90d) are deleted as part of
 # each backup run, before the backup is taken. The most recent matches are always kept regardless of age. Unset

--- a/.env.example
+++ b/.env.example
@@ -63,8 +63,14 @@ SUPER_USERS=
 # where backups are written locally.
 # BACKUPS_DIR=./data/backups
 
-# how many backups to keep, locally and (if configured) on the sftp target. 0 keeps all of them.
+# how many periodic backups to keep, locally and (if configured) on the sftp target. 0 keeps all of them.
 # BACKUPS_RETAIN_COUNT=10
+
+# how many pre-migration backups to keep in BACKUPS_DIR. One is always taken before any migration is applied,
+# whether by the app at boot or by `pnpm db:migrate:prod`, and they are retained separately from the periodic
+# ones (and never uploaded). The default keeps only the most recent, which is the database as it was before the
+# migration you last ran. 0 keeps all of them.
+# PRE_MIGRATION_BACKUPS_RETAIN_COUNT=1
 
 # server events belonging to matches that ended longer ago than this duration (e.g. 90d) are deleted as part of
 # each backup run, before the backup is taken. The most recent matches are always kept regardless of age. Unset

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -19,7 +19,7 @@ mkdir squad-layer-manager && cd squad-layer-manager
 curl -fsSL https://raw.githubusercontent.com/Tactrigsds/squad-layer-manager/main/install.sh | bash
 ```
 
-This lays down the files a deployment is made of: `docker-compose.yaml`, a `.env` (copied from `.env.example`, which is left alongside it), a `.env.secrets` (copied from `.env.secrets.example`, and holding every credential SLM reads: see [3.3](#33-secrets)), the `edit-global-settings.sh` helper, and an `observability/` directory of Grafana, Loki, and Tempo config. It also creates a `data/` directory, which houses the database file and any persistent data and will be bind-mounted to the app container. You can use a volume instead if you prefer. It refuses to run if any of those files, or `data/`, already exists, so it never overwrites an existing deployment.
+This lays down the files a deployment is made of: `docker-compose.yaml`, a `.env` (copied from `.env.example`, which is left alongside it), a `.env.secrets` (copied from `.env.secrets.example`, and holding every credential SLM reads: see [3.3](#33-secrets)), the `edit-global-settings.sh` and `restore.sh` helpers, and an `observability/` directory of Grafana, Loki, and Tempo config. It also creates a `data/` directory, which houses the database file and any persistent data and will be bind-mounted to the app container. You can use a volume instead if you prefer. It refuses to run if any of those files, or `data/`, already exists, so it never overwrites an existing deployment.
 
 #### 3.2. Discord app
 
@@ -129,15 +129,14 @@ Check the environment variable's description of BM_PAT for the required scopes.
 
 #### 3.6. Backups
 
-There are two kinds, and only the periodic one is optional.
+Backups happen for two reasons. One of them is not optional.
 
 **Before every migration**, always, the database is snapshotted into `BACKUPS_DIR` first. This happens whether
 the app applies migrations itself at boot (`DB_AUTOMIGRATE`, the default) or you run `pnpm db:migrate:prod`
 yourself, and it is what you restore from if an upgrade turns out to have been a mistake. Nothing is applied if
-the snapshot fails. These are named `slm-backup-db-pre-migration-20260713-134504.sqlite3.gz` and retained
-separately from the periodic ones, so a busy backup schedule can't age out the one snapshot you need;
-`PRE_MIGRATION_BACKUPS_RETAIN_COUNT` (default `1`, keeping the database as it was before the migration you last
-ran) is how many are kept. They are never uploaded.
+the snapshot fails. These are named `slm-backup-db-pre-migration-20260713-134504.sqlite3.gz`, and the most
+recent one is never deleted by retention, however old it gets: it is the only way back from the migration it
+was taken before.
 
 A migration will not run against a database another process has open: SQLite offers no safe way to change a
 schema under a running app, so the app refuses to boot, or `db:migrate` exits non-zero, rather than risk it.
@@ -145,6 +144,10 @@ An idle app still counts as using the database. Stop it first.
 
 **Periodically** is off by default. Set `AUTOMATIC_BACKUPS_PERIODIC` to a duration (e.g. `72h`) and the app will
 snapshot its database on that interval, optionally shipping each one to an SFTP host.
+
+The two share a schedule and a retention window rather than running as separate systems. A backup taken to
+migrate counts as that interval's backup (it is uploaded and recorded like any other), so an upgrade doesn't
+produce two copies of the same database a minute apart, and the next periodic one is a full interval later.
 
 A snapshot is taken with sqlite's online backup API, so it is a consistent point-in-time copy taken without
 locking the app out of its own database, and it is gzipped (typically 5-10x smaller) before being stored or
@@ -155,35 +158,54 @@ The schedule is anchored to the last backup that actually happened, not to boot,
 often than the interval still gets backed up. A backup that came due while the app was down is taken shortly
 after it comes back up.
 
-| variable                             | default          | what it does                                                                   |
-| ------------------------------------ | ---------------- | ------------------------------------------------------------------------------ |
-| `AUTOMATIC_BACKUPS_PERIODIC`         | unset (disabled) | how often to back up, e.g. `72h`                                               |
-| `EVENT_HISTORY_RETENTION_PERIOD`     | unset (disabled) | prune server events older than this, e.g. `90d` (see below)                    |
-| `BACKUPS_DIR`                        | `./data/backups` | where backups are written                                                      |
-| `BACKUPS_RETAIN_COUNT`               | `10`             | how many periodic backups to keep, locally and remotely. `0` keeps all of them |
-| `PRE_MIGRATION_BACKUPS_RETAIN_COUNT` | `1`              | how many pre-migration backups to keep. `0` keeps all of them                  |
-| `BACKUP_SFTP_HOST`                   | unset (disabled) | setting this uploads each backup to that host                                  |
-| `BACKUP_SFTP_PORT`                   | `22`             |                                                                                |
-| `BACKUP_SFTP_USERNAME`               |                  | required when a host is set                                                    |
-| `BACKUP_SFTP_PASSWORD`               |                  | this or a private key is required when a host is set                           |
-| `BACKUP_SFTP_PRIVATE_KEY_PATH`       |                  | path to a private key, as an alternative to a password                         |
-| `BACKUP_SFTP_PRIVATE_KEY_PASSPHRASE` |                  | if the key needs one                                                           |
-| `BACKUP_SFTP_DIR`                    | `.`              | remote directory, created if missing                                           |
+| variable                             | default          | what it does                                                          |
+| ------------------------------------ | ---------------- | --------------------------------------------------------------------- |
+| `AUTOMATIC_BACKUPS_PERIODIC`         | unset (disabled) | how often to back up, e.g. `72h`                                      |
+| `EVENT_HISTORY_RETENTION_PERIOD`     | unset (disabled) | prune server events older than this, e.g. `90d` (see below)           |
+| `BACKUPS_DIR`                        | `./data/backups` | where backups are written                                             |
+| `BACKUPS_RETAIN_COUNT`               | `10`             | how many backups to keep, locally and remotely. `0` keeps all of them |
+| `BACKUP_SFTP_HOST`                   | unset (disabled) | setting this uploads each backup to that host                         |
+| `BACKUP_SFTP_PORT`                   | `22`             |                                                                       |
+| `BACKUP_SFTP_USERNAME`               |                  | required when a host is set                                           |
+| `BACKUP_SFTP_PASSWORD`               |                  | this or a private key is required when a host is set                  |
+| `BACKUP_SFTP_PRIVATE_KEY_PATH`       |                  | path to a private key, as an alternative to a password                |
+| `BACKUP_SFTP_PRIVATE_KEY_PASSPHRASE` |                  | if the key needs one                                                  |
+| `BACKUP_SFTP_DIR`                    | `.`              | remote directory, created if missing                                  |
 
-Two SLM instances must not share a `BACKUP_SFTP_DIR` unless their databases are named differently: retention
-deletes any backup matching its own name, so they would prune each other's.
+`BACKUPS_RETAIN_COUNT` is one window over both kinds: the newest N backups survive, whatever they were taken
+for, plus the most recent pre-migration one, so you may hold N+1. Two SLM instances must not share a
+`BACKUP_SFTP_DIR` unless their databases are named differently: retention deletes any backup matching its own
+name, so they would prune each other's.
 
 A failed upload does not fail the backup. The local copy is still written, and the audit event records that it
 never left the box.
 
-To restore from a backup, with the application stopped, replace the database with the decompressed snapshot:
+##### Restoring
+
+`restore.sh` stops the app, puts a backup back, and starts it again:
 
 ```sh
-# while the application is OFF:
-# delete or move the existing database and its -wal and -shm files
-rm data/db.sqlite3*
-gunzip -c slm-backup-db-20260713-134504.sqlite3.gz > data/db.sqlite3
+./restore.sh --list             # what backups there are
+./restore.sh --pre-migration    # the snapshot taken before the last migration: undo a bad upgrade
+./restore.sh --latest           # the newest backup of any kind
+./restore.sh --from slm-backup-db-20260713-134504.sqlite3.gz    # a specific one
 ```
+
+`--from` also takes a path, which is how you restore a backup fetched back off the SFTP target. Drop it in
+`data/backups` or pass the full path.
+
+The database being replaced is kept, renamed to `db.sqlite3.replaced-<timestamp>` next to it, because a restore
+is otherwise the one operation with no undo. Delete it once you are happy. The restore is checked
+(`integrity_check`) before anything is moved, so a corrupt archive costs nothing.
+
+Prefer this over doing it by hand. `gunzip -c backup.gz > data/db.sqlite3` looks complete and is not: the old
+`-wal` file is still sitting there, SQLite replays it over the file you just restored, and you silently get the
+**old** database back, with `integrity_check` calling it fine. Restoring while the app is running is worse, as
+the app goes on writing to a database that is no longer at that path, and those writes are simply lost.
+
+If you are rolling back a bad upgrade, roll the image back too. Restoring a pre-migration backup and then
+starting the same version just applies the same migration again (the restore says so if the database it put
+back is behind the build).
 
 #### 3.7. Event history retention
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -129,8 +129,22 @@ Check the environment variable's description of BM_PAT for the required scopes.
 
 #### 3.6. Backups
 
-Off by default. Set `AUTOMATIC_BACKUPS_PERIODIC` to a duration (e.g. `72h`) and the app will snapshot its
-database on that interval, optionally shipping each one to an SFTP host.
+There are two kinds, and only the periodic one is optional.
+
+**Before every migration**, always, the database is snapshotted into `BACKUPS_DIR` first. This happens whether
+the app applies migrations itself at boot (`DB_AUTOMIGRATE`, the default) or you run `pnpm db:migrate:prod`
+yourself, and it is what you restore from if an upgrade turns out to have been a mistake. Nothing is applied if
+the snapshot fails. These are named `slm-backup-db-pre-migration-20260713-134504.sqlite3.gz` and retained
+separately from the periodic ones, so a busy backup schedule can't age out the one snapshot you need;
+`PRE_MIGRATION_BACKUPS_RETAIN_COUNT` (default `1`, keeping the database as it was before the migration you last
+ran) is how many are kept. They are never uploaded.
+
+A migration will not run against a database another process has open: SQLite offers no safe way to change a
+schema under a running app, so the app refuses to boot, or `db:migrate` exits non-zero, rather than risk it.
+An idle app still counts as using the database. Stop it first.
+
+**Periodically** is off by default. Set `AUTOMATIC_BACKUPS_PERIODIC` to a duration (e.g. `72h`) and the app will
+snapshot its database on that interval, optionally shipping each one to an SFTP host.
 
 A snapshot is taken with sqlite's online backup API, so it is a consistent point-in-time copy taken without
 locking the app out of its own database, and it is gzipped (typically 5-10x smaller) before being stored or
@@ -141,19 +155,20 @@ The schedule is anchored to the last backup that actually happened, not to boot,
 often than the interval still gets backed up. A backup that came due while the app was down is taken shortly
 after it comes back up.
 
-| variable                             | default          | what it does                                                  |
-| ------------------------------------ | ---------------- | ------------------------------------------------------------- |
-| `AUTOMATIC_BACKUPS_PERIODIC`         | unset (disabled) | how often to back up, e.g. `72h`                              |
-| `EVENT_HISTORY_RETENTION_PERIOD`     | unset (disabled) | prune server events older than this, e.g. `90d` (see below)   |
-| `BACKUPS_DIR`                        | `./data/backups` | where backups are written                                     |
-| `BACKUPS_RETAIN_COUNT`               | `10`             | how many to keep, locally and remotely. `0` keeps all of them |
-| `BACKUP_SFTP_HOST`                   | unset (disabled) | setting this uploads each backup to that host                 |
-| `BACKUP_SFTP_PORT`                   | `22`             |                                                               |
-| `BACKUP_SFTP_USERNAME`               |                  | required when a host is set                                   |
-| `BACKUP_SFTP_PASSWORD`               |                  | this or a private key is required when a host is set          |
-| `BACKUP_SFTP_PRIVATE_KEY_PATH`       |                  | path to a private key, as an alternative to a password        |
-| `BACKUP_SFTP_PRIVATE_KEY_PASSPHRASE` |                  | if the key needs one                                          |
-| `BACKUP_SFTP_DIR`                    | `.`              | remote directory, created if missing                          |
+| variable                             | default          | what it does                                                                   |
+| ------------------------------------ | ---------------- | ------------------------------------------------------------------------------ |
+| `AUTOMATIC_BACKUPS_PERIODIC`         | unset (disabled) | how often to back up, e.g. `72h`                                               |
+| `EVENT_HISTORY_RETENTION_PERIOD`     | unset (disabled) | prune server events older than this, e.g. `90d` (see below)                    |
+| `BACKUPS_DIR`                        | `./data/backups` | where backups are written                                                      |
+| `BACKUPS_RETAIN_COUNT`               | `10`             | how many periodic backups to keep, locally and remotely. `0` keeps all of them |
+| `PRE_MIGRATION_BACKUPS_RETAIN_COUNT` | `1`              | how many pre-migration backups to keep. `0` keeps all of them                  |
+| `BACKUP_SFTP_HOST`                   | unset (disabled) | setting this uploads each backup to that host                                  |
+| `BACKUP_SFTP_PORT`                   | `22`             |                                                                                |
+| `BACKUP_SFTP_USERNAME`               |                  | required when a host is set                                                    |
+| `BACKUP_SFTP_PASSWORD`               |                  | this or a private key is required when a host is set                           |
+| `BACKUP_SFTP_PRIVATE_KEY_PATH`       |                  | path to a private key, as an alternative to a password                         |
+| `BACKUP_SFTP_PRIVATE_KEY_PASSPHRASE` |                  | if the key needs one                                                           |
+| `BACKUP_SFTP_DIR`                    | `.`              | remote directory, created if missing                                           |
 
 Two SLM instances must not share a `BACKUP_SFTP_DIR` unless their databases are named differently: retention
 deletes any backup matching its own name, so they would prune each other's.
@@ -203,7 +218,8 @@ Once you've got the app running, you'll be able to sign in with discord OAuth, a
 docker compose pull && docker compose up -d
 ```
 
-Migrations are applied on boot by default; set `DB_AUTOMIGRATE=0` to disable this behavior.
+Migrations are applied on boot by default; set `DB_AUTOMIGRATE=0` to disable this behavior. Either way the
+database is backed up first (see [3.6](#36-backups)), so a bad upgrade is recoverable.
 
 An install that predates `.env.secrets` keeps working untouched: SLM reads the credentials from wherever it
 finds them. To move them out of the environment (see [3.3](#33-secrets)), take the six variables in that

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,7 @@ FILES=(
 	.env.example
 	.env.secrets.example
 	edit-global-settings.sh
+	restore.sh
 	observability/README.md
 	observability/loki-config.yaml
 	observability/tempo-config.yaml
@@ -90,7 +91,7 @@ for file in "${FILES[@]}"; do
 	say "  + $file"
 done
 
-chmod +x "$DIR/edit-global-settings.sh"
+chmod +x "$DIR/edit-global-settings.sh" "$DIR/restore.sh"
 
 cp "$DIR/.env.example" "$DIR/.env"
 say "  + .env (from .env.example)"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "tsx --tsconfig tsconfig.node.json src/scripts/migrate.ts",
 		"db:migrate:prod": "node --enable-source-maps dist-server/scripts/migrate.js",
+		"db:restore": "tsx --tsconfig tsconfig.node.json src/scripts/restore.ts",
+		"db:restore:prod": "node --enable-source-maps dist-server/scripts/restore.js",
 		"setup:hooks": "git config core.hooksPath .githooks && chmod +x .githooks/pre-push .githooks/pre-push.js",
 		"remove:hooks": "git config --unset core.hooksPath",
 		"test:e2e": "pnpm run build:engine && NODE_ENV=production vite build && playwright test",

--- a/restore.sh
+++ b/restore.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Restore the database from a backup, stopping the app around it.
+#
+#   ./restore.sh --list                  what backups there are
+#   ./restore.sh --pre-migration         the snapshot taken before the last migration (undo a bad upgrade)
+#   ./restore.sh --latest                the newest backup of any kind
+#   ./restore.sh --from <file>           a specific one, e.g. one pulled back off the sftp target into ./data/backups
+#
+# The app must not be running: it would go on writing to the database being replaced and lose those writes, without
+# an error anywhere. This stops it first and starts it again afterwards. The database being replaced is kept, renamed
+# aside, because a restore is otherwise the one operation with no undo.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+command -v docker > /dev/null 2>&1 || { echo "error: docker is required" >&2; exit 1; }
+docker compose version > /dev/null 2>&1 || { echo "error: docker compose (v2) is required" >&2; exit 1; }
+
+# --list reads the backups directory and touches nothing, so it has no business stopping anybody's app
+for arg in "$@"; do
+	if [[ $arg == --list ]]; then
+		exec docker compose run --rm app pnpm db:restore:prod "$@"
+	fi
+done
+
+was_running=""
+if [[ -n "$(docker compose ps --status running --quiet app 2>/dev/null)" ]]; then
+	was_running=1
+	echo "stopping the app..."
+	docker compose stop app
+fi
+
+# deliberately not `set -e`'d into oblivion: on failure we want to say what state things are in, and a failed restore
+# must not silently take the app back up on a database nobody has looked at.
+status=0
+docker compose run --rm app pnpm db:restore:prod "$@" || status=$?
+
+if [[ $status -ne 0 ]]; then
+	echo >&2
+	echo "restore failed (exit $status). The app is left stopped: check the message above before starting it." >&2
+	[[ -n $was_running ]] && echo "Start it with 'docker compose up -d app' once you are happy." >&2
+	exit $status
+fi
+
+if [[ -n $was_running ]]; then
+	echo "starting the app..."
+	docker compose up -d app
+fi

--- a/restore.sh
+++ b/restore.sh
@@ -35,6 +35,16 @@ fi
 status=0
 docker compose run --rm app pnpm db:restore:prod "$@" || status=$?
 
+# 2 means the restore worked but the database it put back is behind this image. Starting the app now would migrate it
+# straight back up, which for a rollback undoes the exact thing you just did -- so this is the one success we refuse to
+# restart on.
+if [[ $status -eq 2 ]]; then
+	echo
+	echo "The app is left stopped on purpose. Point docker-compose.yaml at the version this database belongs to, then:"
+	echo "  docker compose up -d app"
+	exit 0
+fi
+
 if [[ $status -ne 0 ]]; then
 	echo >&2
 	echo "restore failed (exit $status). The app is left stopped: check the message above before starting it." >&2

--- a/rolldown-server-prod.config.ts
+++ b/rolldown-server-prod.config.ts
@@ -26,6 +26,9 @@ export default defineConfig({
 		// .ts migration registry ships in the slim prod image; .sql files are read at
 		// runtime from the copied drizzle-sqlite/ folder.
 		'scripts/migrate': 'src/scripts/migrate.ts',
+		// Puts a backup back (`pnpm db:restore:prod`, or the restore.sh wrapper). Bundled for the same reason as the
+		// migration runner: it reads the migration registry, to say whether the database it restored is behind the build.
+		'scripts/restore': 'src/scripts/restore.ts',
 		// Layer-db (re)build pipeline. Bundled so it can run in the slim prod image against a
 		// mounted /app/data volume; it builds the layer db schema in-process (no drizzle-kit),
 		// so no config/src tree is needed at runtime. Run via `pnpm run preprocess:prod`.

--- a/src/models/app-events.models.test.ts
+++ b/src/models/app-events.models.test.ts
@@ -65,6 +65,25 @@ describe('app-events persistence', () => {
 		expect(AppEvents.fromRow(row)).toBeNull()
 	})
 
+	it('reads a backup row from before pre-migration backups existed as a periodic one', () => {
+		const e = AppEvents.create<AppEvents.BackupCreated>({
+			type: 'BACKUP_CREATED',
+			actor: { type: 'system' },
+			serverId: null,
+			matchId: null,
+			causeId: null,
+			fileName: 'slm-backup-db-20260713-134504.sqlite3.gz',
+			sizeBytes: 1024,
+			reason: 'periodic',
+			durationMs: 80,
+		})
+		const row = AppEvents.toRow(e) as any
+		// an old row, written before the reason was recorded. Every one of them is a periodic backup: there was no
+		// other kind. Dropping them (fromRow returns null on a parse failure) would put holes in the audit log.
+		row.data = superjson.serialize({ fileName: e.fileName, sizeBytes: e.sizeBytes, durationMs: e.durationMs })
+		expect(AppEvents.fromRow(row)).toEqual(e)
+	})
+
 	it('round-trips a settings diff, including a path that had no previous value', () => {
 		const e = AppEvents.create<AppEvents.SettingsUpdated>({
 			type: 'SETTINGS_UPDATED',

--- a/src/models/app-events.models.ts
+++ b/src/models/app-events.models.ts
@@ -199,7 +199,11 @@ export type AppRestarted = z.infer<typeof AppRestartedSchema>
 export const BackupCreatedSchema = event('BACKUP_CREATED', {
 	fileName: z.string(),
 	sizeBytes: z.number(),
-	durationMs: z.number(),
+	// why the snapshot was taken. Defaulted rather than required: every row written before pre-migration backups
+	// existed is a periodic one, so old rows read back correctly instead of being dropped by fromRow.
+	reason: z.enum(['periodic', 'pre-migration']).default('periodic'),
+	// absent for a pre-migration backup: it is taken before the app (and this event system) is up, so nobody timed it
+	durationMs: z.number().optional(),
 	// absent when no sftp target is configured; false when the upload failed (the local backup still exists)
 	uploaded: z.boolean().optional(),
 	// the prune that ran before the snapshot was taken. absent when event-history retention is disabled.
@@ -530,7 +534,8 @@ export function describeAppEvent(e: AppEvent): string {
 			const pruned = e.pruned && e.pruned.events > 0
 				? `, pruned ${e.pruned.events} events from ${e.pruned.matches} ${e.pruned.matches === 1 ? 'match' : 'matches'}`
 				: ''
-			return `backed up the database to ${e.fileName} (${size})${upload}${pruned}`
+			const what = e.reason === 'pre-migration' ? 'backed up the database before migrating it' : 'backed up the database'
+			return `${what}, to ${e.fileName} (${size})${upload}${pruned}`
 		}
 	}
 }

--- a/src/scripts/migrate.ts
+++ b/src/scripts/migrate.ts
@@ -30,7 +30,7 @@ try {
 		sqlDir: SQL_DIR,
 		tsMigrations,
 		log: (msg) => console.log(msg),
-		backup: { dbPath: ENV.DB_PATH, dir: ENV.BACKUPS_DIR, retainCount: ENV.PRE_MIGRATION_BACKUPS_RETAIN_COUNT },
+		backup: { dbPath: ENV.DB_PATH, dir: ENV.BACKUPS_DIR, retainCount: ENV.BACKUPS_RETAIN_COUNT },
 	})
 	console.log(applied.length ? `done — applied ${applied.length} migration(s)` : 'done — already up to date')
 } catch (err) {

--- a/src/scripts/migrate.ts
+++ b/src/scripts/migrate.ts
@@ -1,4 +1,5 @@
 import { tsMigrations } from '@/migrations/registry'
+import * as Env from '@/server/env'
 import * as Migrate from '@/server/migrate'
 import DatabaseConstructor from 'better-sqlite3'
 import fs from 'node:fs'
@@ -8,58 +9,35 @@ import path from 'node:path'
 // `pnpm db:migrate`; in the production image via `pnpm db:migrate:prod` (bundled
 // to dist-server/scripts/migrate.js, alongside the shipped drizzle-sqlite/ folder).
 //
-// DB_PATH default is kept in sync with drizzle.config.ts and src/server/env.ts.
-const DB_PATH = process.env.DB_PATH ?? './data/db.sqlite3'
+// The db is snapshotted first and held offline for the run; the app applying migrations itself at boot
+// (DB_AUTOMIGRATE, the default) goes through the same path. See src/server/migrate.ts.
+
+Env.ensureEnvSetup()
+const ENV = Env.getEnvBuilder({ ...Env.groups.db, ...Env.groups.backups })()
 const SQL_DIR = path.resolve(process.cwd(), 'drizzle-sqlite')
 
-fs.mkdirSync(path.dirname(DB_PATH), { recursive: true })
-const driver = new DatabaseConstructor(DB_PATH)
+fs.mkdirSync(path.dirname(ENV.DB_PATH), { recursive: true })
+const driver = new DatabaseConstructor(ENV.DB_PATH)
 driver.pragma('journal_mode = WAL')
-// Short timeout on purpose: if the write lock is held, that almost certainly means the app is
-// running, and we want to fail fast with a clear message rather than block (and rather than
-// contend for the lock and risk stalling live app writes). SQLite has no online-DDL guarantees,
-// so migrating against a running app is unsafe regardless.
+// Short timeout on purpose: if the db is in use, that almost certainly means the app is running, and we want to fail
+// fast with a clear message rather than block (and rather than contend for the lock and risk stalling live app writes).
 driver.pragma('busy_timeout = 2000')
 // foreign_keys intentionally left at its default (OFF) during migrations, matching
 // drizzle-kit — table-rebuild migrations rely on FK enforcement being off.
 
-function isDatabaseLocked(err: unknown): boolean {
-	for (let e: unknown = err; e != null; e = (e as { cause?: unknown }).cause) {
-		const code = (e as { code?: string }).code
-		if (code === 'SQLITE_BUSY' || code === 'SQLITE_BUSY_SNAPSHOT') return true
-	}
-	return false
-}
-
-function abortLocked(): never {
-	console.error(
-		'Database is locked — the app appears to be running. Stop the server before migrating; '
-			+ 'SQLite cannot safely apply schema changes against a live app.',
-	)
-	process.exit(1)
-}
-
-// Probe the write lock before touching anything, so the common case (app running the whole time)
-// fails immediately with a friendly message instead of mid-run.
 try {
-	driver.exec('BEGIN IMMEDIATE')
-	driver.exec('ROLLBACK')
-} catch (err) {
-	if (driver.inTransaction) driver.exec('ROLLBACK')
-	if (isDatabaseLocked(err)) abortLocked()
-	throw err
-}
-
-try {
-	const { applied } = await Migrate.runMigrations(driver, {
+	const { applied } = await Migrate.applyPendingMigrations(driver, {
 		sqlDir: SQL_DIR,
 		tsMigrations,
 		log: (msg) => console.log(msg),
+		backup: { dbPath: ENV.DB_PATH, dir: ENV.BACKUPS_DIR, retainCount: ENV.PRE_MIGRATION_BACKUPS_RETAIN_COUNT },
 	})
 	console.log(applied.length ? `done — applied ${applied.length} migration(s)` : 'done — already up to date')
 } catch (err) {
-	// The app could have grabbed the lock between the probe and now (or mid-run).
-	if (isDatabaseLocked(err)) abortLocked()
+	if (err instanceof Migrate.DbInUseError) {
+		console.error(err.message)
+		process.exit(1)
+	}
 	throw err
 } finally {
 	driver.close()

--- a/src/scripts/restore.ts
+++ b/src/scripts/restore.ts
@@ -1,0 +1,226 @@
+import { tsMigrations } from '@/migrations/registry'
+import * as DbBackup from '@/server/db-backup'
+import * as Env from '@/server/env'
+import * as Migrate from '@/server/migrate'
+import DatabaseConstructor, { type Database } from 'better-sqlite3'
+import * as DateFns from 'date-fns'
+import fs from 'node:fs'
+import path from 'node:path'
+import * as readline from 'node:readline/promises'
+import * as Stream from 'node:stream/promises'
+import { parseArgs } from 'node:util'
+import * as Zlib from 'node:zlib'
+
+// Puts a backup back. Run in dev via `pnpm db:restore`; in the production image via `pnpm db:restore:prod`, with the
+// app stopped (restore.sh does that choreography for a docker deployment).
+//
+// This exists because the manual version is a loaded gun. `gunzip -c backup.gz > data/db.sqlite3` looks complete and
+// is not: the old -wal is still sitting there, sqlite replays it over the file you just restored, and you silently get
+// the OLD database back, with integrity_check calling it ok. Doing it while the app is running is worse -- the app
+// keeps writing to an unlinked inode, those writes are lost, and nothing anywhere raises an error.
+
+const args = parseArgs({
+	options: {
+		list: { type: 'boolean', default: false },
+		'pre-migration': { type: 'boolean', default: false },
+		latest: { type: 'boolean', default: false },
+		from: { type: 'string' },
+		yes: { type: 'boolean', short: 'y', default: false },
+	},
+	allowPositionals: false,
+})
+
+Env.ensureEnvSetup()
+const ENV = Env.getEnvBuilder({ ...Env.groups.db, ...Env.groups.backups })()
+const DB_PATH = path.resolve(ENV.DB_PATH)
+
+type Candidate = { fileName: string; path: string; kind: DbBackup.BackupKind; takenAt: Date; sizeBytes: number }
+
+// every backup of this database, newest first, whatever kind
+function candidates(): Candidate[] {
+	if (!fs.existsSync(ENV.BACKUPS_DIR)) return []
+	const names = fs.readdirSync(ENV.BACKUPS_DIR)
+	return DbBackup.backupFiles(names, ENV.DB_PATH).map(({ name, kind }) => {
+		const p = path.join(ENV.BACKUPS_DIR, name)
+		const stat = fs.statSync(p)
+		return { fileName: name, path: p, kind, takenAt: stat.mtime, sizeBytes: stat.size }
+	})
+}
+
+function describe(c: Candidate) {
+	const size = `${(c.sizeBytes / 1024 / 1024).toFixed(1)} MB`
+	return `${c.fileName}\n    ${c.kind}, taken ${DateFns.format(c.takenAt, 'yyyy-MM-dd HH:mm:ss')}, ${size}`
+}
+
+function list() {
+	const all = candidates()
+	if (all.length === 0) {
+		console.log(`no backups of ${path.basename(ENV.DB_PATH)} in ${ENV.BACKUPS_DIR}`)
+		return
+	}
+	console.log(`backups of ${path.basename(ENV.DB_PATH)} in ${ENV.BACKUPS_DIR}, newest first:\n`)
+	for (const c of all) console.log(`  ${describe(c)}\n`)
+}
+
+function pick(): Candidate {
+	if (args.values.from) {
+		// an explicit path is taken as given: it's the escape hatch for a backup pulled off the sftp target, which
+		// won't be in BACKUPS_DIR and may not be named the way we name ours.
+		const p = path.resolve(args.values.from)
+		const fallback = path.join(ENV.BACKUPS_DIR, args.values.from)
+		const resolved = fs.existsSync(p) ? p : fs.existsSync(fallback) ? fallback : null
+		if (!resolved) fail(`no such backup: ${args.values.from}`)
+		const stat = fs.statSync(resolved)
+		return {
+			fileName: path.basename(resolved),
+			path: resolved,
+			kind: DbBackup.kindOf(path.basename(resolved), ENV.DB_PATH) ?? 'periodic',
+			takenAt: stat.mtime,
+			sizeBytes: stat.size,
+		}
+	}
+
+	const all = candidates()
+	const wanted = args.values['pre-migration'] ? all.filter(c => c.kind === 'pre-migration') : all
+	if (wanted.length === 0) {
+		fail(
+			args.values['pre-migration']
+				? `no pre-migration backups of ${path.basename(ENV.DB_PATH)} in ${ENV.BACKUPS_DIR}`
+				: `no backups of ${path.basename(ENV.DB_PATH)} in ${ENV.BACKUPS_DIR}`,
+		)
+	}
+	return wanted[0]
+}
+
+function fail(msg: string): never {
+	console.error(msg)
+	process.exit(1)
+}
+
+async function gunzipTo(sourcePath: string, destPath: string) {
+	await Stream.pipeline(fs.createReadStream(sourcePath), Zlib.createGunzip(), fs.createWriteStream(destPath))
+}
+
+// a sqlite database is three files, and the other two are only ever meaningful next to the one they were named for
+function rmDbFiles(dbPath: string, opts?: { keepDb?: boolean }) {
+	for (const suffix of opts?.keepDb ? ['-wal', '-shm'] : ['', '-wal', '-shm']) fs.rmSync(dbPath + suffix, { force: true })
+}
+
+function assertIntact(dbPath: string) {
+	const db = new DatabaseConstructor(dbPath, { readonly: true })
+	try {
+		const res = db.pragma('integrity_check', { simple: true })
+		if (res !== 'ok') fail(`the restored database failed its integrity check (${String(res)}); the original is untouched`)
+	} finally {
+		db.close()
+	}
+}
+
+// how far the restored db is behind the code that is about to run against it. Restoring a pre-migration backup and then
+// starting the same build just re-applies the migration you were rolling back, which is worth saying out loud.
+function pendingAfterRestore(dbPath: string) {
+	const db = new DatabaseConstructor(dbPath, { readonly: true })
+	try {
+		return Migrate.getPendingMigrations(db, { sqlDir: path.resolve(process.cwd(), 'drizzle-sqlite'), tsMigrations })
+	} finally {
+		db.close()
+	}
+}
+
+async function confirm(question: string) {
+	if (args.values.yes) return
+	if (!process.stdin.isTTY) fail('refusing to restore without a confirmation. Re-run with --yes if you mean it.')
+	const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+	try {
+		const answer = await rl.question(`${question} [y/N] `)
+		if (!/^y(es)?$/i.test(answer.trim())) fail('aborted, nothing was changed')
+	} finally {
+		rl.close()
+	}
+}
+
+// Proves nothing else has the database open, and keeps holding it while we look at the backup. An idle app holds no
+// write lock, so this has to be the exclusive-lock check the migration runner uses rather than a BEGIN IMMEDIATE probe
+// -- restoring under a running app leaves it writing to an unlinked inode, losing those writes silently.
+function lockExisting(): Database | null {
+	if (!fs.existsSync(DB_PATH)) return null
+	const driver = new DatabaseConstructor(DB_PATH)
+	driver.pragma('busy_timeout = 2000')
+	try {
+		driver.prepare('SELECT 1 FROM sqlite_master').get()
+		driver.pragma('locking_mode = EXCLUSIVE')
+		driver.exec('BEGIN IMMEDIATE')
+		driver.exec('ROLLBACK')
+		return driver
+	} catch (err) {
+		if (driver.inTransaction) driver.exec('ROLLBACK')
+		driver.close()
+		if (Migrate.isDatabaseLocked(err)) {
+			fail(
+				`${ENV.DB_PATH} is open in another process. Stop the app before restoring: it would go on writing to the database you are replacing, and lose those writes.`,
+			)
+		}
+		throw err
+	}
+}
+
+if (args.values.list) {
+	list()
+	process.exit(0)
+}
+if (!args.values.from && !args.values['pre-migration'] && !args.values.latest) {
+	console.error('pick a backup: --latest (newest of any kind), --pre-migration (newest taken before a migration),')
+	console.error('or --from <file>. `--list` shows what there is.')
+	process.exit(1)
+}
+
+const backup = pick()
+const existing = lockExisting()
+try {
+	console.log(`restoring ${describe(backup)}\n     -> ${ENV.DB_PATH}\n`)
+	if (existing) {
+		await confirm(`this replaces the current ${ENV.DB_PATH}. It will be kept, renamed aside. Continue?`)
+	}
+
+	// unpacked and checked before anything is moved, so a corrupt archive costs nothing
+	const tmpPath = `${DB_PATH}.restore-${process.pid}.tmp`
+	rmDbFiles(tmpPath)
+	await gunzipTo(backup.path, tmpPath)
+	assertIntact(tmpPath)
+
+	const pending = pendingAfterRestore(tmpPath)
+
+	// An archive holds one file, so a -wal next to the unpacked copy can only be the empty one sqlite made for the
+	// read-only connections just above, which they aren't allowed to tidy up on close. Left there they would follow
+	// the rename by name and be replayed over the restored database.
+	rmDbFiles(tmpPath, { keepDb: true })
+
+	// The lock has to go before the files move: sqlite finds a database's -wal by its path, so a connection left open
+	// across the rename would checkpoint into whatever ends up at that path -- i.e. into the database we just restored.
+	// Closing is also what folds the current db's -wal into it, which is what makes the copy we keep self-contained.
+	if (existing) {
+		existing.pragma('wal_checkpoint(TRUNCATE)')
+		existing.close()
+
+		const asideName = `${path.basename(DB_PATH)}.replaced-${DateFns.format(new Date(), 'yyyyMMdd-HHmmss')}`
+		const asidePath = path.join(path.dirname(DB_PATH), asideName)
+		fs.renameSync(DB_PATH, asidePath)
+		// checkpointed above, so these hold nothing the copy needs. Left in place they would be replayed over the
+		// restored database, which is the whole trap this script exists to avoid.
+		rmDbFiles(DB_PATH, { keepDb: true })
+		console.log(`kept the database you replaced as ${asidePath}`)
+	}
+
+	fs.renameSync(tmpPath, DB_PATH)
+	console.log(`restored ${ENV.DB_PATH} from ${backup.fileName}`)
+
+	if (pending.length > 0) {
+		console.log(
+			`\nnote: this database is ${pending.length} migration(s) behind this build (${pending.join(', ')}).\n`
+				+ 'Starting the app will apply them again (taking a fresh pre-migration backup first). If you are rolling back a\n'
+				+ 'bad upgrade, roll the image back to the matching version too, or the migration you just undid comes straight back.',
+		)
+	}
+} finally {
+	if (existing?.open) existing.close()
+}

--- a/src/scripts/restore.ts
+++ b/src/scripts/restore.ts
@@ -34,6 +34,11 @@ Env.ensureEnvSetup()
 const ENV = Env.getEnvBuilder({ ...Env.groups.db, ...Env.groups.backups })()
 const DB_PATH = path.resolve(ENV.DB_PATH)
 
+// The restore worked, but the database it put back is older than the code about to run against it -- which is the
+// normal case for `--pre-migration`, and the one where blindly starting the app would apply the migration again and
+// undo the whole exercise. Its own exit code so the wrapper can decline to restart the app rather than walk into that.
+const EXIT_RESTORED_BEHIND_BUILD = 2
+
 type Candidate = { fileName: string; path: string; kind: DbBackup.BackupKind; takenAt: Date; sizeBytes: number }
 
 // every backup of this database, newest first, whatever kind
@@ -217,9 +222,10 @@ try {
 	if (pending.length > 0) {
 		console.log(
 			`\nnote: this database is ${pending.length} migration(s) behind this build (${pending.join(', ')}).\n`
-				+ 'Starting the app will apply them again (taking a fresh pre-migration backup first). If you are rolling back a\n'
-				+ 'bad upgrade, roll the image back to the matching version too, or the migration you just undid comes straight back.',
+				+ 'Starting this version of the app applies them again, undoing the restore -- so roll the image back to the version\n'
+				+ 'this database belongs to before starting it (or set DB_AUTOMIGRATE=0 if you know what you are doing).',
 		)
+		process.exit(EXIT_RESTORED_BEHIND_BUILD)
 	}
 } finally {
 	if (existing?.open) existing.close()

--- a/src/server/db-backup.test.ts
+++ b/src/server/db-backup.test.ts
@@ -1,0 +1,96 @@
+import * as DbBackup from '@/server/db-backup'
+import { describe, expect, test } from 'vitest'
+
+const DB_PATH = './data/db.sqlite3'
+
+const periodic = (stamp: string) => `slm-backup-db-${stamp}.sqlite3.gz`
+const preMigration = (stamp: string) => `slm-backup-db-pre-migration-${stamp}.sqlite3.gz`
+
+function stale(fileNames: string[], retainCount: number, keep?: string) {
+	return DbBackup.staleBackupFiles(fileNames, { dbPath: DB_PATH, retainCount, keep })
+}
+
+describe('backupFiles', () => {
+	test('orders both kinds chronologically, newest first', () => {
+		// the pre-migration one is the newest, but sorts last of the three by name: `-pre-migration` comes between the
+		// db name and the timestamp, so a name sort would put it first and the dates would mean nothing
+		const files = DbBackup.backupFiles(
+			[periodic('20260101-000000'), preMigration('20260716-120000'), periodic('20260301-000000')],
+			DB_PATH,
+		)
+		expect(files.map(f => f.name)).toEqual([
+			preMigration('20260716-120000'),
+			periodic('20260301-000000'),
+			periodic('20260101-000000'),
+		])
+	})
+
+	test('ignores anything that is not a backup of this database', () => {
+		const files = DbBackup.backupFiles([
+			periodic('20260101-000000'),
+			'slm-backup-otherdb-20260101-000000.sqlite3.gz',
+			'notes.txt',
+			'slm-backup-db-20260101-000000.sqlite3.gz.tmp',
+			'slm-backup-db.sqlite3.gz',
+		], DB_PATH)
+		expect(files.map(f => f.name)).toEqual([periodic('20260101-000000')])
+	})
+
+	test('reads the kind back off the name', () => {
+		expect(DbBackup.kindOf(preMigration('20260101-000000'), DB_PATH)).toBe('pre-migration')
+		expect(DbBackup.kindOf(periodic('20260101-000000'), DB_PATH)).toBe('periodic')
+		expect(DbBackup.kindOf('slm-backup-otherdb-20260101-000000.sqlite3.gz', DB_PATH)).toBeNull()
+	})
+
+	test('names a backup so it parses back', () => {
+		for (const kind of DbBackup.BACKUP_KINDS) {
+			const name = DbBackup.fileName(DB_PATH, kind, new Date(2026, 6, 16, 13, 40, 16))
+			expect(DbBackup.parseBackupFile(name, DB_PATH)).toEqual({ name, kind, stamp: '20260716134016' })
+		}
+	})
+})
+
+describe('staleBackupFiles', () => {
+	test('keeps the newest N across both kinds', () => {
+		const files = [
+			periodic('20260103-000000'),
+			preMigration('20260102-000000'),
+			periodic('20260101-000000'),
+		]
+		expect(stale(files, 2)).toEqual([periodic('20260101-000000')])
+	})
+
+	test('never prunes the newest pre-migration backup, however far outside the window it is', () => {
+		const rollbackPoint = preMigration('20260101-000000')
+		const files = [periodic('20260705-000000'), periodic('20260704-000000'), periodic('20260703-000000'), rollbackPoint]
+
+		// a window of 2 is filled by periodic backups alone, all of them newer than the rollback point
+		expect(stale(files, 2)).toEqual([periodic('20260703-000000')])
+	})
+
+	test('pins only the newest pre-migration backup, not every one of them', () => {
+		const files = [
+			periodic('20260705-000000'),
+			preMigration('20260704-000000'),
+			preMigration('20260101-000000'),
+		]
+		expect(stale(files, 1)).toEqual([preMigration('20260101-000000')])
+	})
+
+	test('keeps everything when the count is 0', () => {
+		const files = [periodic('20260101-000000'), preMigration('20250101-000000'), periodic('20240101-000000')]
+		expect(stale(files, 0)).toEqual([])
+	})
+
+	test('never prunes the file it was told to keep', () => {
+		const current = periodic('20260101-000000')
+		// deliberately the oldest, so only `keep` can save it
+		const files = [periodic('20260703-000000'), periodic('20260702-000000'), current]
+		expect(stale(files, 1, current)).toEqual([periodic('20260702-000000')])
+	})
+
+	test('leaves files it did not write alone', () => {
+		const files = ['db.sqlite3.replaced-20260101-000000', 'slm-backup-otherdb-20260101-000000.sqlite3.gz', 'readme.md']
+		expect(stale(files, 1)).toEqual([])
+	})
+})

--- a/src/server/db-backup.ts
+++ b/src/server/db-backup.ts
@@ -1,0 +1,93 @@
+import * as DateFns from 'date-fns'
+import fs from 'node:fs'
+import path from 'node:path'
+import * as Stream from 'node:stream/promises'
+import * as Zlib from 'node:zlib'
+
+// Naming, writing and retention of database backups, shared by the two things that take them: the periodic
+// backup loop (backups.server.ts) and the pre-migration snapshot (migrate.ts). This module deliberately knows
+// nothing about env, logging or the driver -- the pre-migration path runs before any of that is set up.
+//
+// Backups are named slm-backup-<db filename>[-pre-migration]-<yyyyMMdd>-<HHmmss>.sqlite3.gz, e.g.
+// slm-backup-db-20260713-134016.sqlite3.gz for the default ./data/db.sqlite3. Naming them after the source db
+// means backups of different databases (two SLM instances pointed at one sftp directory, say) can't be mistaken
+// for each other -- which matters because retention deletes everything matching the prefix. Restore with
+// `gunzip -c <backup> > db.sqlite3`.
+export const BACKUP_FILE_EXT = '.sqlite3.gz'
+
+// the two kinds are named apart because they are retained apart: each kind's retention only ever sees, and only
+// ever deletes, files of its own kind. A pre-migration snapshot is the one backup you want to still be there
+// after a migration went wrong, so a busy periodic schedule must not be able to age it out.
+export type BackupKind = 'periodic' | 'pre-migration'
+
+function filePrefix(dbPath: string, kind: BackupKind) {
+	const db = path.basename(dbPath).replace(/\.sqlite3?$/, '')
+	return kind === 'pre-migration' ? `slm-backup-${db}-pre-migration` : `slm-backup-${db}`
+}
+
+function filePattern(dbPath: string, kind: BackupKind) {
+	return new RegExp(`^${escapeRegExp(filePrefix(dbPath, kind))}-\\d{8}-\\d{6}${escapeRegExp(BACKUP_FILE_EXT)}$`)
+}
+
+export function fileName(dbPath: string, kind: BackupKind, at = new Date()) {
+	return `${filePrefix(dbPath, kind)}-${DateFns.format(at, 'yyyyMMdd-HHmmss')}${BACKUP_FILE_EXT}`
+}
+
+// the backups of THIS database, of THIS kind, in a directory, newest first (the timestamp is in the name, so
+// lexical order is chronological). Anything else there is left alone: retention only ever deletes files we wrote
+// ourselves. The periodic pattern requires the timestamp immediately after the db name, so it can't match a
+// pre-migration backup.
+export function backupFiles(fileNames: string[], dbPath: string, kind: BackupKind) {
+	const pattern = filePattern(dbPath, kind)
+	return fileNames.filter(name => pattern.test(name)).sort().reverse()
+}
+
+// the backups beyond retainCount, and never the one we just took. retainCount 0 keeps all of them.
+export function staleBackupFiles(fileNames: string[], opts: { dbPath: string; kind: BackupKind; retainCount: number; keep?: string }) {
+	if (opts.retainCount === 0) return []
+	return backupFiles(fileNames, opts.dbPath, opts.kind).slice(opts.retainCount).filter(name => name !== opts.keep)
+}
+
+export function pruneBackups(opts: { dir: string; dbPath: string; kind: BackupKind; retainCount: number; keep?: string }) {
+	const stale = staleBackupFiles(fs.readdirSync(opts.dir), opts)
+	for (const name of stale) fs.rmSync(path.join(opts.dir, name), { force: true })
+	return stale
+}
+
+// streamed, so a multi-GB db never lands in memory. gzip is a big win here: a sqlite file is mostly repetitive page
+// structure and text, and the archive is what we ship over sftp and keep N copies of at both ends.
+async function gzipFile(sourcePath: string, destPath: string, signal?: AbortSignal) {
+	await Stream.pipeline(
+		fs.createReadStream(sourcePath),
+		Zlib.createGzip(),
+		fs.createWriteStream(destPath),
+		{ signal },
+	)
+}
+
+// Snapshots the db via `snapshot` (which sqlite writes itself) and gzips it into destPath. Both stages land on temp
+// names and only the finished archive is renamed into place (atomic within the directory): a crash at either step
+// would otherwise leave a partial file that still looks like a complete backup.
+export async function writeBackup(
+	opts: { destPath: string; snapshot: (destPath: string) => Promise<unknown>; signal?: AbortSignal },
+) {
+	fs.mkdirSync(path.dirname(opts.destPath), { recursive: true })
+	const snapshotPath = `${opts.destPath}.snapshot.tmp`
+	const tmpPath = `${opts.destPath}.tmp`
+	let snapshotBytes: number
+	try {
+		await opts.snapshot(snapshotPath)
+		snapshotBytes = fs.statSync(snapshotPath).size
+		await gzipFile(snapshotPath, tmpPath, opts.signal)
+		fs.renameSync(tmpPath, opts.destPath)
+	} finally {
+		// the snapshot is an intermediate: it's the archive we keep. removed on the happy path too.
+		fs.rmSync(snapshotPath, { force: true })
+		fs.rmSync(tmpPath, { force: true })
+	}
+	return { sizeBytes: fs.statSync(opts.destPath).size, snapshotBytes }
+}
+
+function escapeRegExp(str: string) {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/src/server/db-backup.ts
+++ b/src/server/db-backup.ts
@@ -15,10 +15,10 @@ import * as Zlib from 'node:zlib'
 // `gunzip -c <backup> > db.sqlite3`.
 export const BACKUP_FILE_EXT = '.sqlite3.gz'
 
-// the two kinds are named apart because they are retained apart: each kind's retention only ever sees, and only
-// ever deletes, files of its own kind. A pre-migration snapshot is the one backup you want to still be there
-// after a migration went wrong, so a busy periodic schedule must not be able to age it out.
-export type BackupKind = 'periodic' | 'pre-migration'
+// why a backup was taken. It is in the file name so that a pre-migration snapshot can be found (and restored) as
+// what it is, and so that retention can pin the newest one -- not because the two are separate collections.
+export const BACKUP_KINDS = ['periodic', 'pre-migration'] as const
+export type BackupKind = typeof BACKUP_KINDS[number]
 
 function filePrefix(dbPath: string, kind: BackupKind) {
 	const db = path.basename(dbPath).replace(/\.sqlite3?$/, '')
@@ -26,29 +26,62 @@ function filePrefix(dbPath: string, kind: BackupKind) {
 }
 
 function filePattern(dbPath: string, kind: BackupKind) {
-	return new RegExp(`^${escapeRegExp(filePrefix(dbPath, kind))}-\\d{8}-\\d{6}${escapeRegExp(BACKUP_FILE_EXT)}$`)
+	return new RegExp(`^${escapeRegExp(filePrefix(dbPath, kind))}-(\\d{8})-(\\d{6})${escapeRegExp(BACKUP_FILE_EXT)}$`)
 }
 
 export function fileName(dbPath: string, kind: BackupKind, at = new Date()) {
 	return `${filePrefix(dbPath, kind)}-${DateFns.format(at, 'yyyyMMdd-HHmmss')}${BACKUP_FILE_EXT}`
 }
 
-// the backups of THIS database, of THIS kind, in a directory, newest first (the timestamp is in the name, so
-// lexical order is chronological). Anything else there is left alone: retention only ever deletes files we wrote
-// ourselves. The periodic pattern requires the timestamp immediately after the db name, so it can't match a
-// pre-migration backup.
-export function backupFiles(fileNames: string[], dbPath: string, kind: BackupKind) {
-	const pattern = filePattern(dbPath, kind)
-	return fileNames.filter(name => pattern.test(name)).sort().reverse()
+// `stamp` is the file's yyyyMMddHHmmss, which sorts chronologically. The whole NAME does not: `-pre-migration`
+// sits between the db name and the timestamp, so sorting on that orders every pre-migration backup after every
+// periodic one, whatever their dates -- which, once the two share a retention window, silently means retention
+// keeps the wrong files.
+export type BackupFile = { name: string; kind: BackupKind; stamp: string }
+
+// null when the file isn't a backup of this database at all. Anything that returns null is left alone forever:
+// retention only ever deletes files we wrote ourselves.
+export function parseBackupFile(fileName: string, dbPath: string): BackupFile | null {
+	// pre-migration first: the periodic pattern requires the timestamp immediately after the db name, so the two
+	// can't both match, but trying the more specific one first makes that a property of this function rather than
+	// of the regexes.
+	for (const kind of ['pre-migration', 'periodic'] as const) {
+		const match = filePattern(dbPath, kind).exec(fileName)
+		if (match) return { name: fileName, kind, stamp: match[1] + match[2] }
+	}
+	return null
 }
 
-// the backups beyond retainCount, and never the one we just took. retainCount 0 keeps all of them.
-export function staleBackupFiles(fileNames: string[], opts: { dbPath: string; kind: BackupKind; retainCount: number; keep?: string }) {
+export function kindOf(fileName: string, dbPath: string): BackupKind | null {
+	return parseBackupFile(fileName, dbPath)?.kind ?? null
+}
+
+// every backup of THIS database in a directory listing, newest first, of either kind
+export function backupFiles(fileNames: string[], dbPath: string): BackupFile[] {
+	return fileNames
+		.map(name => parseBackupFile(name, dbPath))
+		.filter((f): f is BackupFile => f !== null)
+		.sort((a, b) => (a.stamp < b.stamp ? 1 : a.stamp > b.stamp ? -1 : 0))
+}
+
+// The backups outside the retention window: one window over both kinds, because a backup is a backup and the
+// database only has one past. retainCount 0 keeps all of them.
+//
+// One exception, and it is the reason the kinds are distinguishable at all: the newest pre-migration backup is
+// never pruned, however far out of the window it has fallen. It is the only thing a bad upgrade can be rolled
+// back to, and it is precisely the deployments backing up most often that would otherwise age it out within the
+// day. That makes the count a floor rather than a hard cap -- you can end up holding retainCount + 1.
+export function staleBackupFiles(fileNames: string[], opts: { dbPath: string; retainCount: number; keep?: string }) {
 	if (opts.retainCount === 0) return []
-	return backupFiles(fileNames, opts.dbPath, opts.kind).slice(opts.retainCount).filter(name => name !== opts.keep)
+	const all = backupFiles(fileNames, opts.dbPath)
+	const kept = new Set(all.slice(0, opts.retainCount).map(f => f.name))
+	const rollbackPoint = all.find(f => f.kind === 'pre-migration')
+	if (rollbackPoint) kept.add(rollbackPoint.name)
+	if (opts.keep) kept.add(opts.keep)
+	return all.filter(f => !kept.has(f.name)).map(f => f.name)
 }
 
-export function pruneBackups(opts: { dir: string; dbPath: string; kind: BackupKind; retainCount: number; keep?: string }) {
+export function pruneBackups(opts: { dir: string; dbPath: string; retainCount: number; keep?: string }) {
 	const stale = staleBackupFiles(fs.readdirSync(opts.dir), opts)
 	for (const name of stale) fs.rmSync(path.join(opts.dir, name), { force: true })
 	return stale

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -60,7 +60,7 @@ export async function setup(opts?: { skipMigrationCheck?: boolean }) {
 			const { applied } = await Migrate.applyPendingMigrations(driver, {
 				...migrateOpts,
 				log: (msg) => log.info(msg),
-				backup: { dbPath: ENV.DB_PATH, dir: ENV.BACKUPS_DIR, retainCount: ENV.PRE_MIGRATION_BACKUPS_RETAIN_COUNT },
+				backup: { dbPath: ENV.DB_PATH, dir: ENV.BACKUPS_DIR, retainCount: ENV.BACKUPS_RETAIN_COUNT },
 			})
 			if (applied.length > 0) log.info('DB_AUTOMIGRATE applied %d migration(s)', applied.length)
 		} else {

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -19,7 +19,8 @@ let log!: CS.Logger
 
 let driver!: Database
 
-const envBuilder = Env.getEnvBuilder({ ...Env.groups.general, ...Env.groups.db })
+// backups: boot takes a pre-migration snapshot, which is named after DB_PATH and retained in BACKUPS_DIR
+const envBuilder = Env.getEnvBuilder({ ...Env.groups.general, ...Env.groups.db, ...Env.groups.backups })
 let ENV!: ReturnType<typeof envBuilder>
 let db: Db
 let dbRedactParams: Db
@@ -49,13 +50,18 @@ export async function setup(opts?: { skipMigrationCheck?: boolean }) {
 
 	// Schema-vs-code guard, run while foreign_keys is still at its default (OFF) — same as the
 	// standalone `pnpm db:migrate`, since drizzle-kit's table-rebuild migrations require FK
-	// enforcement off. Boot applies pending migrations itself by default; with DB_AUTOMIGRATE off it
-	// merely refuses to run against a DB that's behind, never taking a write lock or mutating the DB
-	// here. Scripts that intentionally run pre-migration pass skipMigrationCheck.
+	// enforcement off. Boot applies pending migrations itself by default, backing the DB up first and
+	// refusing to touch a DB another process has open; with DB_AUTOMIGRATE off it merely refuses to run
+	// against a DB that's behind, never taking a write lock or mutating the DB here. Scripts that
+	// intentionally run pre-migration pass skipMigrationCheck.
 	if (!opts?.skipMigrationCheck) {
 		const migrateOpts = { sqlDir: path.resolve(process.cwd(), 'drizzle-sqlite'), tsMigrations }
 		if (ENV.DB_AUTOMIGRATE) {
-			const { applied } = await Migrate.runMigrations(driver, { ...migrateOpts, log: (msg) => log.info(msg) })
+			const { applied } = await Migrate.applyPendingMigrations(driver, {
+				...migrateOpts,
+				log: (msg) => log.info(msg),
+				backup: { dbPath: ENV.DB_PATH, dir: ENV.BACKUPS_DIR, retainCount: ENV.PRE_MIGRATION_BACKUPS_RETAIN_COUNT },
+			})
 			if (applied.length > 0) log.info('DB_AUTOMIGRATE applied %d migration(s)', applied.length)
 		} else {
 			const pending = Migrate.getPendingMigrations(driver, migrateOpts)

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -171,13 +171,8 @@ export const groups = {
 			envExample: { dev: { include: 'omit' } },
 		}),
 		BACKUPS_RETAIN_COUNT: ParsedIntSchema.pipe(z.number().min(0)).default(10).meta({
-			description: 'how many periodic backups to keep, locally and (if configured) on the sftp target. 0 keeps all of them.',
-			envExample: { dev: { include: 'omit' } },
-		}),
-
-		PRE_MIGRATION_BACKUPS_RETAIN_COUNT: ParsedIntSchema.pipe(z.number().min(0)).default(1).meta({
 			description:
-				'how many pre-migration backups to keep in BACKUPS_DIR. One is always taken before any migration is applied, whether by the app at boot or by `pnpm db:migrate:prod`, and they are retained separately from the periodic ones (and never uploaded). The default keeps only the most recent, which is the database as it was before the migration you last ran. 0 keeps all of them.',
+				'how many backups to keep, locally and (if configured) on the sftp target. 0 keeps all of them. Periodic and pre-migration backups share this one window, with a single exception: the most recent pre-migration backup is always kept, however old it is, since it is the only thing a bad upgrade can be rolled back to.',
 			envExample: { dev: { include: 'omit' } },
 		}),
 

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -171,7 +171,13 @@ export const groups = {
 			envExample: { dev: { include: 'omit' } },
 		}),
 		BACKUPS_RETAIN_COUNT: ParsedIntSchema.pipe(z.number().min(0)).default(10).meta({
-			description: 'how many backups to keep, locally and (if configured) on the sftp target. 0 keeps all of them.',
+			description: 'how many periodic backups to keep, locally and (if configured) on the sftp target. 0 keeps all of them.',
+			envExample: { dev: { include: 'omit' } },
+		}),
+
+		PRE_MIGRATION_BACKUPS_RETAIN_COUNT: ParsedIntSchema.pipe(z.number().min(0)).default(1).meta({
+			description:
+				'how many pre-migration backups to keep in BACKUPS_DIR. One is always taken before any migration is applied, whether by the app at boot or by `pnpm db:migrate:prod`, and they are retained separately from the periodic ones (and never uploaded). The default keeps only the most recent, which is the database as it was before the migration you last ran. 0 keeps all of them.',
 			envExample: { dev: { include: 'omit' } },
 		}),
 

--- a/src/server/migrate.test.ts
+++ b/src/server/migrate.test.ts
@@ -1,0 +1,150 @@
+import DatabaseConstructor, { type Database } from 'better-sqlite3'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Zlib from 'node:zlib'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import * as Migrate from './migrate.ts'
+
+// covers the guarantees applyPendingMigrations exists for -- that a migration can't run against a database
+// something else has open, and can't run without a snapshot of what it is about to change.
+
+let dir: string
+let dbPath: string
+let sqlDir: string
+let backupsDir: string
+let driver: Database
+
+beforeEach(() => {
+	dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slm-migrate-test-'))
+	dbPath = path.join(dir, 'db.sqlite3')
+	sqlDir = path.join(dir, 'sql')
+	backupsDir = path.join(dir, 'backups')
+	fs.mkdirSync(sqlDir)
+	driver = open()
+})
+
+afterEach(() => {
+	if (driver.open) driver.close()
+	fs.rmSync(dir, { recursive: true, force: true })
+})
+
+function open() {
+	const db = new DatabaseConstructor(dbPath)
+	db.pragma('journal_mode = WAL')
+	db.pragma('busy_timeout = 100')
+	return db
+}
+
+function writeSqlMigration(name: string, sql: string) {
+	fs.writeFileSync(path.join(sqlDir, `${name}.sql`), sql)
+}
+
+function apply(retainCount = 1) {
+	return Migrate.applyPendingMigrations(driver, {
+		sqlDir,
+		tsMigrations: [],
+		backup: { dbPath, dir: backupsDir, retainCount },
+	})
+}
+
+// newest first: the timestamp is in the name
+function backupNames() {
+	return fs.existsSync(backupsDir) ? fs.readdirSync(backupsDir).sort().reverse() : []
+}
+
+// backups are timestamped to the second, so two runs in one test land on the same name. Renaming the first out of
+// the way is what a real second-apart run gives you for free.
+function stashBackup(newName: string) {
+	const [name] = backupNames()
+	fs.renameSync(path.join(backupsDir, name), path.join(backupsDir, newName))
+}
+
+function readBackup(name: string) {
+	const restored = path.join(dir, `restored-${name}.sqlite3`)
+	fs.writeFileSync(restored, Zlib.gunzipSync(fs.readFileSync(path.join(backupsDir, name))))
+	const db = new DatabaseConstructor(restored, { readonly: true })
+	try {
+		return db.prepare(`SELECT name FROM sqlite_master WHERE type='table'`).all() as { name: string }[]
+	} finally {
+		db.close()
+	}
+}
+
+describe('applyPendingMigrations', () => {
+	test('backs the db up before applying, and the backup is the pre-migration state', async () => {
+		writeSqlMigration('0001_first', 'CREATE TABLE first (id INTEGER PRIMARY KEY)')
+		await apply()
+		stashBackup('slm-backup-db-pre-migration-20200101-000000.sqlite3.gz')
+
+		writeSqlMigration('0002_second', 'CREATE TABLE second (id INTEGER PRIMARY KEY)')
+		const { applied } = await apply(0)
+		expect(applied).toEqual(['0002_second'])
+
+		const names = backupNames()
+		expect(names.length).toBe(2)
+		// the newest: the db as 0001 left it, which is what a botched 0002 has to be restorable to
+		const tables = readBackup(names[0]).map(t => t.name)
+		expect(tables).toContain('first')
+		expect(tables).not.toContain('second')
+	})
+
+	test('takes no backup when nothing is pending', async () => {
+		writeSqlMigration('0001_first', 'CREATE TABLE first (id INTEGER PRIMARY KEY)')
+		await apply()
+		expect(backupNames().length).toBe(1)
+
+		const { applied } = await apply()
+		expect(applied).toEqual([])
+		expect(backupNames().length).toBe(1)
+	})
+
+	test('retains only the configured number of pre-migration backups', async () => {
+		writeSqlMigration('0001_first', 'CREATE TABLE first (id INTEGER PRIMARY KEY)')
+		await apply()
+		expect(backupNames().length).toBe(1)
+		const old = 'slm-backup-db-pre-migration-20200101-000000.sqlite3.gz'
+		stashBackup(old)
+
+		writeSqlMigration('0002_second', 'CREATE TABLE second (id INTEGER PRIMARY KEY)')
+		await apply()
+		expect(backupNames().length).toBe(1)
+		expect(backupNames()[0]).not.toBe(old)
+	})
+
+	test('leaves periodic backups alone', async () => {
+		fs.mkdirSync(backupsDir, { recursive: true })
+		const periodic = 'slm-backup-db-20200101-000000.sqlite3.gz'
+		fs.writeFileSync(path.join(backupsDir, periodic), '')
+
+		writeSqlMigration('0001_first', 'CREATE TABLE first (id INTEGER PRIMARY KEY)')
+		await apply()
+		expect(backupNames()).toContain(periodic)
+	})
+
+	test('refuses to migrate a db another connection has open, and applies nothing', async () => {
+		writeSqlMigration('0001_first', 'CREATE TABLE first (id INTEGER PRIMARY KEY)')
+		const other = open()
+		// an idle reader, holding no write lock: BEGIN IMMEDIATE would sail straight past this
+		other.prepare(`SELECT 1 FROM sqlite_master`).all()
+		try {
+			await expect(apply()).rejects.toBeInstanceOf(Migrate.DbInUseError)
+		} finally {
+			other.close()
+		}
+		expect(backupNames()).toEqual([])
+		expect(Migrate.getPendingMigrations(driver, { sqlDir, tsMigrations: [] })).toEqual(['0001_first'])
+	})
+
+	test('releases the lock after a run, so the db is usable again', async () => {
+		writeSqlMigration('0001_first', 'CREATE TABLE first (id INTEGER PRIMARY KEY)')
+		await apply()
+
+		const other = open()
+		try {
+			expect(() => other.prepare('SELECT COUNT(*) FROM first').get()).not.toThrow()
+		} finally {
+			other.close()
+		}
+	})
+})

--- a/src/server/migrate.test.ts
+++ b/src/server/migrate.test.ts
@@ -99,28 +99,21 @@ describe('applyPendingMigrations', () => {
 		expect(backupNames().length).toBe(1)
 	})
 
-	test('retains only the configured number of pre-migration backups', async () => {
-		writeSqlMigration('0001_first', 'CREATE TABLE first (id INTEGER PRIMARY KEY)')
-		await apply()
-		expect(backupNames().length).toBe(1)
-		const old = 'slm-backup-db-pre-migration-20200101-000000.sqlite3.gz'
-		stashBackup(old)
-
-		writeSqlMigration('0002_second', 'CREATE TABLE second (id INTEGER PRIMARY KEY)')
-		await apply()
-		expect(backupNames().length).toBe(1)
-		expect(backupNames()[0]).not.toBe(old)
-	})
-
-	test('leaves periodic backups alone', async () => {
+	test('prunes the retention window, which is shared with the periodic backups', async () => {
 		fs.mkdirSync(backupsDir, { recursive: true })
-		const periodic = 'slm-backup-db-20200101-000000.sqlite3.gz'
-		fs.writeFileSync(path.join(backupsDir, periodic), '')
+		for (const day of ['05', '06', '07']) fs.writeFileSync(path.join(backupsDir, `slm-backup-db-202001${day}-000000.sqlite3.gz`), '')
 
+		// window of 2: the snapshot about to be taken, plus the newest periodic one
 		writeSqlMigration('0001_first', 'CREATE TABLE first (id INTEGER PRIMARY KEY)')
-		await apply()
-		expect(backupNames()).toContain(periodic)
+		await apply(2)
+
+		expect(backupNames()).toEqual([
+			expect.stringContaining('-pre-migration-'),
+			'slm-backup-db-20200107-000000.sqlite3.gz',
+		])
 	})
+
+	// retention itself (the shared window, the pinned rollback point) is db-backup.test.ts's business
 
 	test('refuses to migrate a db another connection has open, and applies nothing', async () => {
 		writeSqlMigration('0001_first', 'CREATE TABLE first (id INTEGER PRIMARY KEY)')

--- a/src/server/migrate.ts
+++ b/src/server/migrate.ts
@@ -1,6 +1,7 @@
 import type { Database } from 'better-sqlite3'
 import fs from 'node:fs'
 import path from 'node:path'
+import * as DbBackup from './db-backup.ts'
 
 // Custom migration runner that applies both generated `.sql` schema migrations
 // (authored via `drizzle-kit generate`) and hand-written `.ts` data migrations in
@@ -71,6 +72,97 @@ export async function runMigrations(
 		done.push(m.name)
 	}
 	return { applied: done }
+}
+
+export type BackupConfig = {
+	// the database being migrated, which backups are named after
+	dbPath: string
+	dir: string
+	// how many pre-migration backups to keep, this one included. 0 keeps all of them.
+	retainCount: number
+}
+
+// The database is open in another process, so migrating it now is not safe.
+export class DbInUseError extends Error {}
+
+// The entry point for anything that migrates a database it did not just create: takes the db offline for the
+// duration, snapshots it if there is anything to apply, and only then applies it. `runMigrations` remains the bare
+// runner, for callers holding a database nothing else can reach (a fresh test db, a clone that isn't in place yet).
+export async function applyPendingMigrations(
+	driver: MigrationDriver,
+	opts: { sqlDir: string; tsMigrations: TsMigration[]; log?: (msg: string) => void; backup?: BackupConfig },
+): Promise<{ applied: string[] }> {
+	const log = opts.log ?? (() => {})
+	// checked before taking the lock, because there is usually nothing to do and a caller that isn't migrating has no
+	// business demanding exclusive access: every boot goes through here, and one that overlaps the outgoing process's
+	// shutdown would otherwise refuse to start over migrations it was never going to apply. Re-checked under the lock,
+	// which is the check that counts.
+	if (getPendingMigrations(driver, opts).length === 0) return { applied: [] }
+	return await withDbLockedExclusively(driver, async () => {
+		if (getPendingMigrations(driver, opts).length === 0) return { applied: [] }
+		if (opts.backup) await takePreMigrationBackup(driver, opts.backup, log)
+		return await runMigrations(driver, opts)
+	})
+}
+
+async function takePreMigrationBackup(driver: MigrationDriver, backup: BackupConfig, log: (msg: string) => void) {
+	const name = DbBackup.fileName(backup.dbPath, 'pre-migration')
+	const destPath = path.join(backup.dir, name)
+	const { sizeBytes } = await DbBackup.writeBackup({ destPath, snapshot: (dest) => driver.backup(dest) })
+	log(`wrote pre-migration backup ${destPath} (${sizeBytes} bytes)`)
+	// pruned after the new one is on disk, so a failure here can never leave us with none
+	const pruned = DbBackup.pruneBackups({ ...backup, kind: 'pre-migration', keep: name })
+	for (const stale of pruned) log(`deleted old pre-migration backup ${stale}`)
+}
+
+// Holds sqlite's exclusive lock on the database for the duration of `fn`, so nothing else can read or write it, and
+// throws DbInUseError rather than proceeding if anything else already has it open.
+//
+// An exclusive lock, not `BEGIN IMMEDIATE`. A running app that happens not to be writing holds no write lock, so
+// BEGIN IMMEDIATE succeeds against it and the check would pass exactly when it matters most: sqlite has no online-DDL
+// guarantees, so a table-rebuild migration applied under a live app is how a database gets corrupted. Exclusive
+// locking mode conflicts with any other connection, idle or not, and holds its locks until the mode is dropped again
+// rather than until the transaction ends.
+export async function withDbLockedExclusively<T>(driver: MigrationDriver, fn: () => Promise<T>): Promise<T> {
+	// A WAL connection that goes exclusive before it has ever touched the db keeps its wal-index in heap memory and
+	// never creates the -shm file -- and such a connection can't be put back into NORMAL locking mode at all, short of
+	// reopening it. That's silent: the pragma below reports `normal` afterwards while the file stays locked for the life
+	// of the connection, which for the boot path is the life of the app. One read first, and the -shm exists.
+	driver.prepare('SELECT 1 FROM sqlite_master').get()
+	driver.pragma('locking_mode = EXCLUSIVE')
+	try {
+		// the mode alone takes no locks; the first access after it does
+		driver.exec('BEGIN IMMEDIATE')
+		driver.exec('ROLLBACK')
+	} catch (err) {
+		if (driver.inTransaction) driver.exec('ROLLBACK')
+		driver.pragma('locking_mode = NORMAL')
+		if (isDatabaseLocked(err)) {
+			throw new DbInUseError(
+				`${driver.name} is open in another process. Stop the app (and any other \`db:migrate\` run) before migrating: `
+					+ 'sqlite cannot safely apply schema changes to a database something else is using.',
+				{ cause: err },
+			)
+		}
+		throw err
+	}
+	try {
+		return await fn()
+	} finally {
+		driver.pragma('locking_mode = NORMAL')
+		// NORMAL doesn't take effect until the file is next accessed, so the locks would otherwise stay held for the
+		// life of this connection -- which for the boot path is the life of the app.
+		driver.exec('BEGIN IMMEDIATE')
+		driver.exec('COMMIT')
+	}
+}
+
+export function isDatabaseLocked(err: unknown): boolean {
+	for (let e: unknown = err; e != null; e = (e as { cause?: unknown }).cause) {
+		const code = (e as { code?: string }).code
+		if (code === 'SQLITE_BUSY' || code === 'SQLITE_BUSY_SNAPSHOT') return true
+	}
+	return false
 }
 
 // Read-only: which migrations (by name) exist but aren't recorded as applied. Used by the

--- a/src/server/migrate.ts
+++ b/src/server/migrate.ts
@@ -78,7 +78,8 @@ export type BackupConfig = {
 	// the database being migrated, which backups are named after
 	dbPath: string
 	dir: string
-	// how many pre-migration backups to keep, this one included. 0 keeps all of them.
+	// the retention window this snapshot is pruned against, shared with the periodic backups (BACKUPS_RETAIN_COUNT).
+	// 0 keeps all of them.
 	retainCount: number
 }
 
@@ -111,8 +112,8 @@ async function takePreMigrationBackup(driver: MigrationDriver, backup: BackupCon
 	const { sizeBytes } = await DbBackup.writeBackup({ destPath, snapshot: (dest) => driver.backup(dest) })
 	log(`wrote pre-migration backup ${destPath} (${sizeBytes} bytes)`)
 	// pruned after the new one is on disk, so a failure here can never leave us with none
-	const pruned = DbBackup.pruneBackups({ ...backup, kind: 'pre-migration', keep: name })
-	for (const stale of pruned) log(`deleted old pre-migration backup ${stale}`)
+	const pruned = DbBackup.pruneBackups({ ...backup, keep: name })
+	for (const stale of pruned) log(`deleted old backup ${stale}`)
 }
 
 // Holds sqlite's exclusive lock on the database for the duration of `fn`, so nothing else can read or write it, and

--- a/src/systems/backups.server.ts
+++ b/src/systems/backups.server.ts
@@ -36,28 +36,78 @@ const FAILED_BACKUP_RETRY_DELAY = parseHumanTime('30m')
 export function setup() {
 	log = module.getLogger()
 	ENV = buildEnv()
+	void run()
+}
+
+async function run() {
+	const ctx = DB.addPooledDb({ ...CS.init(), log, signal: CleanupSys.shutdownSignal })
+
+	// before anything else, and whether or not the periodic schedule is even on: a pre-migration backup may have just
+	// been taken, and until it's adopted this system doesn't know it exists.
+	try {
+		await adoptUnrecordedBackups(ctx)
+	} catch (err) {
+		if (!isAbortError(err)) log.error(err, 'failed to account for backups taken outside the schedule')
+	}
 
 	if (ENV.AUTOMATIC_BACKUPS_PERIODIC === undefined) {
 		log.info('automatic backups disabled (AUTOMATIC_BACKUPS_PERIODIC unset)')
 		return
 	}
-	const interval = ENV.AUTOMATIC_BACKUPS_PERIODIC
 	const sftp = getSftpTarget()
-
 	log.info(
 		'automatic backups every %s to %s%s, event history retention: %s',
-		formatHumanTime(interval),
+		formatHumanTime(ENV.AUTOMATIC_BACKUPS_PERIODIC),
 		ENV.BACKUPS_DIR,
 		sftp ? ` (uploading to ${sftp.username}@${sftp.host}:${ENV.BACKUP_SFTP_DIR})` : '',
 		ENV.EVENT_HISTORY_RETENTION_PERIOD === undefined ? 'disabled' : formatHumanTime(ENV.EVENT_HISTORY_RETENTION_PERIOD),
 	)
-
-	void runBackupLoop(interval)
+	await runBackupLoop(ENV.AUTOMATIC_BACKUPS_PERIODIC, ctx)
 }
 
-async function runBackupLoop(interval: number) {
-	const ctx = DB.addPooledDb({ ...CS.init(), log, signal: CleanupSys.shutdownSignal })
+// A pre-migration snapshot is taken by the migration runner (see server/migrate.ts) before the app exists, so it can't
+// record itself, ship itself offsite, or tell the schedule that it happened. Rather than a handoff, we notice it here:
+// a pre-migration backup newer than the newest BACKUP_CREATED event is one nothing has accounted for. Adopting it is
+// what stops the two triggers producing two snapshots of the same database a minute apart -- and it's also how the
+// audit log gets to mention pre-migration backups at all, and how they reach the sftp target.
+//
+// Deliberately driven off what's on disk rather than a handoff file: it costs nothing, it's self-healing, and it
+// equally covers a snapshot taken by an out-of-band `pnpm db:migrate:prod` days before this boot.
+const adoptUnrecordedBackups = C.spanOp('adoptUnrecordedBackups', { module }, async (ctx: C.Db & CS.AbortSignal) => {
+	if (!fs.existsSync(ENV.BACKUPS_DIR)) return
+	const loggedAt = await getLastBackupEventTime(ctx)
+	// only pre-migration backups: a periodic one is written by the loop below, which records its own event, so an
+	// unrecorded periodic file means the event failed to write and re-adopting it would say it happened twice.
+	const unrecorded = DbBackup.backupFiles(fs.readdirSync(ENV.BACKUPS_DIR), ENV.DB_PATH)
+		.filter(f => f.kind === 'pre-migration')
+		.map(f => ({ fileName: f.name, stat: fs.statSync(path.join(ENV.BACKUPS_DIR, f.name)) }))
+		.filter(f => loggedAt === undefined || f.stat.mtimeMs > loggedAt)
+		.reverse() // oldest first, so the audit log reads in the order they were taken
 
+	for (const { fileName, stat } of unrecorded) {
+		ctx.signal.throwIfAborted()
+		const uploaded = await uploadBackup(ctx, path.join(ENV.BACKUPS_DIR, fileName), fileName)
+		await AppEventsSys.persistAppEvent(
+			ctx,
+			AppEvents.create<AppEvents.BackupCreated>({
+				type: 'BACKUP_CREATED',
+				actor: { type: 'system' },
+				serverId: null,
+				matchId: null,
+				causeId: null,
+				// when the snapshot was taken, not when we noticed it: this event is what anchors the schedule
+				time: stat.mtimeMs,
+				fileName,
+				sizeBytes: stat.size,
+				reason: 'pre-migration',
+				uploaded,
+			}),
+		)
+		log.info('recorded pre-migration backup %s, taken %s ago', fileName, formatDurationApprox(Date.now() - stat.mtimeMs))
+	}
+})
+
+async function runBackupLoop(interval: number, ctx: C.Db & CS.AbortSignal) {
 	// the schedule is anchored to the last backup that actually happened, not to boot: a server restarted more often
 	// than the interval would otherwise never reach its first backup at all. A backup taken shortly before a restart
 	// isn't taken again, and one that came due while we were down is taken now (BOOT_SETTLE_DELAY floors the first
@@ -88,23 +138,32 @@ async function runBackupLoop(interval: number) {
 	}
 }
 
-// when the last backup was taken, or null if we can't account for one. The audit log records every backup this app
-// took; the backups dir holds the artifacts. They normally agree, and when they don't (the db was restored from an
-// older snapshot, or the backups dir lives on storage that didn't survive the restart) the older of the two is the
-// honest answer: a missing signal means we have no backup we can point at, so we take one.
-async function getLastBackupTime(ctx: C.Db) {
+async function getLastBackupEventTime(ctx: C.Db) {
 	const [row] = await ctx.db()
 		.select({ time: Schema.appEvents.time })
 		.from(Schema.appEvents)
 		.where(E.eq(Schema.appEvents.type, 'BACKUP_CREATED'))
 		.orderBy(E.desc(Schema.appEvents.time))
 		.limit(1)
-	const loggedAt = row?.time.getTime()
+	return row?.time.getTime()
+}
 
-	const fileNames = fs.existsSync(ENV.BACKUPS_DIR) ? DbBackup.backupFiles(fs.readdirSync(ENV.BACKUPS_DIR), ENV.DB_PATH, 'periodic') : []
-	const writtenAt = fileNames.length === 0
+// when the last backup was taken, or null if we can't account for one. The audit log records every backup this app
+// took; the backups dir holds the artifacts. They normally agree, and when they don't (the db was restored from an
+// older snapshot, or the backups dir lives on storage that didn't survive the restart) the older of the two is the
+// honest answer: a missing signal means we have no backup we can point at, so we take one.
+//
+// Every backup counts, whatever it was taken for: having just snapshotted the database in order to migrate it, there
+// is nothing for a periodic run to add a minute later, and taking one anyway is how the same database got copied twice
+// per upgrade. This is only safe because adoption uploads what it adopts -- anchoring on a local-only file would
+// quietly mean nothing reaches the sftp target for a whole interval, which is the one thing offsite exists to prevent.
+async function getLastBackupTime(ctx: C.Db) {
+	const loggedAt = await getLastBackupEventTime(ctx)
+
+	const files = fs.existsSync(ENV.BACKUPS_DIR) ? DbBackup.backupFiles(fs.readdirSync(ENV.BACKUPS_DIR), ENV.DB_PATH) : []
+	const writtenAt = files.length === 0
 		? undefined
-		: Math.max(...fileNames.map(name => fs.statSync(path.join(ENV.BACKUPS_DIR, name)).mtimeMs))
+		: Math.max(...files.map(f => fs.statSync(path.join(ENV.BACKUPS_DIR, f.name)).mtimeMs))
 
 	if (loggedAt === undefined || writtenAt === undefined) return null
 	return Math.min(loggedAt, writtenAt)
@@ -145,6 +204,7 @@ export const runBackup = C.spanOp('runBackup', { module }, async (ctx: C.Db & CS
 			causeId: null,
 			fileName,
 			sizeBytes,
+			reason: 'periodic',
 			durationMs: Date.now() - startedAt,
 			uploaded,
 			pruned,
@@ -292,5 +352,5 @@ function pruneOldBackups(currentFileName: string) {
 }
 
 function retentionOpts() {
-	return { dbPath: ENV.DB_PATH, kind: 'periodic' as const, retainCount: ENV.BACKUPS_RETAIN_COUNT }
+	return { dbPath: ENV.DB_PATH, retainCount: ENV.BACKUPS_RETAIN_COUNT }
 }

--- a/src/systems/backups.server.ts
+++ b/src/systems/backups.server.ts
@@ -7,17 +7,15 @@ import * as CS from '@/models/context-shared'
 import * as MH from '@/models/match-history.models'
 import * as C from '@/server/context'
 import * as DB from '@/server/db'
+import * as DbBackup from '@/server/db-backup'
 import * as Env from '@/server/env'
 import { initModule } from '@/server/logger'
 import * as AppEventsSys from '@/systems/app-events.server'
 import * as CleanupSys from '@/systems/cleanup.server'
-import * as DateFns from 'date-fns'
 import * as E from 'drizzle-orm'
 import fs from 'node:fs'
 import path from 'node:path'
-import * as Stream from 'node:stream/promises'
 import * as Timers from 'node:timers/promises'
-import * as Zlib from 'node:zlib'
 
 const module = initModule('backups')
 let log!: CS.Logger
@@ -34,32 +32,6 @@ const MIN_RETAINED_MATCHES = Math.max(100, MH.MAX_RECENT_MATCHES)
 // the rest of the app is still setting itself up
 const BOOT_SETTLE_DELAY = parseHumanTime('1m')
 const FAILED_BACKUP_RETRY_DELAY = parseHumanTime('30m')
-
-// backups are named slm-backup-<db filename>-<yyyyMMdd>-<HHmmss>.sqlite3.gz, e.g.
-// slm-backup-db-20260713-134016.sqlite3.gz for the default ./data/db.sqlite3. Naming them after the source db means
-// backups of different databases (two SLM instances pointed at one sftp directory, say) can't be mistaken for each
-// other -- which matters because retention deletes everything matching this prefix. Restore with
-// `gunzip -c <backup> > db.sqlite3`.
-const BACKUP_FILE_EXT = '.sqlite3.gz'
-
-function backupFilePrefix() {
-	return `slm-backup-${path.basename(ENV.DB_PATH).replace(/\.sqlite3?$/, '')}`
-}
-
-function backupFilePattern() {
-	return new RegExp(`^${escapeRegExp(backupFilePrefix())}-\\d{8}-\\d{6}${escapeRegExp(BACKUP_FILE_EXT)}$`)
-}
-
-// streamed, so a multi-GB db never lands in memory. gzip is a big win here: a sqlite file is mostly repetitive page
-// structure and text, and the archive is what we ship over sftp and keep N copies of at both ends.
-async function gzipFile(sourcePath: string, destPath: string, signal: AbortSignal) {
-	await Stream.pipeline(
-		fs.createReadStream(sourcePath),
-		Zlib.createGzip(),
-		fs.createWriteStream(destPath),
-		{ signal },
-	)
-}
 
 export function setup() {
 	log = module.getLogger()
@@ -129,7 +101,7 @@ async function getLastBackupTime(ctx: C.Db) {
 		.limit(1)
 	const loggedAt = row?.time.getTime()
 
-	const fileNames = fs.existsSync(ENV.BACKUPS_DIR) ? backupFiles(fs.readdirSync(ENV.BACKUPS_DIR)) : []
+	const fileNames = fs.existsSync(ENV.BACKUPS_DIR) ? DbBackup.backupFiles(fs.readdirSync(ENV.BACKUPS_DIR), ENV.DB_PATH, 'periodic') : []
 	const writtenAt = fileNames.length === 0
 		? undefined
 		: Math.max(...fileNames.map(name => fs.statSync(path.join(ENV.BACKUPS_DIR, name)).mtimeMs))
@@ -145,27 +117,13 @@ export const runBackup = C.spanOp('runBackup', { module }, async (ctx: C.Db & CS
 	const startedAt = Date.now()
 	const pruned = await pruneEventHistory(ctx)
 
-	fs.mkdirSync(ENV.BACKUPS_DIR, { recursive: true })
-	const fileName = `${backupFilePrefix()}-${DateFns.format(new Date(), 'yyyyMMdd-HHmmss')}${BACKUP_FILE_EXT}`
+	const fileName = DbBackup.fileName(ENV.DB_PATH, 'periodic')
 	const destPath = path.join(ENV.BACKUPS_DIR, fileName)
-	// sqlite writes its snapshot itself and we then gzip it, so a crash at either step would leave a partial file that
-	// still looks like a complete backup. both stages land on temp names, and only the finished archive is renamed into
-	// place (atomic within the directory).
-	const snapshotPath = `${destPath}.snapshot.tmp`
-	const tmpPath = `${destPath}.tmp`
-	let snapshotBytes: number
-	try {
-		await DB.backupTo(snapshotPath)
-		snapshotBytes = fs.statSync(snapshotPath).size
-		await gzipFile(snapshotPath, tmpPath, ctx.signal)
-		fs.renameSync(tmpPath, destPath)
-	} finally {
-		// the snapshot is an intermediate: it's the archive we keep. removed on the happy path too.
-		fs.rmSync(snapshotPath, { force: true })
-		fs.rmSync(tmpPath, { force: true })
-	}
-
-	const sizeBytes = fs.statSync(destPath).size
+	const { sizeBytes, snapshotBytes } = await DbBackup.writeBackup({
+		destPath,
+		snapshot: DB.backupTo,
+		signal: ctx.signal,
+	})
 	log.info(
 		'wrote backup %s (%d bytes, %sx smaller than the %d byte snapshot)',
 		destPath,
@@ -310,7 +268,7 @@ const uploadBackup = C.spanOp('uploadBackup', { module }, async (ctx: CS.AbortSi
 			// offsite the run has done its job, and a delete we're not permitted to make must not get recorded as a
 			// backup that never left the box.
 			try {
-				for (const stale of staleBackupFiles(await sftp.listDir(remoteDir), fileName)) {
+				for (const stale of DbBackup.staleBackupFiles(await sftp.listDir(remoteDir), { ...retentionOpts(), keep: fileName })) {
 					await sftp.unlink(`${remoteDir}/${stale}`)
 					log.info('deleted remote backup %s', stale)
 				}
@@ -328,25 +286,11 @@ const uploadBackup = C.spanOp('uploadBackup', { module }, async (ctx: CS.AbortSi
 })
 
 function pruneOldBackups(currentFileName: string) {
-	for (const stale of staleBackupFiles(fs.readdirSync(ENV.BACKUPS_DIR), currentFileName)) {
-		fs.rmSync(path.join(ENV.BACKUPS_DIR, stale), { force: true })
+	for (const stale of DbBackup.pruneBackups({ ...retentionOpts(), dir: ENV.BACKUPS_DIR, keep: currentFileName })) {
 		log.info('deleted local backup %s', stale)
 	}
 }
 
-// the backups beyond BACKUPS_RETAIN_COUNT, and never the one we just took
-function staleBackupFiles(fileNames: string[], currentFileName: string) {
-	if (ENV.BACKUPS_RETAIN_COUNT === 0) return []
-	return backupFiles(fileNames).slice(ENV.BACKUPS_RETAIN_COUNT).filter(name => name !== currentFileName)
-}
-
-// the backups of THIS database in a directory, newest first (the timestamp is in the name, so lexical order is
-// chronological). Anything else there is left alone: retention only ever deletes files we wrote ourselves.
-function backupFiles(fileNames: string[]) {
-	const pattern = backupFilePattern()
-	return fileNames.filter(name => pattern.test(name)).sort().reverse()
-}
-
-function escapeRegExp(str: string) {
-	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+function retentionOpts() {
+	return { dbPath: ENV.DB_PATH, kind: 'periodic' as const, retainCount: ENV.BACKUPS_RETAIN_COUNT }
 }


### PR DESCRIPTION
## What

Three things, all about not losing a database to a migration, and not making needless copies of it either.

### A backup is always taken before any migration is applied

Whether the app applies them at boot (`DB_AUTOMIGRATE`, the default) or you run `pnpm db:migrate` / `db:migrate:prod`, the db is snapshotted into `BACKUPS_DIR` first. Nothing is applied if the snapshot fails; nothing is taken when nothing is pending.

### A migration will not run against a database another process has open

The old check was a `BEGIN IMMEDIATE` probe, which only catches a connection that is *mid-write*. A running-but-idle app holds no write lock, so it sailed past the probe and got migrated under, which is the case the check existed for. Exclusive locking mode conflicts with any connection, idle or not, and is held across the whole run. The lock is only taken when something is pending, so a restart overlapping the outgoing process still boots.

### One backup system with two triggers

The periodic loop couldn't see the pre-migration snapshot: it anchors on periodic files and `BACKUP_CREATED` events, and the migration path writes neither, because it runs before the app exists. An upgrade landing on or after a due backup copied the same database **twice, a minute apart**, and the audit log recorded only the second.

The snapshot can't call into the app, so the backups system **adopts** it: a pre-migration backup newer than the newest `BACKUP_CREATED` event is one nothing has accounted for, so record it (timestamped when it was taken), ship it offsite, and let it anchor the schedule. Driven off what's on disk rather than a handoff, so it's self-healing and covers an out-of-band `db:migrate:prod` equally. The upload is what makes skipping the periodic run safe: anchoring on a local-only file would quietly mean nothing reached the SFTP target for a whole interval.

Retention is now **one window over both kinds** under `BACKUPS_RETAIN_COUNT`, with one exception: the newest pre-migration backup is never pruned, however far out of the window it falls, since it's the only way back from the migration it preceded. So you may hold N+1. `PRE_MIGRATION_BACKUPS_RETAIN_COUNT` is gone.

### `pnpm db:restore` / `restore.sh`

```sh
./restore.sh --list           # what backups there are
./restore.sh --pre-migration  # undo a bad upgrade
./restore.sh --latest
./restore.sh --from <file>    # incl. one fetched back off the sftp target
```

A backup you can't safely restore isn't a backup, and the manual version is a loaded gun: `gunzip -c backup.gz > data/db.sqlite3` leaves the old `-wal` in place, SQLite replays it over the restored file, and you silently get the **old** database back with `integrity_check` calling it fine. Doing it under a running app is worse (writes go to an unlinked inode and are lost, with no error).

So it reuses the exclusive-lock check, integrity-checks the archive before moving anything, keeps the database it replaced (renamed aside, since a restore has no undo), and reports when what it restored is behind the build, which is what stops a rollback from immediately re-applying the migration it was rolling back. `restore.sh` (laid down by `install.sh`, like `edit-global-settings.sh`) does the docker choreography.

## Notes for review

- naming/writing/retention live in `src/server/db-backup.ts`, shared by the periodic loop, the migration path and the restore.
- **Bug worth a look:** sorting backups by *name* is wrong once the kinds share a window. `-pre-migration` sits between the db name and the timestamp, so every pre-migration backup sorted after every periodic one whatever the dates, and retention silently kept the wrong files. They sort on the parsed timestamp now (`db-backup.test.ts` covers it).
- The subtle bit is commented in `withDbLockedExclusively`: a WAL connection that goes exclusive *before its first read* keeps its wal-index in heap, never creates the `-shm`, and then cannot be put back into NORMAL locking mode. It fails silently, reporting `normal` while the file stays locked for the life of the connection, which on the boot path is the life of the app. A unit test covers it because I hit it.
- `pnpm db:migrate` now reads config through `env.ts` (like `dev-clone-db`) instead of raw `process.env`. **Behaviour change:** it validates the whole env, so a run with a broken `.env` fails rather than migrating whatever `DB_PATH` defaulted to.

## Persisted-data changes

- `BACKUP_CREATED` gains `reason` ('periodic' | 'pre-migration'), **defaulted** to `periodic` so the rows already in the audit log still parse (`fromRow` drops rows that don't). `durationMs` is now optional: a pre-migration backup is taken before anything exists to time it.
- `PRE_MIGRATION_BACKUPS_RETAIN_COUNT` removed before it ever shipped. No migration; `BACKUPS_RETAIN_COUNT` keeps its meaning and default.

## Verified

Unit tests: `db-backup.test.ts` (ordering across kinds, shared window, the pinned rollback point, retainCount 0, foreign files), `migrate.test.ts` (backup is the pre-migration state, none when nothing pending, prunes the shared window, refusal against an idle reader, lock released after a run), an old-shaped `BACKUP_CREATED` row reading back as periodic. Full suite: 548 passing.

End to end against a dev instance with a real cloned db:
- `db:migrate` with a pending migration -> backup written, applied; the restored gzip has no trace of the new table and passes `integrity_check`; rerun with nothing pending -> no backup
- with the app running -> refused, nothing applied, no backup written
- boot with `DB_AUTOMIGRATE=true` -> backup + applied + app up, and another process could open the db afterwards (lock released)
- **adoption**: pre-migration backup, then boot with `AUTOMATIC_BACKUPS_PERIODIC=2m` -> `recorded pre-migration backup ..., taken 17s ago` then `last backup was 17s ago, next in 1m 44s`, one file on disk (previously: `no previous backup found, taking one in 1m` and a second copy), audit row written with `reason: pre-migration` at the snapshot's timestamp; the next periodic backup then fired on schedule
- **restore**: `--list`, `--pre-migration` and `--latest` against the real db; restored db has neither the marker table nor the migration, `integrity_check` ok, the replaced db kept and still readable with its `-wal` folded in, no temp files left behind, and the pending-migration warning fired
- restore with the app running -> refused, db untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)