### PR TITLE
Attribute queue-driven MAP_SETs so they fold into their QUEUE_UPDATED

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
 		"vite-plugin-oxlint": "^2.1.2",
 		"vite-tsconfig-paths": "^6.1.1",
 		"vitest": "^4.1.10",
+		"ws": "^8.21.1",
 		"zod": "^4.1.13",
 		"zustand": "^5.0.6",
 		"zustand-rx": "^2.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,9 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.16.0)(msw@2.4.11(typescript@7.0.1-rc))(vite@8.1.3(@types/node@22.16.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      ws:
+        specifier: ^8.21.1
+        version: 8.21.1(bufferutil@4.0.9)(utf-8-validate@6.0.5)
       zod:
         specifier: ^4.1.13
         version: 4.1.13

--- a/src/components/server-event.tsx
+++ b/src/components/server-event.tsx
@@ -739,14 +739,9 @@ function AppEventEntry(
 		return <TeamswapsUpdatedEvent event={event} appEvent={appEvent} actorLabel={actorLabel} stores={stores} />
 	}
 	if (appEvent.type === 'MAP_SET') {
-		// only override sets reach the feed; queue-driven MAP_SETs fold into their QUEUE_UPDATED (audit-only)
-		if (appEvent.reason === 'queue-updated') {
-			return (
-				<EventLine time={event.time} icon={<Icons.RefreshCw className="h-4 w-4 text-amber-500 shrink-0" />}>
-					Next layer set to <ShortLayerName layerId={appEvent.layerId} />
-				</EventLine>
-			)
-		}
+		// audit-only (see AppEvents.isFeedVisible): its QUEUE_UPDATED already names the layer, so drawing this too
+		// would just repeat it. Only override sets are worth a line of their own.
+		if (appEvent.reason === 'queue-updated') return null
 		// the overridden player (if any) is resolved into targetPlayers via involvedPlayerIds
 		const overrodePlayer = event.targetPlayers[0]
 		const who = appEvent.overrode?.type === 'player' && overrodePlayer && matchId !== null

--- a/src/models/app-events.models.test.ts
+++ b/src/models/app-events.models.test.ts
@@ -259,3 +259,39 @@ describe('summarizeQueueChanges', () => {
 		])
 	})
 })
+
+// the feed and the backfill both gate on this, so it's the one place the audit-only rule is written down
+describe('isFeedVisible', () => {
+	function mapSet(reason: AppEvents.MapSet['reason']) {
+		return AppEvents.create<AppEvents.MapSet>({
+			type: 'MAP_SET',
+			actor: { type: 'system' },
+			serverId: 's1',
+			matchId: 1,
+			causeId: null,
+			layerId: 'GD-RAAS-V1:USA-CA:RGF-CA',
+			reason,
+		})
+	}
+
+	it('hides a queue-driven MAP_SET: its QUEUE_UPDATED already reports the layer', () => {
+		expect(AppEvents.isFeedVisible(mapSet('queue-updated'))).toBe(false)
+	})
+
+	it('shows an override MAP_SET: nothing else in the feed reports it', () => {
+		expect(AppEvents.isFeedVisible(mapSet('override'))).toBe(true)
+	})
+
+	it('shows other event types', () => {
+		const warned = AppEvents.create<AppEvents.PlayerWarned>({
+			type: 'PLAYER_WARNED',
+			actor: { type: 'slm-user', userId: 42n },
+			serverId: 's1',
+			matchId: 1,
+			causeId: null,
+			message: 'stop',
+			targets: ['eos-1'],
+		})
+		expect(AppEvents.isFeedVisible(warned)).toBe(true)
+	})
+})

--- a/src/models/app-events.models.ts
+++ b/src/models/app-events.models.ts
@@ -367,6 +367,20 @@ export const AppEventSchema = z.discriminatedUnion('type', [
 ])
 export type AppEvent = z.infer<typeof AppEventSchema>
 
+// Whether this event belongs in the live activity feed, as opposed to being audit-log-only. The audit log records
+// what SLM did; the feed only wants what's worth reading, and a queue-driven MAP_SET says nothing its QUEUE_UPDATED
+// hasn't already said.
+//
+// Both sides of the feed have to agree on this: emitAppEvent vs persistAppEvent applies it when the event happens,
+// and the backfill that rebuilds the buffer from the db applies it again -- an unfiltered backfill puts audit-only
+// events into the feed on the next restart, which is not a state the live path can ever produce.
+export function isFeedVisible(event: AppEvent): boolean {
+	// 'queue-updated' folds into the QUEUE_UPDATED it links to via causeId; 'override' is news (SLM put the layer
+	// back over someone else's set) and names who it overrode
+	if (event.type === 'MAP_SET') return event.reason === 'override'
+	return true
+}
+
 export type AppEventType = AppEvent['type']
 
 // the players involved in an app event (targets, or a disbanded squad's members) as eos ids

--- a/src/models/chat.models.test.ts
+++ b/src/models/chat.models.test.ts
@@ -126,6 +126,44 @@ describe('chat.models application-event collapse', () => {
 		expect(entry.targetPlayers.map(p => p.ids.eos)).toEqual(['eos-1'])
 	})
 
+	// a queue save renders the next layer itself, so its MAP_SET server event must fold into the QUEUE_UPDATED rather
+	// than trailing it as a redundant "Next layer set to X" line
+	it('collapses a queue-driven MAP_SET into its QUEUE_UPDATED entry', () => {
+		const state = seededState([makePlayer('eos-1')])
+		const queueUpdated: CHAT.AppFeedEvent = {
+			type: 'APP_EVENT',
+			appEvent: {
+				type: 'QUEUE_UPDATED',
+				id: 'app-q',
+				time: 100,
+				actor: { type: 'slm-user', userId: 1n },
+				serverId: 's1',
+				matchId: 1,
+				causeId: null,
+				instanceId: null,
+				trigger: 'user-edit',
+				ops: [],
+				prevList: [],
+				list: [],
+			} satisfies AppEvents.QueueUpdated,
+		}
+		CHAT.handleEvent(state, queueUpdated)
+		const mapSet: SE.MapSet = {
+			type: 'MAP_SET',
+			id: 1,
+			time: 101,
+			matchId: 1,
+			layerId: 'l1',
+			source: { type: 'event', id: 'app-q' },
+		}
+		CHAT.handleEvent(state, mapSet)
+
+		expect(state.eventBuffer).toHaveLength(1)
+		const entry = state.eventBuffer[0]
+		if (entry.type !== 'APP_EVENT') throw new Error('expected APP_EVENT')
+		expect(entry.collapsed).toHaveLength(1)
+	})
+
 	it('enriches a SQUAD_DISBANDED app event with its members as targetPlayers', () => {
 		const state = seededState([makePlayer('eos-1'), makePlayer('eos-2')])
 		const appEvent: CHAT.AppFeedEvent = {

--- a/src/models/pending-events.models.test.ts
+++ b/src/models/pending-events.models.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it, vi } from 'vitest'
 const LAYER_A = 'RAW:Gorodok_RAAS_v1 RGF+CombinedArms ADF+Mechanized' as L.LayerId
 const LAYER_A_CLASSNAME = 'Gorodok_RAAS_v1'
 // Narva_RAAS_v1, Faction_1=CAF, Faction_2=RGF
+const LAYER_B = 'RAW:Narva_RAAS_v1 CAF+CombinedArms RGF+CombinedArms' as L.LayerId
 
 // --- Helpers ---
 
@@ -1725,6 +1726,75 @@ describe('PendingEvents', () => {
 			})
 			const events = await collect(state)
 			expect(events.find(e => e.type === 'PLAYER_LEFT_SQUAD')).toBeUndefined()
+		})
+	})
+
+	// SLM pushes an attribution when it sets a layer, and the MAP_SET the server reports back claims it, so the event
+	// carries the app event that caused it rather than the bare `rcon` the log line says.
+	describe('MAP_SET attribution', () => {
+		function syncedState() {
+			const { state } = makeState()
+			state.syncState = { type: 'synced' }
+			state.currentMatch = { historyEntryId: 1, layerId: LAYER_A }
+			state.currTeams = { players: [], squads: [] }
+			state.lastKnownLogEventTime = 1000
+			return state
+		}
+
+		function mapSetLog(state: PendingEvents.State, classname: string, factions: string) {
+			PendingEvents.onLogEvent(state, {
+				type: 'MAP_SET',
+				time: 2000,
+				chainID: 0,
+				raw: '',
+				nextLayer: classname,
+				nextFactions: factions,
+				source: { type: 'rcon' },
+			})
+		}
+
+		async function collectMapSet(state: PendingEvents.State, time = 2001) {
+			const events = await collectAt(state, time)
+			return events.find(e => e.type === 'MAP_SET') as SE.MapSet | undefined
+		}
+
+		it('claims the attribution for the layer that was actually set', async () => {
+			const state = syncedState()
+			PendingEvents.pushAttribution(state, { type: 'MAP_SET_ATTRIBUTION', itemId: 'item-1', layerId: LAYER_A, appEventId: 'app-1' })
+			mapSetLog(state, LAYER_A_CLASSNAME, 'RGF+CombinedArms ADF+Mechanized')
+
+			expect((await collectMapSet(state))?.source).toEqual({ type: 'event', id: 'app-1' })
+			expect(state.attributions).toHaveLength(0)
+		})
+
+		// a set-next whose MAP_SET never came back (or came back before its attribution landed) leaves one behind.
+		// Consuming it positionally left the next map set reporting a bare `rcon`, which renders as a redundant
+		// standalone feed entry instead of folding into the save that caused it.
+		it('is not poisoned by a stale attribution for a different layer', async () => {
+			const state = syncedState()
+			PendingEvents.pushAttribution(state, { type: 'MAP_SET_ATTRIBUTION', itemId: 'stale', layerId: LAYER_B, appEventId: 'app-stale' })
+			PendingEvents.pushAttribution(state, { type: 'MAP_SET_ATTRIBUTION', itemId: 'item-1', layerId: LAYER_A, appEventId: 'app-1' })
+			mapSetLog(state, LAYER_A_CLASSNAME, 'RGF+CombinedArms ADF+Mechanized')
+
+			expect((await collectMapSet(state))?.source).toEqual({ type: 'event', id: 'app-1' })
+		})
+
+		it('leaves a map set nobody attributed alone', async () => {
+			const state = syncedState()
+			mapSetLog(state, LAYER_A_CLASSNAME, 'RGF+CombinedArms ADF+Mechanized')
+
+			expect((await collectMapSet(state))?.source).toEqual({ type: 'rcon' })
+		})
+
+		it('drops an attribution whose MAP_SET never landed once it ages out', async () => {
+			const state = syncedState()
+			PendingEvents.pushAttribution(state, { type: 'MAP_SET_ATTRIBUTION', itemId: 'item-1', layerId: LAYER_A, appEventId: 'app-1' })
+			// process() ages attributions off against its own clock, so pin this one just past the TTL relative to it
+			state.attributions[0].time = 2001 - PendingEvents.ATTRIBUTION_TTL_MS - 1
+			mapSetLog(state, LAYER_A_CLASSNAME, 'RGF+CombinedArms ADF+Mechanized')
+
+			expect((await collectMapSet(state))?.source).toEqual({ type: 'rcon' })
+			expect(state.attributions).toHaveLength(0)
 		})
 	})
 })

--- a/src/models/pending-events.models.ts
+++ b/src/models/pending-events.models.ts
@@ -22,13 +22,18 @@ export type Attribution = {
 	itemId: string
 	layerId: L.LayerId
 	time: number
-	// when set, the resulting MAP_SET links to this QUEUE_UPDATED app event instead of the bespoke layer-queue source
+	// when set, the resulting MAP_SET links to this app event instead of the bespoke layer-queue source. it's whichever
+	// app event renders in the feed (a QUEUE_UPDATED, or a MAP_SET for an override), so the server event collapses into it
 	appEventId?: string
 }
 
 // how long an armed expectation lives before it's GC'd if its event never lands (RCON error, player left).
 // matched expectations are consumed immediately, so this is only a safety net -- NOT the matching window.
 export const DEFAULT_EXPECTATION_TTL_MS = 60_000
+
+// how long a pending MAP_SET attribution lives before it's GC'd if its MAP_SET never lands. Same safety-net role
+// as the expectation TTL: matching ones are consumed on match, so this only drops sets the server never reported.
+export const ATTRIBUTION_TTL_MS = 60_000
 
 // number of consecutive teams polls a player in currTeams must be absent from RCON ListPlayers before we cull
 // them. 2 == one grace poll, so a single dropped/partial poll never evicts a still-connected player. At the ~5s
@@ -356,6 +361,9 @@ export async function* process(
 	const ctx = { log, ...CS.init() }
 	// GC expectations whose event never landed (matched ones are consumed on match, so this only drops stale arms)
 	state.expectations = state.expectations.filter(e => e.expiresAt >= time)
+	// same for attributions: a set-next whose MAP_SET never came back would otherwise sit here forever, and a later
+	// set of that same layer would wrongly inherit it
+	state.attributions = state.attributions.filter(a => time - a.time <= ATTRIBUTION_TTL_MS)
 
 	// Roll/sync watchdog. While non-synced every event is dropped (see the synced gate), so a roll whose real-layer
 	// NEW_GAME log never arrived would wedge us in 'rolling' indefinitely. If we've been mid-sync past the timeout,
@@ -838,14 +846,17 @@ async function* processPendingEvent(
 			}
 			let source: SE.MapSet['source'] = pendingEvent.source
 			state.nextLayerId = layer.id
-			const attributionIndex = state.attributions.findIndex(a => a.type === 'MAP_SET_ATTRIBUTION')
+			// match on the layer, not on position: a set-next whose MAP_SET never landed (or landed before its own
+			// attribution did) leaves an attribution behind, and taking that one here would consume it AND leave this
+			// event unattributed -- which is what made a stale attribution poison the next map set
+			const attributionIndex = state.attributions.findIndex(a =>
+				a.type === 'MAP_SET_ATTRIBUTION' && L.areLayersCompatible(a.layerId, layer.id)
+			)
 			if (attributionIndex !== -1) {
 				const attribution = state.attributions[attributionIndex]
-				if (L.areLayersCompatible(attribution.layerId, layer.id)) {
-					source = attribution.appEventId
-						? { type: 'event', id: attribution.appEventId }
-						: { type: 'layer-queue', itemId: attribution.itemId }
-				}
+				source = attribution.appEventId
+					? { type: 'event', id: attribution.appEventId }
+					: { type: 'layer-queue', itemId: attribution.itemId }
 				state.attributions.splice(attributionIndex, 1)
 			}
 			yield {

--- a/src/systems/layer-queue.server.ts
+++ b/src/systems/layer-queue.server.ts
@@ -463,7 +463,10 @@ export const syncNextLayerToServer = C.spanOp(
 					})
 					if (mapSetCause.reason === 'override') await SquadServer.emitAppEvent(ctx, mapSet)
 					else await AppEventsSys.persistAppEvent(ctx, mapSet)
-					mapSetAppEventId = mapSet.id
+					// attribute to whichever app event reaches the feed, since that's what the server event collapses into:
+					// the QUEUE_UPDATED for a queue-driven set (its MAP_SET is audit-only), the MAP_SET itself for an override.
+					// the audit-only MAP_SET stays reachable from the QUEUE_UPDATED via its causeId.
+					mapSetAppEventId = mapSetCause.reason === 'queue-updated' ? mapSetCause.causeId : mapSet.id
 				}
 				// awaiting this will cause a deadlock on map roll, so it stays detached; observe its rejection
 				SquadServer.pushAttribution(ctx, {

--- a/src/systems/layer-queue.server.ts
+++ b/src/systems/layer-queue.server.ts
@@ -461,7 +461,7 @@ export const syncNextLayerToServer = C.spanOp(
 						matchId: (await MatchHistory.getCurrentMatch(ctx))?.historyEntryId ?? null,
 						causeId: mapSetCause.reason === 'queue-updated' ? mapSetCause.causeId : null,
 					})
-					if (mapSetCause.reason === 'override') await SquadServer.emitAppEvent(ctx, mapSet)
+					if (AppEvents.isFeedVisible(mapSet)) await SquadServer.emitAppEvent(ctx, mapSet)
 					else await AppEventsSys.persistAppEvent(ctx, mapSet)
 					// attribute to whichever app event reaches the feed, since that's what the server event collapses into:
 					// the QUEUE_UPDATED for a queue-driven set (its MAP_SET is audit-only), the MAP_SET itself for an override.

--- a/src/systems/squad-server.server.ts
+++ b/src/systems/squad-server.server.ts
@@ -1867,7 +1867,12 @@ const loadSavedEvents = C.spanOp(
 				.where(E.eq(Schema.appEvents.matchId, lastMatch.id))
 				.orderBy(E.asc(Schema.appEvents.time))
 			: []
-		server.emittedAppEvents = appEventRows.map((r) => AppEvents.fromRow(r)).filter((e): e is AppEvents.AppEvent => e !== null)
+		// this buffer is the feed, so it has to hold what the live path would have pushed -- not every row the audit
+		// log kept. Without the isFeedVisible filter an audit-only event (a queue-driven MAP_SET) reappears as its own
+		// feed entry after a restart, duplicating the QUEUE_UPDATED it was folded into.
+		server.emittedAppEvents = appEventRows
+			.map((r) => AppEvents.fromRow(r))
+			.filter((e): e is AppEvents.AppEvent => e !== null && AppEvents.isFeedVisible(e))
 	},
 )
 

--- a/test/harness/app-fixture.ts
+++ b/test/harness/app-fixture.ts
@@ -154,6 +154,10 @@ export type AppFixture = {
 	// fresh read-only connection to the app's db, for assertions
 	readDb: () => SqliteDb
 	waitFor: <T>(probe: () => T | Promise<T>, opts?: { timeoutMs?: number; intervalMs?: number; label?: string }) => Promise<NonNullable<T>>
+	// stop the app and boot it again against the same db, emulator and ports. For anything that only happens on
+	// boot -- notably the feed backfill, which rebuilds state from the db rather than from what it saw live.
+	// `child` on the fixture is the original process and goes stale across this; nothing else does.
+	restart: () => Promise<void>
 	dispose: () => Promise<void>
 }
 
@@ -457,7 +461,15 @@ export async function createAppFixture(opts: AppFixtureOptions = {}): Promise<Ap
 		)
 	}
 
-	if (opts.spawn !== false) {
+	async function stopApp() {
+		if (!child || child.exitCode !== null) return
+		child.kill('SIGTERM')
+		const killTimer = setTimeout(() => child?.kill('SIGKILL'), 8000)
+		await childExited
+		clearTimeout(killTimer)
+	}
+
+	async function spawnApp() {
 		const out = fs.openSync(logFile, 'a')
 		const [command, args] = serverCommand()
 		child = childProcess.spawn(command, args, { cwd: REPO_ROOT, env, stdio: ['ignore', out, out] })
@@ -472,6 +484,8 @@ export async function createAppFixture(opts: AppFixtureOptions = {}): Promise<Ap
 			return res !== null
 		}, { label: 'app readiness', timeoutMs: 60_000 })
 	}
+
+	if (opts.spawn !== false) await spawnApp()
 
 	// the real server agent tails the file the emulator writes and proxies its RCON; start it only once the
 	// app is listening so its first connection lands
@@ -514,14 +528,13 @@ export async function createAppFixture(opts: AppFixtureOptions = {}): Promise<Ap
 		},
 		readDb: () => new Database(dbPath, { readonly: true }),
 		waitFor,
+		restart: async () => {
+			await stopApp()
+			await spawnApp()
+		},
 		dispose: async () => {
 			serverAgent?.dispose()
-			if (child && child.exitCode === null) {
-				child.kill('SIGTERM')
-				const killTimer = setTimeout(() => child?.kill('SIGKILL'), 8000)
-				await childExited
-				clearTimeout(killTimer)
-			}
+			await stopApp()
 			emu.dispose()
 			bm.close()
 			// set SLM_KEEP_TEST_TMP=1 to retain the db + app log of a failing run

--- a/test/integration/queue-save-attribution.test.ts
+++ b/test/integration/queue-save-attribution.test.ts
@@ -1,4 +1,7 @@
+import type * as AppEvents from '@/models/app-events.models'
+import type * as CHAT from '@/models/chat.models'
 import * as SLL from '@/models/shared-layer-list'
+import * as SM from '@/models/squad.models'
 import type { OrpcAppRouter } from '@/server/orpc-app-router'
 import { createORPCClient } from '@orpc/client'
 import { RPCLink } from '@orpc/client/websocket'
@@ -37,6 +40,12 @@ beforeAll(async () => {
 		layerQueue: [queueItem(LAYERS.gorodokRaas, { itemId: HEAD_ITEM_ID }), queueItem(LAYERS.sumariSeed)],
 	})
 
+	await connect()
+}, 120_000)
+
+// opens an authed oRPC websocket, replacing any existing one (a restart drops the old socket with the app)
+async function connect() {
+	socket?.close()
 	// the query-param bypass logs the seeded admin in and hands back the session cookie the /orpc upgrade authenticates
 	const loginRes = await fetch(app.loginUrl(app.adminUser), { redirect: 'manual' })
 	const cookie = loginRes.headers.getSetCookie().map((c) => c.split(';')[0]).join('; ')
@@ -48,7 +57,7 @@ beforeAll(async () => {
 		socket.once('error', reject)
 	})
 	client = createORPCClient(new RPCLink({ websocket: socket as unknown as globalThis.WebSocket }))
-}, 120_000)
+}
 
 afterAll(async () => {
 	socket?.close()
@@ -57,6 +66,18 @@ afterAll(async () => {
 
 function dispatch(op: SLL.Operation) {
 	return client.layerQueue.dispatchOp({ serverId: app.serverId, op })
+}
+
+// the feed exactly as a freshly-connected client receives it: everything watchChatEvents replays up to the SYNCED
+// marker that closes the initial batch (which arrives in pages, see Arr.paged)
+async function initialFeedBatch(): Promise<(CHAT.Event | CHAT.LifecycleEvent)[]> {
+	const batch: (CHAT.Event | CHAT.LifecycleEvent)[] = []
+	for await (const page of await client.squadServer.watchChatEvents({ serverId: app.serverId })) {
+		if (SM.isServerNotLoaded(page)) continue
+		batch.push(...page)
+		if (page.some((e) => e.type === 'SYNCED')) break
+	}
+	return batch
 }
 
 // the app event a MAP_SET server event for `layerId` is attributed to, or null if it landed unattributed.
@@ -95,5 +116,25 @@ describe('queue save attribution', () => {
 		// null here is the regression: an unattributed MAP_SET renders as its own redundant feed entry
 		expect(attribution.appEventId, `MAP_SET for ${layerId} landed unattributed`).not.toBeNull()
 		expect(attribution.appType).toBe('QUEUE_UPDATED')
+	})
+
+	// The live feed never sees a queue-driven MAP_SET app event, because it's persisted rather than emitted. The
+	// backfill rebuilds that same buffer from the db on boot, and used to take every row for the match -- so a
+	// restart put the audit-only event into the feed, where it drew back the duplicate line the attribution above
+	// exists to avoid. Only a restart can see this: the live path can never produce that state.
+	it('does not replay the audit-only MAP_SET into the feed after a restart', { timeout: 120_000 }, async () => {
+		await app.restart()
+		await connect()
+
+		const batch = await initialFeedBatch()
+
+		const appEvents = batch.filter((e): e is { type: 'APP_EVENT'; appEvent: AppEvents.AppEvent } => e.type === 'APP_EVENT')
+		const queueUpdateds = appEvents.filter((e) => e.appEvent.type === 'QUEUE_UPDATED')
+		// the saves above are all in this match, so their QUEUE_UPDATEDs must survive the restart -- otherwise this
+		// test would pass simply by backfilling nothing at all
+		expect(queueUpdateds.length, "expected the saves' QUEUE_UPDATEDs to be backfilled").toBeGreaterThan(0)
+
+		const auditOnly = appEvents.filter((e) => e.appEvent.type === 'MAP_SET' && e.appEvent.reason === 'queue-updated')
+		expect(auditOnly, 'audit-only MAP_SETs must not be backfilled into the feed').toEqual([])
 	})
 })

--- a/test/integration/queue-save-attribution.test.ts
+++ b/test/integration/queue-save-attribution.test.ts
@@ -1,0 +1,99 @@
+import * as SLL from '@/models/shared-layer-list'
+import type { OrpcAppRouter } from '@/server/orpc-app-router'
+import { createORPCClient } from '@orpc/client'
+import { RPCLink } from '@orpc/client/websocket'
+import type { RouterClient } from '@orpc/server'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { WebSocket } from 'ws'
+import { type AppFixture, createAppFixture } from '../harness/app-fixture'
+import { LAYERS, queueItem } from '../harness/arrange'
+
+// A queue save sets the next layer over RCON, which the game server reports back as a MAP_SET log line. That
+// server event has to carry a `source` pointing at the QUEUE_UPDATED app event the save emitted, so the feed can
+// fold it into that entry (see chat.models.ts handleEvent) instead of trailing it with a redundant "Next layer
+// set to X" line.
+//
+// This drives the save over a real oRPC call rather than calling the handler directly, so it covers the whole
+// path the UI takes: dispatch the ops, set the layer over RCON, ingest the log line the emulator writes back, and
+// project the attribution onto the serverEvents row. The per-layer attribution matching this depends on is covered
+// directly (and far more cheaply) by the MAP_SET attribution unit tests in pending-events.models.test.ts.
+//
+// `repeats` because attribution state is carried between saves: an attribution the previous save left behind is
+// exactly what used to break the next one, and a single-save test can't see that.
+
+let app: AppFixture
+let client: RouterClient<OrpcAppRouter>
+let socket: WebSocket
+
+const HEAD_ITEM_ID = 'head-item'
+
+// each repeat has to land on a layer that isn't already the server's next one, or syncNextLayerToServer
+// short-circuits and no MAP_SET is ever produced. Distinct maps also keep the queue's repeat rules quiet.
+const LAYER_CYCLE = [LAYERS.narvaRaas, LAYERS.skorpoRaas, LAYERS.sumariRaas, LAYERS.harjuRaas, LAYERS.gorodokAas]
+let run = 0
+
+beforeAll(async () => {
+	app = await createAppFixture({
+		layerQueue: [queueItem(LAYERS.gorodokRaas, { itemId: HEAD_ITEM_ID }), queueItem(LAYERS.sumariSeed)],
+	})
+
+	// the query-param bypass logs the seeded admin in and hands back the session cookie the /orpc upgrade authenticates
+	const loginRes = await fetch(app.loginUrl(app.adminUser), { redirect: 'manual' })
+	const cookie = loginRes.headers.getSetCookie().map((c) => c.split(';')[0]).join('; ')
+	expect(cookie, 'login did not set a session cookie').toContain('session-id=')
+
+	socket = new WebSocket(`${app.appUrl.replace(/^http/, 'ws')}/orpc`, { headers: { cookie } })
+	await new Promise<void>((resolve, reject) => {
+		socket.once('open', resolve)
+		socket.once('error', reject)
+	})
+	client = createORPCClient(new RPCLink({ websocket: socket as unknown as globalThis.WebSocket }))
+}, 120_000)
+
+afterAll(async () => {
+	socket?.close()
+	await app?.dispose()
+})
+
+function dispatch(op: SLL.Operation) {
+	return client.layerQueue.dispatchOp({ serverId: app.serverId, op })
+}
+
+// the app event a MAP_SET server event for `layerId` is attributed to, or null if it landed unattributed.
+// undefined while the event hasn't been written yet (events flush to the db on an interval).
+function mapSetAttribution(layerId: string): { appEventId: string | null; appType: string | null } | undefined {
+	const db = app.readDb()
+	try {
+		return db
+			.prepare(
+				`SELECT se.appEventId as appEventId, ae.type as appType
+				 FROM serverEvents se LEFT JOIN appEvents ae ON ae.id = se.appEventId
+				 WHERE se.type = 'MAP_SET' AND json_extract(se.data, '$.json.layerId') = ?
+				 ORDER BY se.id DESC LIMIT 1`,
+			)
+			.get(layerId) as { appEventId: string | null; appType: string | null } | undefined
+	} finally {
+		db.close()
+	}
+}
+
+describe('queue save attribution', () => {
+	it("attributes the resulting MAP_SET to the save's QUEUE_UPDATED", { repeats: 4, timeout: 60_000 }, async () => {
+		const layerId = LAYER_CYCLE[run++ % LAYER_CYCLE.length]
+
+		// editWindowSeqId 0 is the fresh session's window: SLL.applyOperation only enforces a match for a non-zero id
+		const editWindowSeqId = 0
+		const userId = app.adminUser.discordId
+		await dispatch({ op: 'edit-layer', itemId: HEAD_ITEM_ID, newLayerId: layerId, opId: SLL.createOpId(), userId, editWindowSeqId })
+		await dispatch({ op: 'save', opId: SLL.createOpId(), userId, editWindowSeqId })
+
+		const attribution = await app.waitFor(() => mapSetAttribution(layerId), {
+			timeoutMs: 30_000,
+			label: `MAP_SET server event for ${layerId}`,
+		})
+
+		// null here is the regression: an unattributed MAP_SET renders as its own redundant feed entry
+		expect(attribution.appEventId, `MAP_SET for ${layerId} landed unattributed`).not.toBeNull()
+		expect(attribution.appType).toBe('QUEUE_UPDATED')
+	})
+})


### PR DESCRIPTION
A queue save rendered its next layer twice: once in the QUEUE_UPDATED entry, then again as a redundant standalone `Next layer set to X` line right below it.

The MAP_SET server event is supposed to collapse into the app event that caused it (`chat.models.ts` `handleEvent`, which folds it into the parent's `collapsed`). Three separate things stopped that from holding.

**1. The attribution pointed at an app event the feed never sees.** A queue save creates two app events: the `QUEUE_UPDATED` (emitted to the live feed) and a `MAP_SET` app event that is audit-only, written with `persistAppEvent` rather than `emitAppEvent`. The MAP_SET server event's `source` pointed at that audit-only app event, so the client's buffer lookup always missed and fell through to a standalone entry. It now points at whichever app event actually renders in the feed: the `QUEUE_UPDATED` for a queue-driven set, the `MAP_SET` itself for an override (which is emitted, and already worked).

**2. Attributions were claimed by position, not by layer.** `pending-events.models.ts` took `findIndex(a => a.type === 'MAP_SET_ATTRIBUTION')` — the first one, whatever layer it was for — and spliced it away *even when the layer did not match*. So a set-next whose MAP_SET never came back (or came back before its own attribution landed) left an attribution behind, and the next map set claimed that stale entry, kept the bare `{type:'rcon'}` off the log line, and discarded the attribution that actually matched. This is what made the duplicate look intermittent: it needs a stale attribution sitting there, and a restart clears it. Now the match is on the layer, and attributions age out on the same safety-net TTL as expectations (which they never had — `time` was recorded but never read).

**3. The backfill ignored the audit-only rule.** "Audit-only" was enforced only at the emit site. The backfill that rebuilds the feed buffer from the db on boot took every app event row for the match, so a restart put the audit-only MAP_SET back into the feed as its own entry — reintroducing the same duplicate by a different route, and hitting a renderer branch whose own comment claimed to be unreachable. Both sides now gate on one predicate, `AppEvents.isFeedVisible`: the write path picks emit-vs-persist with it, the backfill filters with it, and the renderer branch returns `null`.

## Why keep the audit-only MAP_SET at all

It records something QUEUE_UPDATED cannot: QUEUE_UPDATED is emitted *before* `saveQueueAndUpdateServer`, so it exists even when the RCON set fails, whereas the MAP_SET app event is only written in the `case 'ok'` branch. It's also visible in the Audit Log page. Keeping it was a deliberate call (discussed) rather than dropping it in favour of attributing to QUEUE_UPDATED alone.

Worth knowing: `causeId` is written but **never traversed** anywhere — no query, no join, no UI, unindexed text column, no FK. So "reachable from the QUEUE_UPDATED via its causeId" is true of the data but not of any code today.

## Tests

- **`app-events.models.test.ts` — `isFeedVisible` (3).** The audit-only rule, in the one place it's now written down.
- **`pending-events.models.test.ts` — MAP_SET attribution (4).** The matching rules: claims the right layer, is not poisoned by a stale attribution for a different layer, leaves an unattributed set alone, ages a stranded attribution out. Two fail against the old positional matching, the stale-attribution one with exactly the production symptom (`expected { type: 'rcon' } to deeply equal { type: 'event', id: 'app-1' }`).
- **`test/integration/queue-save-attribution.test.ts` (2).** Drives a real queue save over oRPC (login bypass → session cookie → authed `/orpc` websocket → `edit-layer` + `save`) and asserts the `serverEvents` row resolves to the save's QUEUE_UPDATED; `repeats: 4`, since attribution state carries between saves and a single-save test cannot see bug 2. The second test restarts the app and reads the feed back through `watchChatEvents` exactly as a client would — without the filter it fails with five audit-only MAP_SETs replayed, one per save. It also guards against passing vacuously by asserting the QUEUE_UPDATEDs *were* backfilled.
- Adds `AppFixture.restart()` — only a reboot reaches the backfill.

`pnpm run check` and `lint:fix` clean; 566 unit tests pass; `server-rolling`, `boot` and `recovery` integration suites pass. Also verified by hand in a dev instance against the emulator.

Adds `ws` as a devDependency — the integration test needs a WebSocket client that can send the session cookie on the handshake, which the built-in one can't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)