### PR TITLE
Resolve discord avatar urls via discord.js

### DIFF
--- a/src/components/filter-index.tsx
+++ b/src/components/filter-index.tsx
@@ -4,7 +4,6 @@ import * as Typo from '@/lib/typography'
 import { cn } from '@/lib/utils'
 import type * as F from '@/models/filter.models'
 import type * as LQY from '@/models/layer-queries.models'
-import * as USR from '@/models/users.models'
 import * as RBAC from '@/rbac.models'
 import * as ConfigClient from '@/systems/config.client'
 import * as FilterEntityClient from '@/systems/filter-entity.client'
@@ -52,7 +51,7 @@ function FilterEntityCard({ entity, cfg }: FilterEntityCardProps) {
 									style={{ backgroundColor: user.displayHexColor ?? undefined }}
 									className="hover:cursor-pointer select-none h-5 w-5 shrink-0"
 								>
-									<AvatarImage src={USR.getAvatarUrl(user)} crossOrigin="anonymous" />
+									<AvatarImage src={user.avatarUrl} crossOrigin="anonymous" />
 									<AvatarFallback className="text-xs">{user.displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
 								</Avatar>
 								<span>

--- a/src/components/layer-source-display.tsx
+++ b/src/components/layer-source-display.tsx
@@ -61,7 +61,7 @@ export default function LayerSourceDisplay(props: { source: LL.Source }) {
 			return renderAvatar('Generated', 'G', '#059669', <Icons.Dices />)
 		case 'manual': {
 			if (!user) return null
-			return renderAvatar(username, USR.getUserInitials(user), user.displayHexColor ?? undefined, USR.getAvatarUrl(user), true)
+			return renderAvatar(username, USR.getUserInitials(user), user.displayHexColor ?? undefined, user.avatarUrl, true)
 		}
 		default:
 			assertNever(props.source)

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -22,7 +22,6 @@ import { useIsDesktopSize, useIsSmallViewport } from '@/lib/browser.ts'
 import * as Obj from '@/lib/object'
 import { cn } from '@/lib/utils'
 import * as ZusUtils from '@/lib/zustand'
-import * as USR from '@/models/users.models.ts'
 import * as RPC from '@/orpc.client'
 import * as RBAC from '@/rbac.models'
 import * as ClientOnlySettings from '@/systems/client-only-settings.client'
@@ -46,7 +45,7 @@ export default function NavBar() {
 	const { simulate, setSimulate } = ZusUtils.useStore(RbacClient.RbacStore)
 	const user = useLoggedInUser()
 
-	const avatarUrl = user && USR.getAvatarUrl(user)
+	const avatarUrl = user?.avatarUrl
 
 	// Check if we're on the server dashboard route
 	const isOnServerDashboard = TSR.useMatch({ from: '/_app/servers/$serverId', shouldThrow: false })

--- a/src/components/user-presence-panel.tsx
+++ b/src/components/user-presence-panel.tsx
@@ -4,7 +4,7 @@ import * as MapUtils from '@/lib/map'
 import { cn } from '@/lib/utils'
 import * as ZusUtils from '@/lib/zustand'
 import * as UP from '@/models/user-presence'
-import * as USR from '@/models/users.models'
+import type * as USR from '@/models/users.models'
 import * as ConfigClient from '@/systems/config.client'
 import * as UPClient from '@/systems/user-presence.client'
 import * as UsersClient from '@/systems/users.client'
@@ -147,7 +147,7 @@ const PresenceAvatar = React.forwardRef<
 				style={{ backgroundColor: user.displayHexColor ?? undefined }}
 				className={cn('h-full w-full', presence.away && 'grayscale opacity-50', avatarClassName)}
 			>
-				<AvatarImage src={USR.getAvatarUrl(user)} crossOrigin="anonymous" />
+				<AvatarImage src={user.avatarUrl} crossOrigin="anonymous" />
 				<AvatarFallback className={fallbackClassName}>{user.displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
 			</Avatar>
 			{badge !== undefined && (

--- a/src/models/users.models.ts
+++ b/src/models/users.models.ts
@@ -26,7 +26,7 @@ export type User = SchemaModels.User & {
 	username: string
 	displayName: string
 	displayHexColor: string | null
-	avatar: string | null
+	avatarUrl: string
 	nickname: string | null
 }
 export type MiniUser = {
@@ -58,10 +58,11 @@ export const UserIdSchema = z.bigint().positive()
 
 export type UserId = z.infer<typeof UserIdSchema>
 
-export const getAvatarUrl = (user: User) => {
-	if (user.avatar) return `${DM.CDN_BASE}/avatars/${user.discordId}/${user.avatar}.png`
-	const id = ((user.discordId >> 22n) % 6n).toString()
-	return `${DM.CDN_BASE}/embed/avatars/${id}.png`
+// only for users we couldn't resolve against discord; otherwise the url comes from discord.js, which
+// knows about guild-specific and animated avatars. Mirrors discord.js' User#defaultAvatarURL.
+export const getDefaultAvatarUrl = (discordId: bigint) => {
+	const index = ((discordId >> 22n) % 6n).toString()
+	return `${DM.CDN_BASE}/embed/avatars/${index}.png`
 }
 
 export const getUserInitials = (user: User) => {

--- a/src/systems/users.server.ts
+++ b/src/systems/users.server.ts
@@ -193,7 +193,7 @@ export async function buildUser(dbUser: Schema.User): Promise<USR.User> {
 		return {
 			...dbUser,
 			displayName: dbUser.nickname || dbUser.username,
-			avatar: null,
+			avatarUrl: USR.getDefaultAvatarUrl(dbUser.discordId),
 			displayHexColor: null,
 		}
 	}
@@ -207,7 +207,7 @@ export async function buildUser(dbUser: Schema.User): Promise<USR.User> {
 			member.user.username,
 			dbUser.username,
 		]),
-		avatar: member.avatar ?? member.user.avatar,
+		avatarUrl: member.displayAvatarURL({ size: 128 }),
 		displayHexColor: member.displayHexColor ?? member.user.hexAccentColor,
 	}
 }


### PR DESCRIPTION
Our avatar urls are built by hand and are wrong for a subset of users.

`buildUser` stored `member.avatar ?? member.user.avatar` and `getAvatarUrl` turned that hash into `/avatars/{userId}/{hash}.png`. But `member.avatar` is the **guild-specific** avatar hash, which lives at `/guilds/{guildId}/users/{userId}/avatars/{hash}` -- so any user with a per-server avatar got a url that 404s and fell back to their initials. Animated avatars (`a_` prefix) were also served as `.png` rather than `.gif`.

Rather than fix the path construction by hand, this hands it to discord.js `GuildMember#displayAvatarURL()`, which already picks global vs guild, the right extension, and the size. `searchGuildMembers` in `discord.server.ts` was already doing exactly this, so this brings `buildUser` in line with it.

- `USR.User.avatar: string | null` (a hash) becomes `avatarUrl: string` (a resolved url). Not persisted -- it is derived in `buildUser` on every read, so no migration.
- `USR.getAvatarUrl(user)` is gone; call sites read `user.avatarUrl`. `getDefaultAvatarUrl(discordId)` remains for users we cannot resolve against discord.

## Verification

`pnpm run check` and `pnpm run lint` are clean. Ran the app on a dev instance and confirmed the nav-bar avatar renders and the image loads (`embed/avatars/5.png`, naturalWidth 256). Note the dev instance has no live discord connection, so that exercises the unresolved-member fallback; the `displayAvatarURL` branch is discord.js own logic and needs a real guild to observe.

Dev server for this branch: http://localhost:3151

🤖 Generated with [Claude Code](https://claude.com/claude-code)