### PR TITLE
Stop stripping non-ascii when matching player and squad names

### DIFF
--- a/docs/LOG_NAME_MATCHING.md
+++ b/docs/LOG_NAME_MATCHING.md
@@ -1,0 +1,43 @@
+# Matching player names from logs
+
+`Die()`/`Wound()` log lines identify their victim by display name only, with no online ids. Resolving that name
+against the RCON roster is `PlayerIds.findByUsernameLoose`, which leans on `StrUtils.normalizeForMatch`. This
+documents what those two are actually allowed to assume, because the obvious guesses are wrong in both directions.
+
+## The only real divergence is the clan tag
+
+Measured over ~318MB of production `SquadGame.log` (11 files, 1924 distinct `OnPossess(): PC=` names, 1944 distinct
+`Die()`/`Wound(): Player:` names), comparing every victim name against the set of names the server itself reports:
+
+| normalization applied | victim names resolved to exactly one roster name |
+| --------------------- | ------------------------------------------------ |
+| exact, after trim     | 1792                                             |
+| + lowercase           | +0                                               |
+| + NFKC                | +0                                               |
+| + strip whitespace    | +0                                               |
+
+After trimming, **the log name and the RCON name are byte-identical or they differ by a clan tag.** Nothing else.
+Case, internal whitespace, and unicode composition never diverge between the two sources: they are the same string
+from the same server. The remaining ~420 victim names are the tag-prefix case, which the reverse-containment pass in
+`findByUsernameLoose` handles, plus players who never possessed a pawn in the same log.
+
+So `normalizeForMatch` does not exist to reconcile log-vs-RCON noise. It exists for the _other_ callers, where a
+**human types** a name: chat commands (`!warn`, `!flag`, squad lookup) and the teams-panel search box. Case,
+whitespace, and composition folding are for them, and are justified on that basis alone.
+
+## Why stripping non-ascii was removed
+
+`normalizeForMatch` used to be `s.replace(/[^\x20-\x7E]|\s/g, '').toLowerCase()`, discarding everything outside
+printable ascii. This was actively harmful:
+
+- A fully non-latin name normalized to the **empty string**. Matching here is containment, and the empty string is
+  contained in every name, so such a player matched every search and every search matched them. They were
+  unaddressable by name from chat commands and unfindable in the teams panel.
+- Against the same corpus, stripping **broke 237** victim names that resolve correctly when non-ascii is kept, and
+  uniquely resolved only **2** that keeping does not, both of the form `Ω Trouser Trout`.
+- Those 2 are not evidence for stripping. They are the tag-prefix case with a non-ascii tag, which the reverse pass
+  already handles; they only came out ambiguous here because this analysis matched against a global roster of every
+  name ever seen rather than one server's live roster.
+
+There is no case in the corpus where stripping non-ascii is what rescues a match. If you are about to re-add it,
+re-run the measurement first (`OnPossess(): PC=` names vs `Die()/Wound(): Player:` names) and put the number here.

--- a/src/lib/string.test.ts
+++ b/src/lib/string.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest'
+
+import { normalizeForMatch, simpleUniqueStringMatch } from './string'
+
+const PYOTR = 'Пётр'
+const TANAKA = 'たなか'
+const JOSE_PRECOMPOSED = 'José'
+const JOSE_DECOMPOSED = 'José'
+
+describe('normalizeForMatch', () => {
+	test('keeps non-ascii by default', () => {
+		expect(normalizeForMatch(PYOTR)).toBe(PYOTR.toLowerCase())
+		expect(normalizeForMatch(TANAKA)).toBe(TANAKA)
+	})
+
+	test('folds compatibility and composition differences', () => {
+		expect(JOSE_DECOMPOSED).not.toBe(JOSE_PRECOMPOSED)
+		expect(normalizeForMatch(JOSE_DECOMPOSED)).toBe(normalizeForMatch(JOSE_PRECOMPOSED))
+		// fullwidth tags fold to plain ascii
+		expect(normalizeForMatch('ＴＡＧ')).toBe('tag')
+	})
+
+	test('strips whitespace and case in both modes', () => {
+		expect(normalizeForMatch('[TAG] Bob Smith')).toBe('[tag]bobsmith')
+		expect(normalizeForMatch('[TAG] Bob Smith', { stripNonAscii: true })).toBe('[tag]bobsmith')
+	})
+
+	test('stripNonAscii discards everything outside printable ascii', () => {
+		expect(normalizeForMatch(PYOTR, { stripNonAscii: true })).toBe('')
+		expect(normalizeForMatch(`Ivan ${PYOTR}`, { stripNonAscii: true })).toBe('ivan')
+	})
+})
+
+describe('simpleUniqueStringMatch', () => {
+	const names = [PYOTR, TANAKA, 'Bob', JOSE_PRECOMPOSED]
+
+	test('resolves a non-latin name against itself', () => {
+		expect(simpleUniqueStringMatch(names, PYOTR)).toEqual({ code: 'ok', matched: 0 })
+		expect(simpleUniqueStringMatch(names, TANAKA)).toEqual({ code: 'ok', matched: 1 })
+	})
+
+	test('resolves a partial non-latin name', () => {
+		expect(simpleUniqueStringMatch(names, PYOTR.slice(1))).toEqual({ code: 'ok', matched: 0 })
+	})
+
+	test('resolves a name typed in a different composition form', () => {
+		expect(simpleUniqueStringMatch(names, JOSE_DECOMPOSED)).toEqual({ code: 'ok', matched: 3 })
+	})
+
+	// the reason stripNonAscii is off by default: stripping leaves an empty needle, which every name contains
+	test('stripNonAscii makes a non-latin name match everything', () => {
+		expect(simpleUniqueStringMatch(names, PYOTR, { stripNonAscii: true })).toEqual({
+			code: 'err:multiple-matches',
+			count: names.length,
+		})
+	})
+
+	test('still distinguishes latin names', () => {
+		expect(simpleUniqueStringMatch(names, 'bob')).toEqual({ code: 'ok', matched: 2 })
+		expect(simpleUniqueStringMatch(names, 'zzz')).toEqual({ code: 'err:not-found' })
+	})
+})

--- a/src/lib/string.test.ts
+++ b/src/lib/string.test.ts
@@ -4,11 +4,12 @@ import { normalizeForMatch, simpleUniqueStringMatch } from './string'
 
 const PYOTR = 'Пётр'
 const TANAKA = 'たなか'
-const JOSE_PRECOMPOSED = 'José'
-const JOSE_DECOMPOSED = 'José'
+// escaped rather than literal: dprint normalizes the source file, which would collapse these two into one string
+const JOSE_PRECOMPOSED = 'Jos\u00e9'
+const JOSE_DECOMPOSED = 'Jose\u0301'
 
 describe('normalizeForMatch', () => {
-	test('keeps non-ascii by default', () => {
+	test('keeps non-ascii', () => {
 		expect(normalizeForMatch(PYOTR)).toBe(PYOTR.toLowerCase())
 		expect(normalizeForMatch(TANAKA)).toBe(TANAKA)
 	})
@@ -20,14 +21,8 @@ describe('normalizeForMatch', () => {
 		expect(normalizeForMatch('ＴＡＧ')).toBe('tag')
 	})
 
-	test('strips whitespace and case in both modes', () => {
+	test('folds case and whitespace', () => {
 		expect(normalizeForMatch('[TAG] Bob Smith')).toBe('[tag]bobsmith')
-		expect(normalizeForMatch('[TAG] Bob Smith', { stripNonAscii: true })).toBe('[tag]bobsmith')
-	})
-
-	test('stripNonAscii discards everything outside printable ascii', () => {
-		expect(normalizeForMatch(PYOTR, { stripNonAscii: true })).toBe('')
-		expect(normalizeForMatch(`Ivan ${PYOTR}`, { stripNonAscii: true })).toBe('ivan')
 	})
 })
 
@@ -45,14 +40,6 @@ describe('simpleUniqueStringMatch', () => {
 
 	test('resolves a name typed in a different composition form', () => {
 		expect(simpleUniqueStringMatch(names, JOSE_DECOMPOSED)).toEqual({ code: 'ok', matched: 3 })
-	})
-
-	// the reason stripNonAscii is off by default: stripping leaves an empty needle, which every name contains
-	test('stripNonAscii makes a non-latin name match everything', () => {
-		expect(simpleUniqueStringMatch(names, PYOTR, { stripNonAscii: true })).toEqual({
-			code: 'err:multiple-matches',
-			count: names.length,
-		})
 	})
 
 	test('still distinguishes latin names', () => {

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -37,35 +37,28 @@ export namespace StrPatterns {
 	export const PATH_SEGMENT = /[^/]+/
 }
 
-export type NormalizeForMatchOpts = {
-	// Discards everything outside printable ascii. Only appropriate when the two sides are known to disagree about their
-	// non-ascii characters (see PlayerIds.findByUsernameLoose). For anything a user types this is hostile: a fully
-	// non-latin name normalizes to the empty string, which is contained in every other name.
-	stripNonAscii?: boolean
+// Folds away only what a human plausibly varies when typing a name to search for: case, spacing, and unicode
+// composition. Deliberately keeps non-ascii -- see docs/LOG_NAME_MATCHING.md for why stripping it was wrong.
+export function normalizeForMatch(s: string) {
+	return s.normalize('NFKC').replace(/\s/g, '').toLowerCase()
 }
 
-export function normalizeForMatch(s: string, opts?: NormalizeForMatchOpts) {
-	let normalized = s.normalize('NFKC')
-	if (opts?.stripNonAscii) normalized = normalized.replace(/[^\x20-\x7E]/g, '')
-	return normalized.replace(/\s/g, '').toLowerCase()
-}
-
-export function simpleStringMatch(names: string[], target: string, opts?: NormalizeForMatchOpts) {
-	const normalizedTarget = normalizeForMatch(target, opts)
+export function simpleStringMatch(names: string[], target: string) {
+	const normalizedTarget = normalizeForMatch(target)
 	const matched: number[] = []
 	for (let i = 0; i < names.length; i++) {
-		if (normalizeForMatch(names[i], opts).includes(normalizedTarget)) {
+		if (normalizeForMatch(names[i]).includes(normalizedTarget)) {
 			matched.push(i)
 		}
 	}
 	return matched
 }
 
-export function simpleUniqueStringMatch(names: string[], target: string, opts?: NormalizeForMatchOpts) {
-	const normalizedTarget = normalizeForMatch(target, opts)
+export function simpleUniqueStringMatch(names: string[], target: string) {
+	const normalizedTarget = normalizeForMatch(target)
 	const matched: number[] = []
 	for (let i = 0; i < names.length; i++) {
-		if (normalizeForMatch(names[i], opts).includes(normalizedTarget)) {
+		if (normalizeForMatch(names[i]).includes(normalizedTarget)) {
 			matched.push(i)
 		}
 	}

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -37,25 +37,35 @@ export namespace StrPatterns {
 	export const PATH_SEGMENT = /[^/]+/
 }
 
-export function normalizeForMatch(s: string) {
-	return s.replace(/[^\x20-\x7E]|\s/g, '').toLowerCase()
+export type NormalizeForMatchOpts = {
+	// Discards everything outside printable ascii. Only appropriate when the two sides are known to disagree about their
+	// non-ascii characters (see PlayerIds.findByUsernameLoose). For anything a user types this is hostile: a fully
+	// non-latin name normalizes to the empty string, which is contained in every other name.
+	stripNonAscii?: boolean
 }
-export function simpleStringMatch(names: string[], target: string) {
-	const normalizedTarget = normalizeForMatch(target)
+
+export function normalizeForMatch(s: string, opts?: NormalizeForMatchOpts) {
+	let normalized = s.normalize('NFKC')
+	if (opts?.stripNonAscii) normalized = normalized.replace(/[^\x20-\x7E]/g, '')
+	return normalized.replace(/\s/g, '').toLowerCase()
+}
+
+export function simpleStringMatch(names: string[], target: string, opts?: NormalizeForMatchOpts) {
+	const normalizedTarget = normalizeForMatch(target, opts)
 	const matched: number[] = []
 	for (let i = 0; i < names.length; i++) {
-		if (normalizeForMatch(names[i]).includes(normalizedTarget)) {
+		if (normalizeForMatch(names[i], opts).includes(normalizedTarget)) {
 			matched.push(i)
 		}
 	}
 	return matched
 }
 
-export function simpleUniqueStringMatch(names: string[], target: string) {
-	const normalizedTarget = normalizeForMatch(target)
+export function simpleUniqueStringMatch(names: string[], target: string, opts?: NormalizeForMatchOpts) {
+	const normalizedTarget = normalizeForMatch(target, opts)
 	const matched: number[] = []
 	for (let i = 0; i < names.length; i++) {
-		if (normalizeForMatch(names[i]).includes(normalizedTarget)) {
+		if (normalizeForMatch(names[i], opts).includes(normalizedTarget)) {
 			matched.push(i)
 		}
 	}

--- a/src/models/pending-events.models.ts
+++ b/src/models/pending-events.models.ts
@@ -1246,8 +1246,8 @@ async function* processPendingEvent(
 
 		case 'PLAYER_DIED':
 		case 'PLAYER_WOUNDED': {
-			// the log identifies the victim by display name only, which can diverge from the RCON roster name
-			// (tag/whitespace/unicode); fall back to a loose unique match rather than dropping the event
+			// the log identifies the victim by display name only, which can carry a clan tag the RCON roster name
+			// lacks; fall back to a loose unique match rather than dropping the event
 			let victim = SM.PlayerIds.find(state.currTeams.players, p => p.ids, pendingEvent.victimIds)
 			if (!victim && pendingEvent.victimIds.username) {
 				victim = SM.PlayerIds.findByUsernameLoose(state.currTeams.players, p => p.ids, pendingEvent.victimIds.username)

--- a/src/models/squad.models.test.ts
+++ b/src/models/squad.models.test.ts
@@ -565,6 +565,22 @@ describe('PlayerIds.findByUsernameLoose', () => {
 		const players = [player('a', 'AAA alpha'), player('b', 'beta AAA')]
 		expect(SM.PlayerIds.findByUsernameLoose(players, p => p.ids, 'AAA')).toBeUndefined()
 	})
+
+	// names lifted from the log corpus; these resolve via the tag-prefix pass, not by discarding the non-ascii
+	it('matches a log name whose tag is non-ascii', () => {
+		const players = [player('a', 'Ewan'), player('b', 'Hopeless')]
+		expect(SM.PlayerIds.findByUsernameLoose(players, p => p.ids, 'Ω Ewan')).toBe(players[0])
+	})
+
+	it('does not resolve a non-latin name to an arbitrary player', () => {
+		const players = [player('a', 'Bob'), player('b', 'Hopeless')]
+		expect(SM.PlayerIds.findByUsernameLoose(players, p => p.ids, 'Пётр')).toBeUndefined()
+	})
+
+	it('resolves a fully non-latin name to its own roster entry', () => {
+		const players = [player('a', 'кирикwise d(^. .^)'), player('b', 'Bob')]
+		expect(SM.PlayerIds.findByUsernameLoose(players, p => p.ids, '✘✘✘✘✘✘✘ кирикwise d(^. .^)')).toBe(players[0])
+	})
 })
 
 describe('toRecentPlayer', () => {

--- a/src/models/squad.models.ts
+++ b/src/models/squad.models.ts
@@ -324,14 +324,14 @@ export namespace PlayerIds {
 	// containment is possible when the real player isn't in the list, so only use this as a fallback after find().
 	export function findByUsernameLoose<T>(players: T[], cb: (item: T) => Type, username: string): T | undefined {
 		const names = players.map(p => cb(p).username ?? '')
-		const res = simpleUniqueStringMatch(names, username)
+		const res = simpleUniqueStringMatch(names, username, { stripNonAscii: true })
 		if (res.code === 'ok') return players[res.matched]
 		// the log name may carry a tag the RCON name lacks; try the reverse direction
-		const target = normalizeForMatch(username)
+		const target = normalizeForMatch(username, { stripNonAscii: true })
 		if (!target) return undefined
 		const reverseMatches: number[] = []
 		for (let i = 0; i < names.length; i++) {
-			const name = normalizeForMatch(names[i])
+			const name = normalizeForMatch(names[i], { stripNonAscii: true })
 			if (name && target.includes(name)) reverseMatches.push(i)
 		}
 		if (reverseMatches.length === 1) return players[reverseMatches[0]]

--- a/src/models/squad.models.ts
+++ b/src/models/squad.models.ts
@@ -319,19 +319,20 @@ export namespace PlayerIds {
 	}
 
 	// Resolves a player from a bare display name (e.g. a Die()/Wound() log line, which carries no online ids for the
-	// victim). Exact matching is find()'s job; this adds tolerance for tag/whitespace/unicode differences between log
-	// and RCON names via normalized containment in either direction, requiring the match to be unique. A unique-but-wrong
-	// containment is possible when the real player isn't in the list, so only use this as a fallback after find().
+	// victim). Exact matching is find()'s job; the one divergence this adds tolerance for is the clan tag, which the log
+	// name can carry while the RCON name doesn't -- hence containment in either direction, requiring a unique match.
+	// The log and RCON names do NOT otherwise disagree (docs/LOG_NAME_MATCHING.md). A unique-but-wrong containment is
+	// possible when the real player isn't in the list, so only use this as a fallback after find().
 	export function findByUsernameLoose<T>(players: T[], cb: (item: T) => Type, username: string): T | undefined {
 		const names = players.map(p => cb(p).username ?? '')
-		const res = simpleUniqueStringMatch(names, username, { stripNonAscii: true })
+		const res = simpleUniqueStringMatch(names, username)
 		if (res.code === 'ok') return players[res.matched]
 		// the log name may carry a tag the RCON name lacks; try the reverse direction
-		const target = normalizeForMatch(username, { stripNonAscii: true })
+		const target = normalizeForMatch(username)
 		if (!target) return undefined
 		const reverseMatches: number[] = []
 		for (let i = 0; i < names.length; i++) {
-			const name = normalizeForMatch(names[i], { stripNonAscii: true })
+			const name = normalizeForMatch(names[i])
 			if (name && target.includes(name)) reverseMatches.push(i)
 		}
 		if (reverseMatches.length === 1) return players[reverseMatches[0]]


### PR DESCRIPTION
Non-ascii is no longer stripped when matching player/squad names. Per review, the stripping is **gone entirely** rather than being an opt-in flag: I went looking for a case that justified it and the logs say there is none.

## The bug

`normalizeForMatch` was `s.replace(/[^\x20-\x7E]|\s/g, "").toLowerCase()`. Everything outside printable ascii was discarded, so a fully non-latin username normalized to the **empty string**. Matching here is containment, and the empty string is contained in every name, so `Пётр` matched every player on the server and every search matched `Пётр`. Those players were unaddressable by name from chat commands (`!warn`, `!flag`, squad lookup) and unfindable in the teams-panel search.

## Does the log-vs-RCON divergence actually exist? No.

The stripping was justified by a docstring claiming log names and RCON roster names disagree on `tag/whitespace/unicode`. Measured over ~318MB of production `SquadGame.log` (11 files, 1924 distinct `OnPossess(): PC=` names, 1944 distinct `Die()/Wound(): Player:` victim names):

| normalization applied | victim names resolved to exactly one roster name |
| --- | --- |
| exact, after trim | 1792 |
| + lowercase | +0 |
| + NFKC | +0 |
| + strip whitespace | +0 |

After the trim `PlayerIds.parse` already does, **the log name and the RCON name are byte-identical or they differ by a clan tag.** Nothing else. They are the same string from the same server. The whitespace/unicode claim was never real.

And stripping non-ascii is not neutral, it is negative:

- it **breaks 237** victim names that resolve correctly when non-ascii is kept,
- it uniquely resolves **2**, both of the form `Ω Trouser Trout` — non-ascii clan tags, i.e. the tag-prefix case the reverse-containment pass already handles. They only came out ambiguous because the analysis matched against a global roster of every name ever seen rather than one live roster.

## The change

- `normalizeForMatch(s)` keeps its signature; no opts, no flag. It folds case, whitespace, and unicode composition (NFKC), and keeps non-ascii. That folding is justified by the callers where a **human types** the name, not by log reconciliation.
- `findByUsernameLoose` keeps existing: the clan-tag divergence is real and frequent (~420 victim names), and its two-direction containment handles it.
- Docstrings in `squad.models.ts` and `pending-events.models.ts` corrected to stop asserting the whitespace/unicode divergence.
- The measurement is written down in `docs/LOG_NAME_MATCHING.md` so this does not get re-added on a hunch.

## Notes

- No persisted data or config touched; matching is computed per call.
- Behaviour change worth naming: a search that used to return "multiple matches" for a non-latin name now resolves to that player.
- Gotcha: dprint normalizes source files, which silently collapsed a decomposed-vs-precomposed test literal into a single string. Those constants use `\u` escapes.

## Testing

`src/lib/string.test.ts` (new) plus three `findByUsernameLoose` regression tests using real names from the corpus (`Ω Ewan`, `✘✘✘✘✘✘✘ кирикwise d(^. .^)`). Full unit suite passes (568 tests / 26 files), `tsc -b --force` clean, no merge conflicts with `main`. No new frontend surface beyond the existing teams-panel search box, so no dev-server link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)