### PR TITLE
Stop layer-select racing the filter menu's possible values

### DIFF
--- a/test/e2e/layer-select.test.ts
+++ b/test/e2e/layer-select.test.ts
@@ -40,8 +40,17 @@ test.describe('selecting layers', () => {
 			await expect(rows.filter({ hasText: 'Sumari_Seed_v1' })).toHaveCount(0)
 
 			// turning the filter off is what lets an admin reach outside the pool
+			const matchedCount = dialog.getByText(/matched layers|No layers matched/)
+			const countWithFilter = await matchedCount.textContent()
 			await raasOnly.click()
 			await expect(raasOnly).toHaveAttribute('aria-checked', 'false')
+
+			// the checkbox flips immediately but the query behind it does not, and the same response that refills the
+			// table is what tells the filter menu which gamemodes are still reachable. Until it lands the menu still
+			// shows Seed as out-of-pool, and an out-of-pool option swallows the click that would select it -- so
+			// clicking now is a coin flip. The count only renders on a settled query, so waiting for it to change is
+			// what makes the menu below answer for the pool we actually have.
+			await expect(matchedCount).not.toHaveText(countWithFilter!)
 
 			// and now narrow to the gamemode being asserted on. The table sorts randomly by default (see the layerTable
 			// setting) and pages, so "is Sumari_Seed_v1 in the table" without narrowing to it is really "did the shuffle


### PR DESCRIPTION
`layer-select.test.ts:11` has been the e2e suite's most frequent failure for a while (#31 took an earlier run at it). It is not a click that misses. **The click lands, and the app throws it away.**

## What actually happens

Instrumented in the browser with a capture-phase listener and a 25ms poll of the option's state:

```
  ~60ms  popover opens.  locked=[AAS, Destruction, FRAAS, Insurgency,
                                 Invasion, Seed, Skirmish, TC, Training]   <- stale RAAS-only pool
         click lands:    hit=<span class="flex items-center gap-1 group w-full">
 ~450ms  possible values arrive.  locked=[Destruction, Training]           <- Seed now selectable
```

1. Unchecking the pool filter flips `aria-checked` **immediately**, so the test moves on.
2. The query behind it takes **~400ms**. Its response carries *both* the table rows and the filter menu's possible values.
3. Until it lands the menu still describes the RAAS-only pool, so `Seed` renders as out-of-pool.
4. An out-of-pool option is deliberately not selectable — its label swallows the click via `e.stopPropagation()` so that only the unlock affordance acts. React's synthetic propagation stops there, cmdk's `onSelect` never fires, the popover stays open.
5. ~400ms later the real values arrive and Seed unlocks, but **the click is gone and nothing retries**.

The test passed only when that response won the race, which is exactly why the failure rate tracked machine load.

## The fix

Wait for the matched-layer count to change before touching the menu. It only renders on a settled query, so once it moves the menu answers for the pool we actually have. Test-only; no product change.

## Measurements

The rate is load-dependent, so these are large samples rather than a few runs:

| | pristine main | with fix |
|---|---|---|
| isolated (`:11`) | 3 / 16 | **39 / 40** |
| full suite | 8 / 14 (recorded baseline) | **21 / 22** |

## Two things left deliberately

**The swallowed click is a real UX bug.** A user who clicks a value during that ~400ms window loses the click with no feedback. Fixing it means deciding what an out-of-pool option should do (select anyway? unlock-and-select? show a reason?), which is a product call and not a flake fix. Worth its own issue.

**One full-suite failure in 22 remains** and is still `layer-select:11`. It did not reproduce across 24 further runs, so I could not diagnose it and am not claiming it is gone — only that the dominant cause is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)