### PR TITLE
Don't render a warn's actor as a bare chat-sender prefix

### DIFF
--- a/src/components/server-event.tsx
+++ b/src/components/server-event.tsx
@@ -777,7 +777,9 @@ function AppEventEntry(
 	}
 
 	// warns render message-style (colored channel + border + gradient) like a chat message, with the channel
-	// naming who was warned rather than a chat scope
+	// naming who was warned rather than a chat scope. The actor keeps a verb ("X warned: ...") rather than a bare
+	// chat-sender prefix ("X: ..."), since the warn body may itself carry an admin's name (the warn box's optional
+	// username prefix) and a bare prefix makes the attribution indistinguishable from that.
 	if (appEvent.type === 'PLAYER_WARNED') {
 		const warnCount = appEvent.targets.length
 		const summary = event.warnSummary
@@ -809,7 +811,7 @@ function AppEventEntry(
 			<>
 				<EventTime time={event.time} />
 				<div className="grow min-w-0 wrap-anywhere">
-					{channel} {actorLabel}: "{appEvent.message}"
+					{channel} {actorLabel} warned: "{appEvent.message}"
 				</div>
 			</>
 		)


### PR DESCRIPTION
## The report

> On the player details and squad details window, the warn chat misbehaves by showing the admins' username as part of the warn, even when the username box is unchecked.

## What was actually happening

Nothing leaks into the delivered warn. Verified against a dev instance with the emulator: with the box unchecked, RCON gets `AdminWarn "0002700e..." stop camping` (and `@Squad1 squad warn unchecked` from the squad window). The message body is clean, and the checkbox is the only thing that ever prefixes it.

The problem is the feed rendering. `server-event.tsx` rendered the PLAYER_WARNED line as `{channel} {actorLabel}: "{message}"`, borrowing the chat-message shape (`(all) Alice: hello`), where a bare `Name:` prefix *is* the sender convention. Since the warn box can optionally prefix the body with the sender's username, the attribution became indistinguishable from that prefix:

| box | before |
| --- | --- |
| unchecked | `(warning Alice(RGF)) grey275: "stop camping"` |
| checked | `(warning Alice(RGF)) grey275: "grey275: stop camping"` |

## The fix

Attribution always stays (it's who warned, and this feed is the audit trail), but it now carries a verb instead of masquerading as a message prefix, consistent with every other app-event line (`grey275 broadcast "..."`, `grey275 ended the match`):

| box | after |
| --- | --- |
| unchecked | `(warning Alice(RGF)) grey275 warned: "stop camping"` |
| checked | `(warning Alice(RGF)) grey275 warned: "grey275: stop camping"` |

The renderer is shared, so the main Server Activity feed gets this too.

## Verification

Driven end-to-end on a worktree dev instance (4 emulated players, http://localhost:3131/servers/tt-scrim-2):

- player details window, box unchecked and checked
- squad details window (`@Squad1` body prefix intact)
- main Server Activity feed
- RCON text confirmed clean in the server log for every case
- `pnpm run format`, `pnpm run check`, `pnpm run lint:fix` all clean

One thing worth knowing that is *not* a bug: with only one player online, a warn aimed at that player renders `(warning the entire server)`, because the target set genuinely equals everyone online. It reads oddly on an empty server but is correct, and it resolves to `(warning Alice(RGF))` as soon as others join. Left alone; happy to change the wording if it bothers you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)