### PR TITLE
Collapse advanced settings and add scoped JSON editors

### DIFF
--- a/src/components/schema-json-editor.tsx
+++ b/src/components/schema-json-editor.tsx
@@ -24,6 +24,8 @@ export default function SchemaJsonEditor<TOut, TIn = TOut>(props: SchemaJsonEdit
 	schemaRef.current = props.schema
 	const onValidChangeRef = React.useRef(props.onValidChange)
 	onValidChangeRef.current = props.onValidChange
+	const onReadyRef = React.useRef(props.onReady)
+	onReadyRef.current = props.onReady
 
 	const onChange = React.useCallback((value: string) => {
 		let obj: any
@@ -70,6 +72,7 @@ export default function SchemaJsonEditor<TOut, TIn = TOut>(props: SchemaJsonEdit
 
 		const initialParseRes = schemaRef.current.safeParse(lastSyncedValueRef.current)
 		lastValidRef.current = initialParseRes.success ? initialParseRes.data : null
+		onReadyRef.current?.()
 
 		// remeasure when returning to a hidden tab, matching the old resize-on-visibility behavior
 		const sub = Rx.fromEvent(document, 'visibilitychange').subscribe(() => {

--- a/src/components/schema-json-editor.types.ts
+++ b/src/components/schema-json-editor.types.ts
@@ -18,5 +18,8 @@ export interface SchemaJsonEditorProps<TOut, TIn = TOut> {
 	minHeightPx?: number
 	// rendered in the editor's own header row, so it stays reachable in fullscreen (where the editor covers the page)
 	toolbar?: React.ReactNode
+	// fired once the editor is mounted and laid out. The bundle is lazy-loaded, so a caller that wants to bring the
+	// editor into view has to wait for this rather than acting on the click that selected it.
+	onReady?: () => void
 	ref?: React.Ref<SchemaJsonEditorHandle>
 }

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -3343,9 +3343,11 @@ function toInputShape(schema: z.ZodType, decoded: unknown): unknown {
 // rather than passing a new `value`, because the editor re-syncs only when `value` differs from what it last synced,
 // and a reset typically restores the very value it was seeded with (leaving the user's edits sitting in the buffer).
 function LocalJsonField(
-	{ schema, label, value$, reset$, onChange }: {
+	{ schema, label, domId, value$, reset$, onChange }: {
 		schema: z.ZodType
 		label: string
+		// the field's own anchor, which the editor renders inside: the scroll target once the editor is up
+		domId: string
 		value$: ValueState
 		reset$: Rx.Subject<void>
 		onChange: (v: any) => void
@@ -3357,9 +3359,25 @@ function LocalJsonField(
 		if (v === null) return
 		onChange(toInputShape(schema, v))
 	}, [schema, onChange])
+	// only the first mount scrolls: re-seeding after a reset remounts the editor, and yanking the viewport for that
+	// would be a surprise. This component only exists while the field is in JSON mode, so the ref resets on reopen.
+	const broughtIntoView = React.useRef(false)
+	const onReady = React.useCallback(() => {
+		if (broughtIntoView.current) return
+		broughtIntoView.current = true
+		SettingsNav.scrollToAnchorSettled(domId)
+	}, [domId])
 	return (
 		<React.Suspense fallback={<p className="text-sm text-muted-foreground">Loading editor…</p>}>
-			<SchemaJsonEditor key={seed.nonce} schema={schema} value={seed.value} onValidChange={onValidChange} minHeightPx={320} label={label} />
+			<SchemaJsonEditor
+				key={seed.nonce}
+				schema={schema}
+				value={seed.value}
+				onValidChange={onValidChange}
+				onReady={onReady}
+				minHeightPx={320}
+				label={label}
+			/>
 		</React.Suspense>
 	)
 }
@@ -3416,6 +3434,7 @@ function SectionField(
 						<LocalJsonField
 							schema={jsonSchema}
 							label={settingLabel(path, name)}
+							domId={domId}
 							value$={value$}
 							reset$={reset$}
 							onChange={onChange}
@@ -3499,6 +3518,7 @@ function LeafField(
 						<LocalJsonField
 							schema={jsonSchema}
 							label={settingLabel(path, name)}
+							domId={domId}
 							value$={value$}
 							reset$={reset$}
 							onChange={onChange}

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -24,12 +24,13 @@ import { useDebounced } from '@/hooks/use-debounce'
 import { createId } from '@/lib/id'
 import * as Obj from '@/lib/object'
 import type { SettingsGroup } from '@/lib/settings-groups'
-import { HIDDEN_GLOBAL_SETTINGS_KEYS, splitByGroups } from '@/lib/settings-groups'
+import { HIDDEN_GLOBAL_SETTINGS_KEYS, LOCAL_JSON_EDITOR_PATHS, splitAdvanced, splitByGroups } from '@/lib/settings-groups'
 import { humanize, settingLabel } from '@/lib/settings-labels'
 import * as SettingsNav from '@/lib/settings-nav'
 import * as Templating from '@/lib/templating'
 import { assertNever } from '@/lib/type-guards'
 import { cn } from '@/lib/utils'
+import * as Zod from '@/lib/zod'
 import * as ZusUtils from '@/lib/zustand'
 import * as AAR from '@/models/admin-action-reasons.models'
 import type * as BM from '@/models/battlemetrics.models'
@@ -52,6 +53,7 @@ import * as Icons from 'lucide-react'
 import React from 'react'
 import * as Rx from 'rxjs'
 import { z } from 'zod'
+import type SchemaJsonEditorComponent from './schema-json-editor'
 import { MessagePreviewBox } from './warn-reasons-sub'
 
 // The form is driven off the JSON-Schema projection of a Zod schema (input mode), edited in the encoded/input shape
@@ -202,6 +204,15 @@ const RootValueContext = React.createContext<ValueState | null>(null)
 // the root document's onChange, so a bespoke field can write siblings it isn't scoped to. The command-prefix editor
 // uses it to propagate a prefix rename across every command string / timeout alias that uses that prefix.
 const RootOnChangeContext = React.createContext<((next: any) => void) | null>(null)
+
+// the zod schema of the whole document, so a field can resolve the sub-schema at its own path for its scoped JSON
+// editor (the json-schema projection the form walks can't be handed back to zod for parsing)
+const RootSchemaContext = React.createContext<z.ZodType | null>(null)
+
+// paths that render inside their section's "Advanced" disclosure (see settings-groups.ts). Empty for forms that
+// declare none.
+const NO_ADVANCED_PATHS: ReadonlySet<string> = new Set()
+const AdvancedPathsContext = React.createContext<ReadonlySet<string>>(NO_ADVANCED_PATHS)
 
 // the user's write grant over the settings being edited; leaves outside it render dimmed + inert (see LeafField)
 const WRITE_ACCESS_ALL: RBAC.SettingsWriteAccess = { kind: 'all' }
@@ -3072,11 +3083,18 @@ function ObjectField(
 	},
 ) {
 	const props: Record<string, Node> = node.properties ?? {}
+	const { normal, advanced } = splitAdvanced(Object.keys(props), path.join('.'), React.useContext(AdvancedPathsContext))
+	const field = (key: string) => (
+		<Field key={key} name={key} node={props[key]} path={[...path, key]} parent$={value$} parentOnChange={onChange} reset$={reset$} />
+	)
 	return (
 		<div className="space-y-3">
-			{Object.entries(props).map(([key, childNode]) => (
-				<Field key={key} name={key} node={childNode} path={[...path, key]} parent$={value$} parentOnChange={onChange} reset$={reset$} />
-			))}
+			{normal.map((key) => field(key))}
+			{advanced.length > 0 && (
+				<AdvancedDisclosure paths={advanced.map((key) => [...path, key].join('.'))}>
+					{advanced.map((key) => field(key))}
+				</AdvancedDisclosure>
+			)}
 		</div>
 	)
 }
@@ -3228,6 +3246,117 @@ function AnchorLink({ domId }: { domId: string }) {
 	)
 }
 
+// -------- advanced disclosure --------
+
+// The collapsed tail of a section: the fields most installs never touch (see settings-groups.ts). `paths` are the
+// dotted paths it holds, so it can open itself when one of them is navigated to (the TOC lists advanced settings like
+// any other) or when one of them fails validation, which must never be hidden behind a collapsed row.
+function AdvancedDisclosure({ paths, children }: { paths: string[]; children: React.ReactNode }) {
+	const [expanded, setExpanded] = React.useState(false)
+	const { idPrefix } = React.useContext(FormOptionsContext)
+	const covers = React.useCallback((candidate: string, prefix: string) => {
+		return paths.some((p) => {
+			const full = `${prefix}${p}`
+			return candidate === full || candidate.startsWith(`${full}.`)
+		})
+	}, [paths])
+
+	React.useEffect(() => SettingsNav.onAnchorNavigate((id) => covers(id, idPrefix) && setExpanded(true)), [covers, idPrefix])
+
+	const hasIssue = React.useContext(ValidationContext).some((i) => covers(i.path, ''))
+	const open = expanded || hasIssue
+	return (
+		<div className="rounded-md border border-dashed">
+			<button
+				type="button"
+				className="flex w-full items-center gap-1.5 px-2 py-1.5 text-xs text-muted-foreground hover:text-foreground"
+				onClick={() => setExpanded((v) => !v)}
+				aria-expanded={open}
+			>
+				<Icons.ChevronRight className={cn('h-3.5 w-3.5 transition-transform', open && 'rotate-90')} />
+				Advanced
+				<span className="opacity-60">({paths.length})</span>
+				{hasIssue && <Icons.TriangleAlert className="h-3 w-3 text-destructive" />}
+			</button>
+			{open && <div className="space-y-3 border-t px-2 py-3">{children}</div>}
+		</div>
+	)
+}
+
+// -------- scoped json editor --------
+
+// lazily loaded so a settings visit that never opens a JSON editor doesn't pay for the CodeMirror bundle. The `as`
+// casts restore the generic component signature React.lazy erases (same as the page-level editor in routes/settings).
+const SchemaJsonEditor = React.lazy(
+	() => import('@/components/schema-json-editor') as unknown as Promise<{ default: React.FC<any> }>,
+) as unknown as typeof SchemaJsonEditorComponent
+
+// the sub-schema for this field's scoped JSON editor, or undefined when it doesn't offer one
+function useLocalJsonSchema(pathStr: string, path: Path): z.ZodType | undefined {
+	const rootSchema = React.useContext(RootSchemaContext)
+	return React.useMemo(
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- `path` is rebuilt every render; pathStr identifies it
+		() => (rootSchema && LOCAL_JSON_EDITOR_PATHS.has(pathStr) ? Zod.schemaAtPath(rootSchema, path) : undefined),
+		[
+			rootSchema,
+			pathStr,
+			path,
+		],
+	)
+}
+
+function LocalJsonToggle({ on, onToggle }: { on: boolean; onToggle: () => void }) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button type="button" size="sm" variant={on ? 'secondary' : 'ghost'} className="h-6 gap-1 px-1.5 text-xs" onClick={onToggle}>
+					<Icons.Braces className="h-3 w-3" />
+					JSON
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent>{on ? 'Back to the form' : 'Edit just this setting as JSON'}</TooltipContent>
+		</Tooltip>
+	)
+}
+
+// The form's drafts hold the input/encoded shape, but the editor validates through the sub-schema, which yields the
+// decoded shape (e.g. HumanTime as milliseconds). Encode back where the schema allows it; a subtree carrying a
+// one-way transform can't encode at all, and its output shape is its input shape anyway.
+function toInputShape(schema: z.ZodType, decoded: unknown): unknown {
+	try {
+		return schema.encode(decoded)
+	} catch {
+		return decoded
+	}
+}
+
+// A JSON editor over one subtree of the form, swapped in for that field's widget. The editor owns its buffer while
+// open: handing our own edits straight back as `value` would re-sync the document mid-keystroke, so it's only re-seeded
+// on reset$, which is exactly the programmatic-change signal the uncontrolled inputs re-read on. Re-seeding remounts it
+// rather than passing a new `value`, because the editor re-syncs only when `value` differs from what it last synced,
+// and a reset typically restores the very value it was seeded with (leaving the user's edits sitting in the buffer).
+function LocalJsonField(
+	{ schema, label, value$, reset$, onChange }: {
+		schema: z.ZodType
+		label: string
+		value$: ValueState
+		reset$: Rx.Subject<void>
+		onChange: (v: any) => void
+	},
+) {
+	const [seed, setSeed] = React.useState(() => ({ value: value$.getValue(), nonce: 0 }))
+	useReset(reset$, () => setSeed((prev) => ({ value: value$.getValue(), nonce: prev.nonce + 1 })))
+	const onValidChange = React.useCallback((v: unknown) => {
+		if (v === null) return
+		onChange(toInputShape(schema, v))
+	}, [schema, onChange])
+	return (
+		<React.Suspense fallback={<p className="text-sm text-muted-foreground">Loading editor…</p>}>
+			<SchemaJsonEditor key={seed.nonce} schema={schema} value={seed.value} onValidChange={onValidChange} minHeightPx={320} label={label} />
+		</React.Suspense>
+	)
+}
+
 // a nested object section: titled fieldset. `useIsModified` keeps the reset affordance live without re-rendering
 // the whole subtree on every descendant edit.
 function SectionField(
@@ -3253,6 +3382,8 @@ function SectionField(
 	const SectionExtra = sectionExtraFor(path)
 	// leaves dim themselves individually; the section only needs its own bulk-reset controls neutralized
 	const writable = RBAC.settingsPathOverlaps(React.useContext(WriteAccessContext), path)
+	const jsonSchema = useLocalJsonSchema(pathStr, path)
+	const [jsonMode, setJsonMode] = React.useState(false)
 	return (
 		<fieldset
 			id={domId}
@@ -3267,12 +3398,23 @@ function SectionField(
 					<span className="contents" inert={!writable}>
 						<FieldResetControls value$={value$} reset$={reset$} onChange={onChange} node={node} path={path} showDefaultLabel={false} />
 					</span>
+					{jsonSchema && writable && <LocalJsonToggle on={jsonMode} onToggle={() => setJsonMode((v) => !v)} />}
 					<AnchorLink domId={domId} />
 				</div>
 				{description && <p className="text-xs text-muted-foreground">{description}</p>}
 				{SectionExtra && <SectionExtra />}
 				<FieldIssues issues={sectionIssues} pathStr={pathStr} />
-				<FieldControl node={node} path={path} value$={value$} reset$={reset$} onChange={onChange} />
+				{jsonSchema && jsonMode
+					? (
+						<LocalJsonField
+							schema={jsonSchema}
+							label={settingLabel(path, name)}
+							value$={value$}
+							reset$={reset$}
+							onChange={onChange}
+						/>
+					)
+					: <FieldControl node={node} path={path} value$={value$} reset$={reset$} onChange={onChange} />}
 			</StickyGroup>
 		</fieldset>
 	)
@@ -3302,6 +3444,8 @@ function LeafField(
 	// loose overlap: a grant pointing inside this field's subtree still permits editing part of it, so the field stays
 	// active and the save panel's exact per-path check flags anything outside the grant
 	const writable = RBAC.settingsPathOverlaps(React.useContext(WriteAccessContext), path)
+	const jsonSchema = useLocalJsonSchema(pathStr, path)
+	const [jsonMode, setJsonMode] = React.useState(false)
 	// the inline "default: <value>" hint only reads well for scalars; complex/override fields still get the reset buttons
 	const showDefaultLabel = !hasOverride && isScalarNode(inner)
 	const controls = (
@@ -3335,6 +3479,7 @@ function LeafField(
 						</Tooltip>
 					)}
 					{!isBoolean && controls}
+					{jsonSchema && writable && <LocalJsonToggle on={jsonMode} onToggle={() => setJsonMode((v) => !v)} />}
 					<AnchorLink domId={domId} />
 				</div>
 				{description && <p className="text-xs text-muted-foreground">{description}</p>}
@@ -3342,7 +3487,17 @@ function LeafField(
 			</div>
 			<div className={cn(isBoolean && 'shrink-0 flex items-center gap-1')} inert={!writable}>
 				{isBoolean && controls}
-				<FieldControl node={node} path={path} value$={value$} reset$={reset$} onChange={onChange} />
+				{jsonSchema && jsonMode
+					? (
+						<LocalJsonField
+							schema={jsonSchema}
+							label={settingLabel(path, name)}
+							value$={value$}
+							reset$={reset$}
+							onChange={onChange}
+						/>
+					)
+					: <FieldControl node={node} path={path} value$={value$} reset$={reset$} onChange={onChange} />}
 			</div>
 		</div>
 	)
@@ -3410,18 +3565,28 @@ function GroupedRootFields(
 ) {
 	const props: Record<string, Node> = node.properties ?? {}
 	const { groups: grouped, ungrouped } = splitByGroups(Object.keys(props), groups)
+	const advancedPaths = React.useContext(AdvancedPathsContext)
+	const field = (key: string) => (
+		<Field key={key} name={key} node={props[key]} path={[key]} parent$={value$} parentOnChange={onChange} reset$={reset$} />
+	)
+	// each group carries its own advanced tail, so a rarely-touched setting stays with the settings it belongs to
+	const renderKeys = (keys: string[]) => {
+		const { normal, advanced } = splitAdvanced(keys, '', advancedPaths)
+		return (
+			<>
+				{normal.map((key) => field(key))}
+				{advanced.length > 0 && <AdvancedDisclosure paths={advanced}>{advanced.map((key) => field(key))}</AdvancedDisclosure>}
+			</>
+		)
+	}
 	return (
 		<div className="space-y-6">
 			{grouped.map(({ group, keys }) => (
 				<GroupSection key={group.slug} slug={group.slug} label={group.label}>
-					{keys.map((key) => (
-						<Field key={key} name={key} node={props[key]} path={[key]} parent$={value$} parentOnChange={onChange} reset$={reset$} />
-					))}
+					{renderKeys(keys)}
 				</GroupSection>
 			))}
-			{ungrouped.map((key) => (
-				<Field key={key} name={key} node={props[key]} path={[key]} parent$={value$} parentOnChange={onChange} reset$={reset$} />
-			))}
+			{renderKeys(ungrouped)}
 		</div>
 	)
 }
@@ -3454,7 +3619,19 @@ function JsonFallback({ value$, reset$, onChange }: { value$: ValueState; reset$
 }
 
 export default function SettingsForm(
-	{ schema, value$, reset$, onChange, saved, idPrefix = 'setting:', groups, priorityKeys, issues, writeAccess = WRITE_ACCESS_ALL }: {
+	{
+		schema,
+		value$,
+		reset$,
+		onChange,
+		saved,
+		idPrefix = 'setting:',
+		groups,
+		priorityKeys,
+		advancedPaths = NO_ADVANCED_PATHS,
+		issues,
+		writeAccess = WRITE_ACCESS_ALL,
+	}: {
 		schema: z.ZodType
 		value$: Rx.Observable<any> & { getValue: () => any }
 		reset$: Rx.Subject<void>
@@ -3469,6 +3646,8 @@ export default function SettingsForm(
 		// presentation-level ordering (ungrouped forms only): these top-level keys float to the front, in the given order,
 		// with the rest following in schema order. Keeps the persisted shape untouched, same rationale as `groups`.
 		priorityKeys?: string[]
+		// dotted paths of the fields that render inside their section's collapsed "Advanced" disclosure (see settings-groups.ts)
+		advancedPaths?: ReadonlySet<string>
 		// schema issues for the current draft (input-shape safeParse); each leaf field displays the issues under its path
 		issues?: readonly z.core.$ZodIssue[]
 		// the user's write grant; fields with no overlap render read-only. Defaults to unrestricted.
@@ -3497,17 +3676,21 @@ export default function SettingsForm(
 		<FormOptionsContext.Provider value={formOptions}>
 			<RootValueContext.Provider value={value$}>
 				<RootOnChangeContext.Provider value={onChange}>
-					<WriteAccessContext.Provider value={writeAccess}>
-						<SavedRootContext.Provider value={savedCtx}>
-							<MessageVarsContext.Provider value={messageVars}>
-								<ValidationContext.Provider value={normIssues}>
-									{groups
-										? <GroupedRootFields node={jsonSchema} groups={groups} value$={value$} reset$={reset$} onChange={onChange} />
-										: <ObjectField node={jsonSchema} path={rootPath} value$={value$} reset$={reset$} onChange={onChange} />}
-								</ValidationContext.Provider>
-							</MessageVarsContext.Provider>
-						</SavedRootContext.Provider>
-					</WriteAccessContext.Provider>
+					<RootSchemaContext.Provider value={schema}>
+						<AdvancedPathsContext.Provider value={advancedPaths}>
+							<WriteAccessContext.Provider value={writeAccess}>
+								<SavedRootContext.Provider value={savedCtx}>
+									<MessageVarsContext.Provider value={messageVars}>
+										<ValidationContext.Provider value={normIssues}>
+											{groups
+												? <GroupedRootFields node={jsonSchema} groups={groups} value$={value$} reset$={reset$} onChange={onChange} />
+												: <ObjectField node={jsonSchema} path={rootPath} value$={value$} reset$={reset$} onChange={onChange} />}
+										</ValidationContext.Provider>
+									</MessageVarsContext.Provider>
+								</SavedRootContext.Provider>
+							</WriteAccessContext.Provider>
+						</AdvancedPathsContext.Provider>
+					</RootSchemaContext.Provider>
 				</RootOnChangeContext.Provider>
 			</RootValueContext.Provider>
 		</FormOptionsContext.Provider>

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -3291,31 +3291,37 @@ const SchemaJsonEditor = React.lazy(
 	() => import('@/components/schema-json-editor') as unknown as Promise<{ default: React.FC<any> }>,
 ) as unknown as typeof SchemaJsonEditorComponent
 
+// which editor a field with a scoped JSON editor is currently showing, mirroring the page-level section modes
+type FieldMode = 'gui' | 'json'
+
 // the sub-schema for this field's scoped JSON editor, or undefined when it doesn't offer one
-function useLocalJsonSchema(pathStr: string, path: Path): z.ZodType | undefined {
+function useLocalJsonSchema(pathStr: string): z.ZodType | undefined {
 	const rootSchema = React.useContext(RootSchemaContext)
 	return React.useMemo(
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- `path` is rebuilt every render; pathStr identifies it
-		() => (rootSchema && LOCAL_JSON_EDITOR_PATHS.has(pathStr) ? Zod.schemaAtPath(rootSchema, path) : undefined),
-		[
-			rootSchema,
-			pathStr,
-			path,
-		],
+		// splitting pathStr rather than taking the path array keeps this memo stable: the array is rebuilt every render.
+		// Only the declared paths are split, and those have no dots inside a segment.
+		() => (rootSchema && LOCAL_JSON_EDITOR_PATHS.has(pathStr) ? Zod.schemaAtPath(rootSchema, pathStr.split('.')) : undefined),
+		[rootSchema, pathStr],
 	)
 }
 
-function LocalJsonToggle({ on, onToggle }: { on: boolean; onToggle: () => void }) {
+// the GUI/JSON segmented control the settings-page section headers use, scaled down to sit in a field's header row
+function LocalModeToggle({ mode, onSelect }: { mode: FieldMode; onSelect: (next: FieldMode) => void }) {
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<Button type="button" size="sm" variant={on ? 'secondary' : 'ghost'} className="h-6 gap-1 px-1.5 text-xs" onClick={onToggle}>
-					<Icons.Braces className="h-3 w-3" />
-					JSON
+		<div className="flex items-center rounded-md border p-0.5">
+			{(['gui', 'json'] as const).map((option) => (
+				<Button
+					key={option}
+					type="button"
+					size="sm"
+					variant={mode === option ? 'secondary' : 'ghost'}
+					className="h-5 px-1.5 text-[10px]"
+					onClick={() => onSelect(option)}
+				>
+					{option === 'gui' ? 'GUI' : 'JSON'}
 				</Button>
-			</TooltipTrigger>
-			<TooltipContent>{on ? 'Back to the form' : 'Edit just this setting as JSON'}</TooltipContent>
-		</Tooltip>
+			))}
+		</div>
 	)
 }
 
@@ -3382,8 +3388,8 @@ function SectionField(
 	const SectionExtra = sectionExtraFor(path)
 	// leaves dim themselves individually; the section only needs its own bulk-reset controls neutralized
 	const writable = RBAC.settingsPathOverlaps(React.useContext(WriteAccessContext), path)
-	const jsonSchema = useLocalJsonSchema(pathStr, path)
-	const [jsonMode, setJsonMode] = React.useState(false)
+	const jsonSchema = useLocalJsonSchema(pathStr)
+	const [mode, setMode] = React.useState<FieldMode>('gui')
 	return (
 		<fieldset
 			id={domId}
@@ -3398,13 +3404,13 @@ function SectionField(
 					<span className="contents" inert={!writable}>
 						<FieldResetControls value$={value$} reset$={reset$} onChange={onChange} node={node} path={path} showDefaultLabel={false} />
 					</span>
-					{jsonSchema && writable && <LocalJsonToggle on={jsonMode} onToggle={() => setJsonMode((v) => !v)} />}
+					{jsonSchema && writable && <LocalModeToggle mode={mode} onSelect={setMode} />}
 					<AnchorLink domId={domId} />
 				</div>
 				{description && <p className="text-xs text-muted-foreground">{description}</p>}
 				{SectionExtra && <SectionExtra />}
 				<FieldIssues issues={sectionIssues} pathStr={pathStr} />
-				{jsonSchema && jsonMode
+				{jsonSchema && mode === 'json'
 					? (
 						<LocalJsonField
 							schema={jsonSchema}
@@ -3444,8 +3450,8 @@ function LeafField(
 	// loose overlap: a grant pointing inside this field's subtree still permits editing part of it, so the field stays
 	// active and the save panel's exact per-path check flags anything outside the grant
 	const writable = RBAC.settingsPathOverlaps(React.useContext(WriteAccessContext), path)
-	const jsonSchema = useLocalJsonSchema(pathStr, path)
-	const [jsonMode, setJsonMode] = React.useState(false)
+	const jsonSchema = useLocalJsonSchema(pathStr)
+	const [mode, setMode] = React.useState<FieldMode>('gui')
 	// the inline "default: <value>" hint only reads well for scalars; complex/override fields still get the reset buttons
 	const showDefaultLabel = !hasOverride && isScalarNode(inner)
 	const controls = (
@@ -3479,7 +3485,7 @@ function LeafField(
 						</Tooltip>
 					)}
 					{!isBoolean && controls}
-					{jsonSchema && writable && <LocalJsonToggle on={jsonMode} onToggle={() => setJsonMode((v) => !v)} />}
+					{jsonSchema && writable && <LocalModeToggle mode={mode} onSelect={setMode} />}
 					<AnchorLink domId={domId} />
 				</div>
 				{description && <p className="text-xs text-muted-foreground">{description}</p>}
@@ -3487,7 +3493,7 @@ function LeafField(
 			</div>
 			<div className={cn(isBoolean && 'shrink-0 flex items-center gap-1')} inert={!writable}>
 				{isBoolean && controls}
-				{jsonSchema && jsonMode
+				{jsonSchema && mode === 'json'
 					? (
 						<LocalJsonField
 							schema={jsonSchema}

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -3305,10 +3305,11 @@ function useLocalJsonSchema(pathStr: string): z.ZodType | undefined {
 	)
 }
 
-// the GUI/JSON segmented control the settings-page section headers use, scaled down to sit in a field's header row
+// the GUI/JSON segmented control the settings-page section headers use, scaled down to sit in a field's header row.
+// `ml-auto` pins it to the right end of that row, where the page-level control sits in its own header.
 function LocalModeToggle({ mode, onSelect }: { mode: FieldMode; onSelect: (next: FieldMode) => void }) {
 	return (
-		<div className="flex items-center rounded-md border p-0.5">
+		<div className="ml-auto flex items-center rounded-md border p-0.5">
 			{(['gui', 'json'] as const).map((option) => (
 				<Button
 					key={option}
@@ -3404,8 +3405,8 @@ function SectionField(
 					<span className="contents" inert={!writable}>
 						<FieldResetControls value$={value$} reset$={reset$} onChange={onChange} node={node} path={path} showDefaultLabel={false} />
 					</span>
-					{jsonSchema && writable && <LocalModeToggle mode={mode} onSelect={setMode} />}
 					<AnchorLink domId={domId} />
+					{jsonSchema && writable && <LocalModeToggle mode={mode} onSelect={setMode} />}
 				</div>
 				{description && <p className="text-xs text-muted-foreground">{description}</p>}
 				{SectionExtra && <SectionExtra />}
@@ -3485,8 +3486,8 @@ function LeafField(
 						</Tooltip>
 					)}
 					{!isBoolean && controls}
-					{jsonSchema && writable && <LocalModeToggle mode={mode} onSelect={setMode} />}
 					<AnchorLink domId={domId} />
+					{jsonSchema && writable && <LocalModeToggle mode={mode} onSelect={setMode} />}
 				</div>
 				{description && <p className="text-xs text-muted-foreground">{description}</p>}
 				<FieldIssues issues={fieldIssues} pathStr={pathStr} />

--- a/src/lib/settings-groups.ts
+++ b/src/lib/settings-groups.ts
@@ -32,6 +32,57 @@ export const GLOBAL_SETTINGS_GROUPS: SettingsGroup[] = [
 // order. Presentation-only, so the persisted shape is untouched (same rationale as the groups above).
 export const SERVER_SETTINGS_PRIORITY_KEYS: string[] = ['connections', 'adminListSources', 'adminIdentifyingPermissions']
 
+// Settings most installs never touch. Their field renders inside an "Advanced" disclosure at the bottom of whichever
+// section owns it (a group, a nested section, or the form root), collapsed by default. Matched on the field's dotted
+// path, so a whole subtree can be tucked away by naming its root. Presentation-only, like the groups above: the field
+// itself is unchanged, and the TOC still lists it (navigating to one opens the disclosure it sits in).
+export const ADVANCED_GLOBAL_SETTINGS_PATHS: ReadonlySet<string> = new Set([
+	'topBarColor',
+	'warnOnSlmStart',
+	'warnPrefix',
+	'chat',
+	'allowedPrefixes',
+	'layerQueue.lowQueueWarningThreshold',
+	'layerQueue.adminQueueReminderInterval',
+	'vote.voteReminderInterval',
+	'vote.internalVoteReminderInterval',
+	'vote.finalVoteReminder',
+	'vote.autoStartVoteCutoff',
+	'vote.maxNumVoteChoices',
+	'squadServer',
+	'fogOffDelay',
+	'postRollAnnouncementsTimeout',
+])
+
+export const ADVANCED_SERVER_SETTINGS_PATHS: ReadonlySet<string> = new Set([
+	'updatesToSquadServerDisabled',
+	'overrideAdminSetNextLayer',
+	'warnOnChangeLayer',
+	'navLinks',
+])
+
+// Subtrees whose GUI editor is elaborate enough that bulk edits (reordering, copying a role between installs, pasting a
+// block from a diff) are easier as text. Their field header gets a GUI/JSON toggle that swaps just that subtree for a
+// schema-checked JSON editor, so the rest of the form stays as it is. Matched on the field's dotted path; only paths
+// whose schema is statically addressable (see Zod.schemaAtPath) can be listed, and nothing holding a secret should be.
+export const LOCAL_JSON_EDITOR_PATHS: ReadonlySet<string> = new Set([
+	// global
+	'rbac',
+	'commands',
+	'adminActionReasons',
+	'broadcasts',
+	'commandAliases',
+	'messageVariables',
+	'playerGroupings',
+	'layerTable',
+	'layerGeneration',
+	'balanceTriggerLevels',
+	'chat',
+	// server
+	'queue',
+	'adminListSources',
+])
+
 // paths the TOC must treat as leaves even though their schema node is an object with properties: they render via
 // override widgets, so no per-property anchors exist in the DOM
 export const TOC_LEAF_PATHS: ReadonlySet<string> = new Set([
@@ -44,6 +95,14 @@ export const TOC_LEAF_PATHS: ReadonlySet<string> = new Set([
 	// the whole rbac subtree renders as one consolidated per-role editor, so it emits no per-subkey anchors
 	'rbac',
 ])
+
+// partition a section's child keys into the ones it renders directly and the ones that belong in its "Advanced"
+// disclosure, preserving the incoming order within each. `parentPath` is the dotted path of the section itself ('' at
+// the form root), since advanced-ness is declared per full path.
+export function splitAdvanced(keys: string[], parentPath: string, advanced: ReadonlySet<string>): { normal: string[]; advanced: string[] } {
+	const isAdvanced = (key: string) => advanced.has(parentPath ? `${parentPath}.${key}` : key)
+	return { normal: keys.filter((k) => !isAdvanced(k)), advanced: keys.filter(isAdvanced) }
+}
 
 // partition `keys` (schema property order) into the ordered group buckets plus the ungrouped remainder
 export function splitByGroups(

--- a/src/lib/zod.test.ts
+++ b/src/lib/zod.test.ts
@@ -1,0 +1,48 @@
+import { HumanTime, schemaAtPath } from '@/lib/zod'
+import * as SETTINGS from '@/models/settings.models'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+// schemaAtPath walks zod's internals to find the schema at a path, which is what lets the settings form hand a subtree
+// its own editor. These pin the wrapper shapes it has to see through -- a zod upgrade that renames them would otherwise
+// only surface as a JSON toggle silently disappearing from the page.
+describe('schemaAtPath', () => {
+	it('walks through the wrappers that preserve an object shape', () => {
+		const leaf = z.string()
+		const schema = z.object({
+			plain: z.object({ leaf }),
+			defaulted: z.object({ leaf }).prefault({ leaf: '' }),
+			optional: z.object({ leaf }).optional(),
+			nullable: z.object({ leaf }).nullable(),
+			// a one-way transform: the input side is the shape the settings drafts hold, so the walk follows it
+			transformed: z.object({ leaf }).prefault({ leaf: '' }).transform((v) => v),
+		})
+		for (const key of ['plain', 'defaulted', 'optional', 'nullable', 'transformed']) {
+			expect(schemaAtPath(schema, [key, 'leaf']), key).toBe(leaf)
+		}
+	})
+
+	it('returns a codec whole rather than descending into it', () => {
+		const schema = z.object({ delay: HumanTime })
+		expect(schemaAtPath(schema, ['delay'])).toBe(HumanTime)
+	})
+
+	it('is undefined for paths it cannot statically address', () => {
+		const schema = z.object({ list: z.array(z.object({ leaf: z.string() })), rec: z.record(z.string(), z.string()) })
+		expect(schemaAtPath(schema, ['missing'])).toBeUndefined()
+		expect(schemaAtPath(schema, ['list', 0, 'leaf'])).toBeUndefined()
+		expect(schemaAtPath(schema, ['rec', 'anything'])).toBeUndefined()
+	})
+
+	it('resolves every path the settings form offers a scoped JSON editor for', () => {
+		const parsed = SETTINGS.parseGlobalSettings({})
+		expect(parsed.success).toBe(true)
+		for (const path of ['rbac', 'commands', 'playerGroupings', 'layerTable', 'squadServer.rconCacheTTL']) {
+			const sub = schemaAtPath(SETTINGS.GlobalSettingsSchema, path.split('.'))
+			expect(sub, path).toBeDefined()
+			// the editor writes back through encode, so each subtree must survive the decoded -> input round trip
+			const decoded = path.split('.').reduce<any>((acc, key) => acc?.[key], parsed.data)
+			expect(() => sub!.encode(decoded), path).not.toThrow()
+		}
+	})
+})

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -147,3 +147,32 @@ export type EnumToTuple<S extends z.ZodEnum> = [z.infer<S>, ...z.infer<S>[]]
 export function enumTupleOptions<S extends z.ZodEnum>(schema: S): EnumToTuple<S> {
 	return schema.options as unknown as EnumToTuple<S>
 }
+
+// wrappers that don't change an object's shape at a key boundary. `pipe` resolves to its input side because callers
+// navigate the input/encoded shape (what the settings drafts hold), which is also the side a codec is edited in.
+const SHAPE_PRESERVING_WRAPPERS = ['optional', 'nullable', 'default', 'prefault', 'readonly', 'nonoptional']
+
+function unwrapToObject(schema: unknown): { shape: Record<string, z.ZodType> } | undefined {
+	let cur = schema as any
+	while (cur?.def) {
+		const type = cur.def.type
+		if (type === 'object' || type === 'interface') return cur
+		if (SHAPE_PRESERVING_WRAPPERS.includes(type)) cur = cur.def.innerType
+		else if (type === 'pipe') cur = cur.def.in
+		else return undefined
+	}
+	return undefined
+}
+
+// The schema sitting at `path` within `schema`, or undefined when the path isn't statically addressable (it runs
+// through a record/array entry, or a node with no shape). Codec-carrying subtrees come back whole, so the result parses
+// the same input shape the path addresses.
+export function schemaAtPath(schema: z.ZodType, path: readonly (string | number)[]): z.ZodType | undefined {
+	let cur: z.ZodType | undefined = schema
+	for (const key of path) {
+		const obj: { shape: Record<string, z.ZodType> } | undefined = cur && unwrapToObject(cur)
+		cur = obj?.shape[String(key)]
+		if (!cur) return undefined
+	}
+	return cur
+}

--- a/src/routes/_app/settings.tsx
+++ b/src/routes/_app/settings.tsx
@@ -16,7 +16,7 @@ import { frameManager } from '@/frames/frame-manager'
 import * as SettingsEditorFrame from '@/frames/settings-editor.frame'
 import { createId } from '@/lib/id'
 import { useRefConstructor } from '@/lib/react'
-import { GLOBAL_SETTINGS_GROUPS, SERVER_SETTINGS_PRIORITY_KEYS } from '@/lib/settings-groups'
+import { ADVANCED_GLOBAL_SETTINGS_PATHS, ADVANCED_SERVER_SETTINGS_PATHS, GLOBAL_SETTINGS_GROUPS, SERVER_SETTINGS_PRIORITY_KEYS } from '@/lib/settings-groups'
 import * as SettingsNav from '@/lib/settings-nav'
 import { assertNever } from '@/lib/type-guards'
 import { cn } from '@/lib/utils'
@@ -724,6 +724,7 @@ function ServerSettingsSection(
 								saved={saved}
 								idPrefix={`setting:server:${server.id}:`}
 								priorityKeys={SERVER_SETTINGS_PRIORITY_KEYS}
+								advancedPaths={ADVANCED_SERVER_SETTINGS_PATHS}
 								issues={issues}
 								writeAccess={formWriteAccess}
 							/>
@@ -829,6 +830,7 @@ function CreateServerSection({ stores, onCancel }: { stores: SettingsEditorFrame
 								saved={SettingsEditorFrame.NEW_SERVER_DRAFT}
 								idPrefix="setting:server:__new__:"
 								priorityKeys={SERVER_SETTINGS_PRIORITY_KEYS}
+								advancedPaths={ADVANCED_SERVER_SETTINGS_PATHS}
 								issues={issues}
 							/>
 						)
@@ -932,6 +934,7 @@ function GlobalSettingsSection({ stores }: { stores: SettingsEditorFrame.KeyProp
 								onChange={onFormChange}
 								saved={saved}
 								groups={GLOBAL_SETTINGS_GROUPS}
+								advancedPaths={ADVANCED_GLOBAL_SETTINGS_PATHS}
 								issues={issues}
 								writeAccess={writeAccess}
 							/>

--- a/src/routes/_app/settings.tsx
+++ b/src/routes/_app/settings.tsx
@@ -736,6 +736,7 @@ function ServerSettingsSection(
 									schema={schema}
 									value={draft}
 									onValidChange={(v: any) => SettingsEditorFrame.Actions.setJsonValid({ settingsEditor: key }, v)}
+									onReady={() => SettingsNav.scrollToAnchorSettled(`section:server:${server.id}`)}
 									minHeightPx={350}
 									label="Server Settings"
 									toolbar={
@@ -841,6 +842,7 @@ function CreateServerSection({ stores, onCancel }: { stores: SettingsEditorFrame
 									schema={SETTINGS.ServerSettingsSchema}
 									value={draft}
 									onValidChange={(v: any) => SettingsEditorFrame.Actions.setJsonValid({ settingsEditor: key }, v)}
+									onReady={() => SettingsNav.scrollToAnchorSettled(`section:server:${NEW_SERVER_SELECTION}`)}
 									minHeightPx={350}
 									label="Server Settings"
 								/>
@@ -947,6 +949,7 @@ function GlobalSettingsSection({ stores }: { stores: SettingsEditorFrame.KeyProp
 									schema={SETTINGS.GlobalSettingsSchema}
 									value={draft}
 									onValidChange={(v: any) => SettingsEditorFrame.Actions.setJsonValid({ settingsEditor: key }, v)}
+									onReady={() => SettingsNav.scrollToAnchorSettled('section:global')}
 									minHeightPx={450}
 									label="Global Settings"
 									toolbar={


### PR DESCRIPTION
Two presentation-level improvements to the settings editor. Both are declared in `settings-groups.ts` next to the existing groups, so the persisted settings shape is untouched.

## Advanced disclosures

Settings most installs never touch now render inside a collapsed **Advanced** disclosure at the bottom of whichever section owns them, rather than padding out the section they belong to. It works at any level: a group (`General` is now one field plus `Advanced (2)`), a nested section, or the form root (server settings).

Advanced-ness is declared per dotted path, so naming a subtree root tucks the whole thing away (`squadServer`). The fields are otherwise unchanged, and the TOC still lists them:

- Navigating to an advanced setting (TOC click, pasted fragment) opens its disclosure before the settle-scroll runs.
- A validation issue at or below a collapsed path force-opens it. A hidden error would otherwise block the save with nothing on screen to explain it.

## Scoped JSON editors

Subtrees whose GUI editor is elaborate enough that bulk edits are easier as text (`rbac`, `commands`, `playerGroupings`, `layerTable`, the server pool config, ...) get a **JSON** toggle in their field header. It swaps just that subtree for a schema-checked CodeMirror editor and leaves the rest of the form as it is -- the section's header, description, callouts and reset controls all stay put. The toggle is hidden on fields the user can't write, and nothing holding a secret is listed.

The sub-schema comes from a new `Zod.schemaAtPath`, which walks the shape-preserving wrappers (`optional`/`prefault`/`pipe`/...) to the schema at a path. Notes on the two things that were subtle:

- **Shape.** Drafts hold the input/encoded shape, but the editor validates through the sub-schema and yields the decoded shape. Edits are encoded back, so a codec-carrying subtree round-trips as `"2h"` rather than `7200000`. A subtree with a one-way transform can't encode and its output shape is its input shape, so it falls through.
- **Buffer ownership.** The editor owns its document while open; feeding our own edits back as `value` would re-sync it mid-keystroke. Re-seeding on `reset$` has to remount it, because the editor only re-syncs when `value` differs from what it last synced -- and a reset usually restores the very value it was seeded with, which would leave the user's edits sitting in the buffer.

## Verification

Driven end to end on a dev instance, plus `check` / `lint` / 562 tests green:

- Editing `adminListSources` as JSON updates the shared save panel, and the GUI shows the parsed result on toggle-back.
- `rbac` renders as JSON with `"maxTimeout": "2h"`; changing it to `3h` shows `3h` (not milliseconds) back in the GUI.
- Reset with a scoped editor open re-seeds it (this caught the remount bug above).
- Clicking an advanced TOC entry opens its disclosure and lands on the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)