### PR TITLE
fix flaky seed-layer assertion in the layer-select e2e test

### DIFF
--- a/test/e2e/layer-select.test.ts
+++ b/test/e2e/layer-select.test.ts
@@ -34,13 +34,23 @@ test.describe('selecting layers', () => {
 			await page.getByRole('option', { name: 'Sumari', exact: true }).click()
 
 			const rows = dialog.getByRole('row')
+			// with the filter applied every row this query can return is a Sumari_RAAS_v1 variant, so its absence is
+			// what says the filter withheld the rest, rather than that they are on some other page
 			await expect(rows.filter({ hasText: 'Sumari_RAAS_v1' }).first()).toBeVisible()
-			// Sumari has seed layers, but Seed is not RAAS, so the applied filter withholds them
 			await expect(rows.filter({ hasText: 'Sumari_Seed_v1' })).toHaveCount(0)
 
 			// turning the filter off is what lets an admin reach outside the pool
 			await raasOnly.click()
 			await expect(raasOnly).toHaveAttribute('aria-checked', 'false')
+
+			// and now narrow to the gamemode being asserted on. The table sorts randomly by default (see the layerTable
+			// setting) and pages, so "is Sumari_Seed_v1 in the table" without narrowing to it is really "did the shuffle
+			// deal it onto page one" -- which it did about five times in six. Sumari_Seed_v1 is Sumari's only seed layer,
+			// so once Seed is the gamemode, every row is one of its faction variants whatever the shuffle did.
+			await dialog.getByRole('combobox', { name: 'Gamemode' }).click()
+			await page.getByRole('option', { name: 'Seed', exact: true }).click()
+			await expect(dialog.getByRole('combobox', { name: 'Gamemode' })).toHaveText('Seed')
+
 			const seedRow = rows.filter({ hasText: 'Sumari_Seed_v1' }).first()
 			await expect(seedRow).toBeVisible()
 


### PR DESCRIPTION
## The flake

`layer-select.test.ts` › "applies the pool filter by default, narrows through the filter menu, and adds the chosen layer" fails intermittently on `expect(seedRow).toBeVisible()`. It went red on #30, but nothing on that branch can reach it: the failing commit only touched `src/scripts/restore.ts` and `restore.sh`, and the two commits before it (carrying all the actual app changes) passed. It reproduces on a clean checkout of main.

## Why

The select-layers table sorts **randomly** by default (`layerTable.defaultSortBy = { type: 'random' }`, reseeded each time the dialog opens) and it pages. So

```ts
await expect(rows.filter({ hasText: 'Sumari_Seed_v1' }).first()).toBeVisible()
```

isn't asking "can the admin reach seed layers now that the pool filter is off". It's asking "did the shuffle deal a seed layer onto page one", because Sumari has far more layer/faction rows than fit on a page once the RAAS filter is lifted.

Instrumenting the dialog over six runs of identical code, the number of `Sumari_Seed_v1` rows on page one came out **0, 1, 2, 2, 3, 4**. The zero is the failure. Locally the original test failed 1 in 6 (`--repeat-each=6`), which matches what CI has been doing.

## The fix

Narrow the filter menu to Gamemode=Seed before asserting on a seed layer. `Sumari_Seed_v1` is Sumari's only seed layer, so every row the query can return is then one of its faction variants (16 of 17 rows, the rest being the header) and page one is guaranteed whatever the seed.

The narrowing has to come **after** the pool filter is unticked. While `RAAS Only` is applied, picking a gamemode it excludes is silently declined: the option is offered and is not `aria-disabled`, but clicking it leaves the combobox on "Select Gamemode...". That is consistent with the menu keeping the query non-empty, and I've left it alone here, but a clickable option that silently does nothing may be worth a look on its own.

The "filter withholds them" assertion is unchanged and is sound for the same reason in reverse: with the filter on, every row the query can return is a `Sumari_RAAS_v1` variant, so a seed count of 0 holds on every page, not just page one.

## Verified

- old test, `--repeat-each=6`: 1 failed / 11 passed
- new test, `--repeat-each=10`: **20 passed**, 0 failed

No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)