### PR TITLE
Insert server events as they're emitted

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -697,7 +697,7 @@ state lives in JSON columns rather than being normalized. Those columns are **su
 handled by a `superjsonify`/`unsuperjsonify` pair that walks the drizzle table config and transforms only
 `json`-typed columns. This is what allows bigints (Discord snowflakes) and Dates to round-trip.
 
-**Transactions serialize globally.** better-sqlite3 is one synchronous connection, but callbacks 
+**Transactions serialize globally.** better-sqlite3 is one synchronous connection, but callbacks
 are still treated as though they could be async in the future, so
 `runTransaction` serializes logical transactions with a manual promise-chain lock around manual `BEGIN
 IMMEDIATE`/`COMMIT`/`ROLLBACK`. Re-entrant: an inner transaction joins the outer one, and an inner `rollback()`

--- a/src/models/pending-events.models.test.ts
+++ b/src/models/pending-events.models.test.ts
@@ -44,6 +44,7 @@ function makeState(opts: {
 	layerId?: L.LayerId
 	isNewMatch?: boolean
 } = {}): { state: PendingEvents.State; hooks: PendingEvents.State['hooks'] } {
+	const eventIdCounter = Gen.counter()
 	const hooks: PendingEvents.State['hooks'] = {
 		onNewGameDuringSync: vi.fn().mockResolvedValue({
 			match: makeMatchDetails(opts.matchId ?? 1, opts.layerId ?? LAYER_A),
@@ -54,10 +55,15 @@ function makeState(opts: {
 			nextLayerId: opts.layerId ?? LAYER_A,
 		}),
 		fetchLayersStatus: () => Promise.resolve(null),
+		// stands in for the db insert: hands out ids in emission order, exactly as the autoincrement column does
+		createEvent: (event) => {
+			const id = Gen.next(eventIdCounter)
+			return Promise.resolve({ ...event, id } as SE.Event)
+		},
 	}
 	const state = PendingEvents.init({
 		currentMatch: opts.currentMatch ?? 'PENDING',
-		counters: { eventId: Gen.counter(), squadId: Gen.counter() },
+		counters: { squadId: Gen.counter() },
 		log: makeLog(),
 		hooks,
 	})

--- a/src/models/pending-events.models.ts
+++ b/src/models/pending-events.models.ts
@@ -2,6 +2,7 @@ import * as Arr from '@/lib/array'
 import * as Gen from '@/lib/generator'
 import * as Obj from '@/lib/object'
 import { assertNever } from '@/lib/type-guards'
+import type * as Types from '@/lib/types'
 import * as CS from '@/models/context-shared'
 import * as L from '@/models/layer'
 import type * as MH from '@/models/match-history.models'
@@ -132,7 +133,6 @@ export type State = {
 	// already aware of (PLAYER_RECONCILED) rather than a fresh arrival (PLAYER_CONNECTED). Rebuilt every poll.
 	unassignedPlayers: Set<SM.PlayerId>
 	counters: {
-		eventId: Generator<number, never, unknown>
 		squadId: Generator<number, never, unknown>
 		pendingEventId: Generator<number, never, unknown>
 	}
@@ -141,6 +141,10 @@ export type State = {
 		onNewGameDuringRoll: (newLayerId: L.LayerId, time: number) => Promise<{ match: MH.MatchDetails; nextLayerId: L.LayerId | null }>
 		onNewGameDuringSync: (newLayerId: L.LayerId, time: number) => Promise<{ match: MH.MatchDetails; isNewMatch: boolean }>
 		fetchLayersStatus: () => Promise<SM.LayersStatus | null>
+		// Persists the event and returns it with the id the insert allocated. Every event this module emits goes
+		// through here first, so an event is on disk before any consumer (or our own state) ever sees it, and ids
+		// are handed out in emission order.
+		createEvent: (event: SE.NewEvent) => Promise<SE.Event>
 	}
 
 	// if we receive a non-log event and we haven't received a log event in this amount of time since the time of the received event, we can assume that there are no log events older than this time that we have yet to receive
@@ -227,7 +231,7 @@ export function expectWarn(
 	armExpectation(state, { type: 'PLAYER_WARNED', playerId: opts.playerId, reason: opts.reason }, opts.source, opts.ttlMs)
 }
 
-function expectationMatches(state: State, match: ExpectationMatch, event: SE.Event): boolean {
+function expectationMatches(state: State, match: ExpectationMatch, event: SE.NewEvent): boolean {
 	switch (match.type) {
 		case 'PLAYER_WARNED':
 			// warns have no organic equivalent (players don't warn each other) and never carry a native source,
@@ -263,13 +267,13 @@ function expectationMatches(state: State, match: ExpectationMatch, event: SE.Eve
 // true when the game attributed this event to an admin action (it already carries a source), as opposed to an
 // organic change inferred from team polling (source undefined). Guards against a stale/racing expectation stamping
 // an organic squad-leave / team-change / disband. See the source assignments in the ADMIN_* handlers + reconcileTeamsUpdate.
-function eventIsAdminCaused(event: SE.Event): boolean {
+function eventIsAdminCaused(event: SE.NewEvent): boolean {
 	return (event as { source?: ActionSource }).source !== undefined
 }
 
 // stamps an emitted event with a matching armed expectation's source (consume-once). mutates the event in place.
 // runs before applyEventTeamMutations so SQUAD_DISBANDED can still resolve its squad in currTeams.
-function applyExpectations(state: State, event: SE.Event) {
+function applyExpectations(state: State, event: SE.NewEvent) {
 	const idx = state.expectations.findIndex(exp => expectationMatches(state, exp.match, event))
 	if (idx === -1) return
 	;(event as { source?: ActionSource }).source = state.expectations[idx].source
@@ -309,23 +313,29 @@ export function onTeamsPolled(state: State, teams: SM.Teams, time: number, polle
 	state.eventBufs.teamsUpdates.push({ type: 'TEAMS_UPDATE', id: Gen.next(state.counters.pendingEventId), teams, time, polledAt })
 }
 
-// Fold an emitted event into `state`: seed an empty roster if a roster-bearing event needs one, stamp expectation
-// attribution before mutating teams (SQUAD_DISBANDED matching needs the squad still present), then apply team
-// mutations. Shared by the main processing loop and the watchdog resync.
-function applyEventToState(state: State, ctx: CS.Log, event: SE.Event) {
-	if (SE.eventRoster(event) && !state.currTeams) {
+// The single point every event this module produces passes through. Order matters throughout:
+//   1. seed an empty roster if a roster-bearing event needs one,
+//   2. stamp expectation attribution -- `source` is part of the persisted event (and its appEventId column), so
+//      this has to happen before the insert, and while SQUAD_DISBANDED can still resolve its squad in currTeams,
+//   3. persist, which is what allocates the id,
+//   4. apply team mutations, only once the event is on disk -- a throw from createEvent leaves state untouched
+//      rather than mutated for an event nobody else will ever see.
+async function emit(state: State, ctx: CS.Log, newEvent: SE.NewEvent): Promise<SE.Event> {
+	if (SE.eventRoster(newEvent) && !state.currTeams) {
 		state.currTeams = initUniqueTeams(state, { players: [], squads: [] })
 	}
-	applyExpectations(state, event)
+	applyExpectations(state, newEvent)
+	const event = await state.hooks.createEvent(newEvent)
 	if (state.currTeams) {
 		applyEventTeamMutations(ctx, state.currTeams, event)
 	}
+	return event
 }
 
 // Watchdog recovery: re-establish sync from RCON's current layer when the log-driven roll/sync got wedged. Mirrors
 // the RCON_CONNECTED sync-begin (resolve the match, enter 'syncing', emit a roster-less NEW_GAME for a new match)
 // so the next teams poll produces the RESET that reseeds the roster.
-async function* forceResync(state: State, time: number): AsyncGenerator<SE.Event> {
+async function* forceResync(state: State, time: number): AsyncGenerator<SE.NewEvent> {
 	const layersStatus = await state.hooks.fetchLayersStatus()
 	if (!layersStatus) {
 		state.log.warn('sync watchdog fired but fetchLayersStatus returned null; cannot force resync')
@@ -339,7 +349,6 @@ async function* forceResync(state: State, time: number): AsyncGenerator<SE.Event
 	if (isNewMatch) {
 		yield {
 			type: 'NEW_GAME',
-			id: Gen.next(state.counters.eventId),
 			layerId: state.currentMatch.layerId,
 			matchId: state.currentMatch.historyEntryId,
 			source: 'new-game-detected',
@@ -364,9 +373,8 @@ export async function* process(
 		state.nonSyncedSince ??= time
 		if (time - state.nonSyncedSince >= SYNC_WATCHDOG_TIMEOUT_MS) {
 			state.nonSyncedSince = time // reset the clock so a failed resync retries after another full timeout, not every poll
-			for await (const event of forceResync(state, time)) {
-				applyEventToState(state, ctx, event)
-				yield event
+			for await (const newEvent of forceResync(state, time)) {
+				yield await emit(state, ctx, newEvent)
 			}
 		}
 	} else {
@@ -414,9 +422,8 @@ export async function* process(
 	for (let i = 0; i < toProcess.length; i++) {
 		const pendingEvent = toProcess[i]
 		try {
-			for await (const event of processPendingEvent(state, processedEventIds, time, pendingEvent)) {
-				applyEventToState(state, ctx, event)
-				yield event
+			for await (const newEvent of processPendingEvent(state, processedEventIds, time, pendingEvent)) {
+				yield await emit(state, ctx, newEvent)
 			}
 		} catch (err) {
 			state.log.error(err, 'Error while processing event %s (%s)', pendingEvent.type, pendingEvent.id)
@@ -609,7 +616,7 @@ async function* processPendingEvent(
 	processedEventIds: Set<number>,
 	time: number,
 	pendingEvent: PendingEvent,
-): AsyncGenerator<SE.Event> {
+): AsyncGenerator<SE.NewEvent> {
 	const log = state.log
 
 	if (pendingEvent.type !== 'UNKNOWN') {
@@ -639,7 +646,6 @@ async function* processPendingEvent(
 			matchId: state.currentMatch.historyEntryId,
 			time: pendingEvent.time,
 			reconnected: !state.isFirstConnection,
-			id: Gen.next(state.counters.eventId),
 		}
 
 		if (
@@ -649,7 +655,6 @@ async function* processPendingEvent(
 			yield {
 				type: 'MAP_SET',
 				layerId: state.nextLayerId,
-				id: Gen.next(state.counters.eventId),
 				matchId: state.currentMatch.historyEntryId,
 				time: Date.now(),
 			}
@@ -660,7 +665,6 @@ async function* processPendingEvent(
 		if (isNewMatch) {
 			yield {
 				type: 'NEW_GAME',
-				id: Gen.next(state.counters.eventId),
 				layerId: state.currentMatch.layerId,
 				matchId: state.currentMatch.historyEntryId,
 				source: state.isFirstConnection ? 'slm-started' : 'rcon-reconnected',
@@ -686,7 +690,6 @@ async function* processPendingEvent(
 			yield {
 				type: 'RCON_DISCONNECTED',
 				time: pendingEvent.time,
-				id: Gen.next(state.counters.eventId),
 				matchId: state.currentMatch.historyEntryId,
 			}
 		}
@@ -719,7 +722,6 @@ async function* processPendingEvent(
 			matchId: state.currentMatch.historyEntryId,
 			state: teams,
 			time: pendingEvent.time,
-			id: Gen.next(state.counters.eventId),
 			source: state.isFirstConnection ? 'slm-started' : 'rcon-reconnected',
 		}
 		state.syncState = { type: 'synced' }
@@ -744,7 +746,6 @@ async function* processPendingEvent(
 		// first post-boundary poll carries the definitive roster as a RESET. The reducer applies it to currTeams.
 		yield {
 			type: 'RESET',
-			id: Gen.next(state.counters.eventId),
 			time: pendingEvent.time,
 			matchId: state.currentMatch.historyEntryId,
 			state: teams,
@@ -804,7 +805,6 @@ async function* processPendingEvent(
 			// teams poll timestamped after this (see the rolling TEAMS_UPDATE branch), as a RESET.
 			yield {
 				type: 'NEW_GAME',
-				id: Gen.next(state.counters.eventId),
 				layerId: state.currentMatch.layerId,
 				matchId: state.currentMatch.historyEntryId,
 				source: 'server-roll',
@@ -820,7 +820,6 @@ async function* processPendingEvent(
 	if (!state.currTeams) throw new Error('currTeams is null when synced')
 
 	const base = {
-		id: Gen.next(state.counters.eventId),
 		matchId: state.currentMatch.historyEntryId,
 		time: pendingEvent.time,
 	}
@@ -951,7 +950,7 @@ async function* processPendingEvent(
 				}
 			}
 
-			const event: SE.RoundEnded = {
+			const event: Types.DistributiveOmit<SE.RoundEnded, 'id'> = {
 				type: 'ROUND_ENDED',
 				outcome,
 				action: action,
@@ -1080,7 +1079,6 @@ async function* processPendingEvent(
 					if (!SM.Squads.idsEqual(player, squad)) continue
 					yield {
 						type: 'PLAYER_LEFT_SQUAD',
-						id: Gen.next(state.counters.eventId),
 						player: SM.PlayerIds.getPlayerId(player.ids),
 						uniqueId: existingSquad.uniqueId,
 						matchId: state.currentMatch.historyEntryId,
@@ -1090,7 +1088,6 @@ async function* processPendingEvent(
 
 				yield {
 					type: 'SQUAD_DISBANDED',
-					id: Gen.next(state.counters.eventId),
 					uniqueId: existingSquad.uniqueId,
 					matchId: state.currentMatch.historyEntryId,
 					time: pendingEvent.time,
@@ -1114,7 +1111,6 @@ async function* processPendingEvent(
 				if (player.teamId !== teamId) {
 					yield {
 						type: 'PLAYER_CHANGED_TEAM',
-						id: Gen.next(state.counters.eventId),
 						player: SM.PlayerIds.getPlayerId(player.ids),
 						newTeamId: teamId,
 						time: pendingEvent.time,
@@ -1198,7 +1194,6 @@ async function* processPendingEvent(
 				if (!SM.Squads.idsEqual(player, squad)) continue
 				yield {
 					type: 'PLAYER_LEFT_SQUAD',
-					id: Gen.next(state.counters.eventId),
 					player: SM.PlayerIds.getPlayerId(player.ids),
 					uniqueId: squad.uniqueId,
 					matchId: state.currentMatch.historyEntryId,
@@ -1354,7 +1349,7 @@ async function* processPendingEvent(
 	processedEventIds.add(pendingEvent.id)
 }
 
-function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator<SE.Event> {
+function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator<SE.NewEvent> {
 	const nextTeams = event.teams
 	if (!state.currTeams || state.currentMatch === 'PENDING') return
 	const nextSquads: SM.UniqueSquad[] = []
@@ -1388,7 +1383,6 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 		emittedEvent = true
 		yield {
 			type: prevUnassigned.has(playerId) ? 'PLAYER_RECONCILED' : 'PLAYER_CONNECTED',
-			id: Gen.next(state.counters.eventId),
 			player: {
 				ids: nextPlayer.ids,
 				teamId: nextPlayer.teamId,
@@ -1420,7 +1414,6 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 		emittedEvent = true
 		yield {
 			type: 'PLAYER_DISCONNECTED',
-			id: Gen.next(state.counters.eventId),
 			player: playerId,
 			...base,
 		}
@@ -1460,7 +1453,6 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 		emittedEvent = true
 		yield {
 			type: 'SQUAD_CREATED',
-			id: Gen.next(state.counters.eventId),
 			squad: uniqueSquad,
 			synthesized: true,
 			...base,
@@ -1484,7 +1476,6 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 			// currPlayer.squadId = null
 			emittedEvent = true
 			yield {
-				id: Gen.next(state.counters.eventId),
 				type: 'PLAYER_LEFT_SQUAD',
 				player: playerId,
 				uniqueId: currSquad.uniqueId,
@@ -1500,7 +1491,6 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 			disbandedSquads.add(currSquad.uniqueId)
 			emittedEvent = true
 			yield {
-				id: Gen.next(state.counters.eventId),
 				type: 'SQUAD_DISBANDED',
 				uniqueId: currSquad.uniqueId,
 				...base,
@@ -1513,7 +1503,6 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 		if (!Obj.deepEqual(details, prevDetails)) {
 			emittedEvent = true
 			yield {
-				id: Gen.next(state.counters.eventId),
 				type: 'SQUAD_DETAILS_CHANGED',
 				uniqueId: currSquad.uniqueId,
 				details,
@@ -1529,7 +1518,6 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 		if (currPlayer && nextPlayer.teamId !== currPlayer.teamId) {
 			emittedEvent = true
 			yield {
-				id: Gen.next(state.counters.eventId),
 				type: 'PLAYER_CHANGED_TEAM',
 				player: playerId,
 				newTeamId: nextPlayer.teamId,
@@ -1553,7 +1541,6 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 			if (hasChangedSquad) {
 				emittedEvent = true
 				yield {
-					id: Gen.next(state.counters.eventId),
 					type: 'PLAYER_JOINED_SQUAD',
 					uniqueId: squad.uniqueId,
 					player: playerId,
@@ -1568,7 +1555,6 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 				}
 				emittedEvent = true
 				yield {
-					id: Gen.next(state.counters.eventId),
 					type: 'PLAYER_PROMOTED_TO_LEADER',
 					uniqueId: squad.uniqueId,
 					player: playerId,
@@ -1584,19 +1570,17 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 			if (!Obj.deepEqual(details, prevDetails) || newUsername) {
 				emittedEvent = true
 				yield {
-					id: Gen.next(state.counters.eventId),
 					type: 'PLAYER_DETAILS_CHANGED',
 					player: SM.PlayerIds.getPlayerId(player.ids),
 					details,
 					newUsername,
 					...base,
-				} satisfies SE.PlayerDetailsChanged
+				} satisfies Types.DistributiveOmit<SE.PlayerDetailsChanged, 'id'>
 			}
 		}
 	}
 	if (emittedEvent) {
 		yield {
-			id: Gen.next(state.counters.eventId),
 			type: 'TEAMS_POLLED_UPDATE',
 			matchId: state.currentMatch.historyEntryId,
 			time: event.time,
@@ -1610,11 +1594,10 @@ function* emitLeaveSquadEvents(
 	player: SM.Player,
 	squadUniqueId: number,
 	source?: SM.LogEvents.ActionSource,
-): Generator<SE.Event> {
+): Generator<SE.NewEvent> {
 	if (player.squadId) {
 		yield {
 			type: 'PLAYER_LEFT_SQUAD',
-			id: Gen.next(state.counters.eventId),
 			player: SM.PlayerIds.getPlayerId(player.ids),
 			uniqueId: squadUniqueId,
 			time,
@@ -1630,7 +1613,6 @@ function* emitLeaveSquadEvents(
 		if (otherPlayers.length === 0) {
 			yield {
 				type: 'SQUAD_DISBANDED',
-				id: Gen.next(state.counters.eventId),
 				uniqueId: squadUniqueId,
 				time,
 				matchId: state.currentMatch.historyEntryId,
@@ -1641,7 +1623,6 @@ function* emitLeaveSquadEvents(
 			if (player.isLeader) {
 				yield {
 					type: 'PLAYER_PROMOTED_TO_LEADER',
-					id: Gen.next(state.counters.eventId),
 					player: SM.PlayerIds.getPlayerId(otherPlayer.ids),
 					uniqueId: squadUniqueId,
 					time,

--- a/src/models/pending-events.models.ts
+++ b/src/models/pending-events.models.ts
@@ -313,29 +313,34 @@ export function onTeamsPolled(state: State, teams: SM.Teams, time: number, polle
 	state.eventBufs.teamsUpdates.push({ type: 'TEAMS_UPDATE', id: Gen.next(state.counters.pendingEventId), teams, time, polledAt })
 }
 
-// The single point every event this module produces passes through. Order matters throughout:
-//   1. seed an empty roster if a roster-bearing event needs one,
-//   2. stamp expectation attribution -- `source` is part of the persisted event (and its appEventId column), so
-//      this has to happen before the insert, and while SQUAD_DISBANDED can still resolve its squad in currTeams,
-//   3. persist, which is what allocates the id,
-//   4. apply team mutations, only once the event is on disk -- a throw from createEvent leaves state untouched
-//      rather than mutated for an event nobody else will ever see.
-async function emit(state: State, ctx: CS.Log, newEvent: SE.NewEvent): Promise<SE.Event> {
-	if (SE.eventRoster(newEvent) && !state.currTeams) {
+// Builds an event: stamps expectation attribution, then persists it to get its id. Called at the point each
+// event is constructed, so everything from the yield onwards already carries the real (db-allocated) id.
+//
+// The attribution stamp belongs here rather than in the caller: `source` is part of the persisted event (and of
+// its appEventId column), so stamping after the insert would silently drop it. It also has to precede
+// applyEventTeamMutations (which the caller runs on the yielded event) -- SQUAD_DISBANDED resolves its squad out
+// of currTeams, so the squad has to still be in there.
+async function createEvent(state: State, event: SE.NewEvent): Promise<SE.Event> {
+	applyExpectations(state, event)
+	return await state.hooks.createEvent(event)
+}
+
+// Fold an emitted event into `state`: seed an empty roster if a roster-bearing event needs one, then apply team
+// mutations. Runs on the event the generator handed over, i.e. once it is already on disk. Shared by the main
+// processing loop and the watchdog resync.
+function applyEventToState(state: State, ctx: CS.Log, event: SE.Event) {
+	if (SE.eventRoster(event) && !state.currTeams) {
 		state.currTeams = initUniqueTeams(state, { players: [], squads: [] })
 	}
-	applyExpectations(state, newEvent)
-	const event = await state.hooks.createEvent(newEvent)
 	if (state.currTeams) {
 		applyEventTeamMutations(ctx, state.currTeams, event)
 	}
-	return event
 }
 
 // Watchdog recovery: re-establish sync from RCON's current layer when the log-driven roll/sync got wedged. Mirrors
 // the RCON_CONNECTED sync-begin (resolve the match, enter 'syncing', emit a roster-less NEW_GAME for a new match)
 // so the next teams poll produces the RESET that reseeds the roster.
-async function* forceResync(state: State, time: number): AsyncGenerator<SE.NewEvent> {
+async function* forceResync(state: State, time: number): AsyncGenerator<SE.Event> {
 	const layersStatus = await state.hooks.fetchLayersStatus()
 	if (!layersStatus) {
 		state.log.warn('sync watchdog fired but fetchLayersStatus returned null; cannot force resync')
@@ -347,13 +352,13 @@ async function* forceResync(state: State, time: number): AsyncGenerator<SE.NewEv
 	state.currentMatch = { historyEntryId: match.historyEntryId, layerId: match.layerId }
 	state.syncState = { type: 'syncing', isNewMatch, boundaryTime: time }
 	if (isNewMatch) {
-		yield {
+		yield await createEvent(state, {
 			type: 'NEW_GAME',
 			layerId: state.currentMatch.layerId,
 			matchId: state.currentMatch.historyEntryId,
 			source: 'new-game-detected',
 			time,
-		}
+		})
 	}
 }
 
@@ -373,8 +378,9 @@ export async function* process(
 		state.nonSyncedSince ??= time
 		if (time - state.nonSyncedSince >= SYNC_WATCHDOG_TIMEOUT_MS) {
 			state.nonSyncedSince = time // reset the clock so a failed resync retries after another full timeout, not every poll
-			for await (const newEvent of forceResync(state, time)) {
-				yield await emit(state, ctx, newEvent)
+			for await (const event of forceResync(state, time)) {
+				applyEventToState(state, ctx, event)
+				yield event
 			}
 		}
 	} else {
@@ -422,8 +428,9 @@ export async function* process(
 	for (let i = 0; i < toProcess.length; i++) {
 		const pendingEvent = toProcess[i]
 		try {
-			for await (const newEvent of processPendingEvent(state, processedEventIds, time, pendingEvent)) {
-				yield await emit(state, ctx, newEvent)
+			for await (const event of processPendingEvent(state, processedEventIds, time, pendingEvent)) {
+				applyEventToState(state, ctx, event)
+				yield event
 			}
 		} catch (err) {
 			state.log.error(err, 'Error while processing event %s (%s)', pendingEvent.type, pendingEvent.id)
@@ -616,7 +623,7 @@ async function* processPendingEvent(
 	processedEventIds: Set<number>,
 	time: number,
 	pendingEvent: PendingEvent,
-): AsyncGenerator<SE.NewEvent> {
+): AsyncGenerator<SE.Event> {
 	const log = state.log
 
 	if (pendingEvent.type !== 'UNKNOWN') {
@@ -641,35 +648,35 @@ async function* processPendingEvent(
 		}
 
 		state.isFirstConnection = state.isFirstConnection === null
-		yield {
+		yield await createEvent(state, {
 			type: 'RCON_CONNECTED',
 			matchId: state.currentMatch.historyEntryId,
 			time: pendingEvent.time,
 			reconnected: !state.isFirstConnection,
-		}
+		})
 
 		if (
 			pendingEvent.nextLayerId !== null && (state.nextLayerId === null || !L.layersEqual(state.nextLayerId, pendingEvent.nextLayerId))
 		) {
 			state.nextLayerId = pendingEvent.nextLayerId
-			yield {
+			yield await createEvent(state, {
 				type: 'MAP_SET',
 				layerId: state.nextLayerId,
 				matchId: state.currentMatch.historyEntryId,
 				time: Date.now(),
-			}
+			})
 		}
 
 		// Roster-less boundary marker for a genuinely new match; the roster follows on the first post-boundary poll
 		// (RESET). A same-match reconnect (isNewMatch=false) emits no NEW_GAME -- just the RESET reseed.
 		if (isNewMatch) {
-			yield {
+			yield await createEvent(state, {
 				type: 'NEW_GAME',
 				layerId: state.currentMatch.layerId,
 				matchId: state.currentMatch.historyEntryId,
 				source: state.isFirstConnection ? 'slm-started' : 'rcon-reconnected',
 				time: pendingEvent.time,
-			}
+			})
 		}
 	}
 
@@ -687,11 +694,11 @@ async function* processPendingEvent(
 		state.unknownSquadStreaks.clear()
 		state.unassignedPlayers.clear()
 		if (state.currentMatch !== 'PENDING') {
-			yield {
+			yield await createEvent(state, {
 				type: 'RCON_DISCONNECTED',
 				time: pendingEvent.time,
 				matchId: state.currentMatch.historyEntryId,
-			}
+			})
 		}
 	}
 
@@ -717,13 +724,13 @@ async function* processPendingEvent(
 
 		// The definitive roster always arrives via RESET. For a new match the roster-less NEW_GAME boundary was
 		// already emitted at RCON_CONNECTED; a same-match reconnect emits only this RESET.
-		yield {
+		yield await createEvent(state, {
 			type: 'RESET',
 			matchId: state.currentMatch.historyEntryId,
 			state: teams,
 			time: pendingEvent.time,
 			source: state.isFirstConnection ? 'slm-started' : 'rcon-reconnected',
-		}
+		})
 		state.syncState = { type: 'synced' }
 	}
 
@@ -744,13 +751,13 @@ async function* processPendingEvent(
 		const teams = initUniqueTeams(state, { players: teamedPlayers, squads: pendingEvent.teams.squads }, prior)
 		// The roster-less NEW_GAME(server-roll) boundary was emitted when the real-layer NEW_GAME log arrived; this
 		// first post-boundary poll carries the definitive roster as a RESET. The reducer applies it to currTeams.
-		yield {
+		yield await createEvent(state, {
 			type: 'RESET',
 			time: pendingEvent.time,
 			matchId: state.currentMatch.historyEntryId,
 			state: teams,
 			source: 'server-roll',
-		}
+		})
 		state.syncState = { type: 'synced' }
 	}
 
@@ -803,13 +810,13 @@ async function* processPendingEvent(
 
 			// Roster-less boundary marker, emitted promptly at the real-layer log. The roster follows on the first
 			// teams poll timestamped after this (see the rolling TEAMS_UPDATE branch), as a RESET.
-			yield {
+			yield await createEvent(state, {
 				type: 'NEW_GAME',
 				layerId: state.currentMatch.layerId,
 				matchId: state.currentMatch.historyEntryId,
 				source: 'server-roll',
 				time: pendingEvent.time,
-			}
+			})
 		}
 	}
 
@@ -847,12 +854,12 @@ async function* processPendingEvent(
 				}
 				state.attributions.splice(attributionIndex, 1)
 			}
-			yield {
+			yield await createEvent(state, {
 				type: 'MAP_SET',
 				...base,
 				layerId: layer.id,
 				source,
-			}
+			})
 			break
 		}
 
@@ -950,37 +957,37 @@ async function* processPendingEvent(
 				}
 			}
 
-			const event: Types.DistributiveOmit<SE.RoundEnded, 'id'> = {
+			const roundEnded: Types.DistributiveOmit<SE.RoundEnded, 'id'> = {
 				type: 'ROUND_ENDED',
 				outcome,
 				action: action,
 				...base,
 			}
 
-			yield event
+			yield await createEvent(state, roundEnded)
 
 			break
 		}
 
 		case 'PLAYER_KICKED_CHAIN': {
 			const events = pendingEvent.events
-			yield {
+			yield await createEvent(state, {
 				...base,
 				type: 'PLAYER_KICKED',
 				player: SM.PlayerIds.getPlayerId(events.PLAYER_KICKED.playerIds),
 				reason: events.KICKING_PLAYER.reason,
-			}
+			})
 			break
 		}
 
 		// carryover from squadjs, no recent instances of this in current prod logs
 		case 'PLAYER_BANNED': {
-			yield {
+			yield await createEvent(state, {
 				...base,
 				type: 'PLAYER_BANNED',
 				player: SM.PlayerIds.getPlayerId(pendingEvent.playerIds),
 				interval: pendingEvent.interval,
-			}
+			})
 			break
 		}
 
@@ -990,30 +997,30 @@ async function* processPendingEvent(
 				log.error('Player not found in currTeams: %s', SM.PlayerIds.prettyPrint(pendingEvent.playerIds))
 				break
 			}
-			yield {
+			yield await createEvent(state, {
 				...base,
 				type: 'PLAYER_WARNED',
 				reason: pendingEvent.reason,
 				player: SM.PlayerIds.getPlayerId(player.ids),
-			}
+			})
 			break
 		}
 
 		case 'POSSESSED_ADMIN_CAMERA': {
-			yield {
+			yield await createEvent(state, {
 				...base,
 				type: 'POSSESSED_ADMIN_CAMERA',
 				player: SM.PlayerIds.getPlayerId(pendingEvent.playerIds),
-			}
+			})
 			break
 		}
 
 		case 'UNPOSSESSED_ADMIN_CAMERA': {
-			yield {
+			yield await createEvent(state, {
 				...base,
 				type: 'UNPOSSESSED_ADMIN_CAMERA',
 				player: SM.PlayerIds.getPlayerId(pendingEvent.playerIds),
-			}
+			})
 			break
 		}
 
@@ -1034,11 +1041,11 @@ async function* processPendingEvent(
 				role: 'unknown',
 			}
 
-			yield {
+			yield await createEvent(state, {
 				type: 'PLAYER_CONNECTED',
 				...base,
 				player: Obj.deepClone(player),
-			}
+			})
 			break
 		}
 
@@ -1077,21 +1084,21 @@ async function* processPendingEvent(
 			if (existingSquad) {
 				for (const player of state.currTeams.players) {
 					if (!SM.Squads.idsEqual(player, squad)) continue
-					yield {
+					yield await createEvent(state, {
 						type: 'PLAYER_LEFT_SQUAD',
 						player: SM.PlayerIds.getPlayerId(player.ids),
 						uniqueId: existingSquad.uniqueId,
 						matchId: state.currentMatch.historyEntryId,
 						time: pendingEvent.time,
-					}
+					})
 				}
 
-				yield {
+				yield await createEvent(state, {
 					type: 'SQUAD_DISBANDED',
 					uniqueId: existingSquad.uniqueId,
 					matchId: state.currentMatch.historyEntryId,
 					time: pendingEvent.time,
-				}
+				})
 			}
 
 			if (player) {
@@ -1109,13 +1116,13 @@ async function* processPendingEvent(
 				}
 
 				if (player.teamId !== teamId) {
-					yield {
+					yield await createEvent(state, {
 						type: 'PLAYER_CHANGED_TEAM',
 						player: SM.PlayerIds.getPlayerId(player.ids),
 						newTeamId: teamId,
 						time: pendingEvent.time,
 						matchId: state.currentMatch.historyEntryId,
-					}
+					})
 				}
 			} else {
 				// the creator not being in currTeams yet (e.g. their connect was missed) is no reason to drop the
@@ -1126,11 +1133,11 @@ async function* processPendingEvent(
 				)
 			}
 
-			yield {
+			yield await createEvent(state, {
 				type: 'SQUAD_CREATED',
 				squad: squad,
 				...base,
-			}
+			})
 
 			break
 		}
@@ -1151,11 +1158,11 @@ async function* processPendingEvent(
 				log.warn(`Player not found on disconnect: ${SM.PlayerIds.prettyPrint(pendingEvent.playerIds)}`)
 				break
 			}
-			yield {
+			yield await createEvent(state, {
 				type: 'PLAYER_DISCONNECTED',
 				player: SM.PlayerIds.getPlayerId(pendingEvent.playerIds),
 				...base,
-			}
+			})
 			break
 		}
 
@@ -1165,13 +1172,13 @@ async function* processPendingEvent(
 				log.error('SQUAD_RENAMED: squad not found for squadId=%d, teamId=%d', pendingEvent.squadId, pendingEvent.teamId)
 				break
 			}
-			yield {
+			yield await createEvent(state, {
 				type: 'SQUAD_RENAMED',
 				uniqueId: squad.uniqueId,
 				oldSquadName: pendingEvent.oldSquadName,
 				newSquadName: pendingEvent.newSquadName,
 				...base,
-			}
+			})
 			break
 		}
 
@@ -1192,21 +1199,21 @@ async function* processPendingEvent(
 			}
 			for (const player of state.currTeams.players) {
 				if (!SM.Squads.idsEqual(player, squad)) continue
-				yield {
+				yield await createEvent(state, {
 					type: 'PLAYER_LEFT_SQUAD',
 					player: SM.PlayerIds.getPlayerId(player.ids),
 					uniqueId: squad.uniqueId,
 					matchId: state.currentMatch.historyEntryId,
 					time: pendingEvent.time,
 					source: pendingEvent.source,
-				}
+				})
 			}
-			yield {
+			yield await createEvent(state, {
 				type: 'SQUAD_DISBANDED',
 				...base,
 				uniqueId: squad.uniqueId,
 				source: pendingEvent.source,
-			}
+			})
 			break
 		}
 
@@ -1232,7 +1239,10 @@ async function* processPendingEvent(
 		}
 
 		case 'TEAMS_UPDATE': {
-			const events = Array.from(reconcileTeamsUpdate(state, pendingEvent))
+			// drained before any of it is yielded, as it always has been: every event the reconciler produces is
+			// computed against the pre-mutation roster, and the caller only mutates once we hand an event over
+			const events: SE.Event[] = []
+			for await (const event of reconcileTeamsUpdate(state, pendingEvent)) events.push(event)
 			yield* events
 			// a forced-team-change attribution is valid for exactly one poll -- discard whatever wasn't consumed
 			state.forcedTeamChanges.clear()
@@ -1273,7 +1283,7 @@ async function* processPendingEvent(
 				variant = 'normal'
 			}
 
-			yield {
+			yield await createEvent(state, {
 				type: pendingEvent.type,
 				...base,
 				damage: pendingEvent.damage,
@@ -1281,7 +1291,7 @@ async function* processPendingEvent(
 				variant,
 				attacker: SM.PlayerIds.getPlayerId(attacker.ids),
 				victim: SM.PlayerIds.getPlayerId(victim.ids),
-			}
+			})
 
 			break
 		}
@@ -1325,23 +1335,23 @@ async function* processPendingEvent(
 				if (squad) channel = { ...squadChannel, uniqueId: squad.uniqueId }
 			}
 
-			yield {
+			yield await createEvent(state, {
 				type: 'CHAT_MESSAGE',
 				message: pendingEvent.message,
 				player: SM.PlayerIds.getPlayerId(pendingEvent.playerIds),
 				channel,
 				...base,
-			}
+			})
 			break
 		}
 
 		case 'ADMIN_BROADCAST': {
-			yield {
+			yield await createEvent(state, {
 				type: 'ADMIN_BROADCAST',
 				message: pendingEvent.message,
 				source: pendingEvent.source,
 				...base,
-			}
+			})
 			break
 		}
 	}
@@ -1349,7 +1359,7 @@ async function* processPendingEvent(
 	processedEventIds.add(pendingEvent.id)
 }
 
-function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator<SE.NewEvent> {
+async function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): AsyncGenerator<SE.Event> {
 	const nextTeams = event.teams
 	if (!state.currTeams || state.currentMatch === 'PENDING') return
 	const nextSquads: SM.UniqueSquad[] = []
@@ -1381,7 +1391,7 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 		}
 		if (inCurrTeams) continue
 		emittedEvent = true
-		yield {
+		yield await createEvent(state, {
 			type: prevUnassigned.has(playerId) ? 'PLAYER_RECONCILED' : 'PLAYER_CONNECTED',
 			player: {
 				ids: nextPlayer.ids,
@@ -1393,7 +1403,7 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 				role: nextPlayer.role,
 			},
 			...base,
-		}
+		})
 	}
 	state.unassignedPlayers = nextUnassigned
 
@@ -1412,11 +1422,11 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 		}
 		state.pollAbsenceStreaks.delete(playerId)
 		emittedEvent = true
-		yield {
+		yield await createEvent(state, {
 			type: 'PLAYER_DISCONNECTED',
 			player: playerId,
 			...base,
-		}
+		})
 	}
 
 	// we want the SQUAD_CREATED event to have always landed before attempting to process teams updates, so an unknown
@@ -1451,12 +1461,12 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 			UNKNOWN_SQUAD_SYNTHESIS_THRESHOLD,
 		)
 		emittedEvent = true
-		yield {
+		yield await createEvent(state, {
 			type: 'SQUAD_CREATED',
 			squad: uniqueSquad,
 			synthesized: true,
 			...base,
-		}
+		})
 		nextSquads.push(uniqueSquad)
 	}
 	// entries for squads that matched or vanished this poll are stale
@@ -1475,12 +1485,12 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 		if (currSquad && (!squad || currSquad.uniqueId !== squad.uniqueId)) {
 			// currPlayer.squadId = null
 			emittedEvent = true
-			yield {
+			yield await createEvent(state, {
 				type: 'PLAYER_LEFT_SQUAD',
 				player: playerId,
 				uniqueId: currSquad.uniqueId,
 				...base,
-			}
+			})
 		}
 	}
 
@@ -1490,11 +1500,11 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 		if (!nextSquad) {
 			disbandedSquads.add(currSquad.uniqueId)
 			emittedEvent = true
-			yield {
+			yield await createEvent(state, {
 				type: 'SQUAD_DISBANDED',
 				uniqueId: currSquad.uniqueId,
 				...base,
-			}
+			})
 			continue
 		}
 
@@ -1502,12 +1512,12 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 		const prevDetails = Obj.selectProps(currSquad, SM.SQUAD_DETAILS)
 		if (!Obj.deepEqual(details, prevDetails)) {
 			emittedEvent = true
-			yield {
+			yield await createEvent(state, {
 				type: 'SQUAD_DETAILS_CHANGED',
 				uniqueId: currSquad.uniqueId,
 				details,
 				...base,
-			}
+			})
 		}
 	}
 
@@ -1517,14 +1527,14 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 
 		if (currPlayer && nextPlayer.teamId !== currPlayer.teamId) {
 			emittedEvent = true
-			yield {
+			yield await createEvent(state, {
 				type: 'PLAYER_CHANGED_TEAM',
 				player: playerId,
 				newTeamId: nextPlayer.teamId,
 				// attributed if an admin forced this change (recorded from the log); undefined for organic switches
 				source: state.forcedTeamChanges.get(playerId),
 				...base,
-			}
+			})
 		}
 	}
 
@@ -1540,12 +1550,12 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 
 			if (hasChangedSquad) {
 				emittedEvent = true
-				yield {
+				yield await createEvent(state, {
 					type: 'PLAYER_JOINED_SQUAD',
 					uniqueId: squad.uniqueId,
 					player: playerId,
 					...base,
-				}
+				})
 			}
 
 			if (player.isLeader && !prevPlayer?.isLeader) {
@@ -1554,12 +1564,12 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 					return
 				}
 				emittedEvent = true
-				yield {
+				yield await createEvent(state, {
 					type: 'PLAYER_PROMOTED_TO_LEADER',
 					uniqueId: squad.uniqueId,
 					player: playerId,
 					...base,
-				}
+				})
 			}
 		}
 
@@ -1569,41 +1579,44 @@ function* reconcileTeamsUpdate(state: State, event: TeamsUpdateEvent): Generator
 			const newUsername = prevPlayer.ids.username !== player.ids.username ? player.ids.username : undefined
 			if (!Obj.deepEqual(details, prevDetails) || newUsername) {
 				emittedEvent = true
-				yield {
-					type: 'PLAYER_DETAILS_CHANGED',
-					player: SM.PlayerIds.getPlayerId(player.ids),
-					details,
-					newUsername,
-					...base,
-				} satisfies Types.DistributiveOmit<SE.PlayerDetailsChanged, 'id'>
+				yield await createEvent(
+					state,
+					{
+						type: 'PLAYER_DETAILS_CHANGED',
+						player: SM.PlayerIds.getPlayerId(player.ids),
+						details,
+						newUsername,
+						...base,
+					} satisfies Types.DistributiveOmit<SE.PlayerDetailsChanged, 'id'>,
+				)
 			}
 		}
 	}
 	if (emittedEvent) {
-		yield {
+		yield await createEvent(state, {
 			type: 'TEAMS_POLLED_UPDATE',
 			matchId: state.currentMatch.historyEntryId,
 			time: event.time,
-		}
+		})
 	}
 }
 
-function* emitLeaveSquadEvents(
+async function* emitLeaveSquadEvents(
 	state: StateWithCurrentMatchAndPlayers,
 	time: number,
 	player: SM.Player,
 	squadUniqueId: number,
 	source?: SM.LogEvents.ActionSource,
-): Generator<SE.NewEvent> {
+): AsyncGenerator<SE.Event> {
 	if (player.squadId) {
-		yield {
+		yield await createEvent(state, {
 			type: 'PLAYER_LEFT_SQUAD',
 			player: SM.PlayerIds.getPlayerId(player.ids),
 			uniqueId: squadUniqueId,
 			time,
 			matchId: state.currentMatch.historyEntryId,
 			source,
-		}
+		})
 		const otherPlayers: SM.Player[] = []
 		for (const otherPlayer of state.currTeams.players) {
 			if (SM.Squads.idsEqual(otherPlayer, player) && !SM.PlayerIds.match(player.ids, otherPlayer.ids)) {
@@ -1611,23 +1624,23 @@ function* emitLeaveSquadEvents(
 			}
 		}
 		if (otherPlayers.length === 0) {
-			yield {
+			yield await createEvent(state, {
 				type: 'SQUAD_DISBANDED',
 				uniqueId: squadUniqueId,
 				time,
 				matchId: state.currentMatch.historyEntryId,
 				source,
-			}
+			})
 		} else if (otherPlayers.length === 1) {
 			const otherPlayer = otherPlayers[0]
 			if (player.isLeader) {
-				yield {
+				yield await createEvent(state, {
 					type: 'PLAYER_PROMOTED_TO_LEADER',
 					player: SM.PlayerIds.getPlayerId(otherPlayer.ids),
 					uniqueId: squadUniqueId,
 					time,
 					matchId: state.currentMatch.historyEntryId,
-				}
+				})
 			}
 		}
 	}

--- a/src/models/server-events.models.ts
+++ b/src/models/server-events.models.ts
@@ -1,6 +1,7 @@
 import type * as SchemaModels from '$root/drizzle/schema.models'
 import * as Obj from '@/lib/object'
 import { assertNever } from '@/lib/type-guards'
+import type * as Types from '@/lib/types'
 import type * as CS from '@/models/context-shared'
 import type * as L from '@/models/layer'
 import * as MH from '@/models/match-history.models'
@@ -119,7 +120,7 @@ export const PLAYER_CONNECTED_META = meta({ players: [{ assocType: 'player' }] }
 // Emitted by the teams-poll reconciler for a player RCON reports as present but who was missing from our roster
 // (e.g. their PLAYER_CONNECTED landed during a round roll and was dropped). Semantically distinct from
 // PLAYER_CONNECTED -- it is a roster backfill, not a fresh join -- so join-only consumers (feed card, battlemetrics,
-// connection indicator, teamswap tracking) ignore it. Carries the full player so saveEvents registers them.
+// connection indicator, teamswap tracking) ignore it. Carries the full player so the event insert registers them.
 export type PlayerReconciled<P = SM.Player> =
 	& {
 		type: 'PLAYER_RECONCILED'
@@ -361,6 +362,10 @@ export type Event<P = SM.PlayerId> =
 	| PlayerJoinedSquad<P>
 	| PlayerPromotedToLeader<P>
 	| TeamsPolledUpdate
+
+// An event before it has been written to the db. `id` is serverEvents.id, allocated by the insert, so it only
+// exists once the row does -- see the createEvent hook in pending-events.models.ts.
+export type NewEvent = Types.DistributiveOmit<Event, 'id'>
 
 // ---- persisted form (serverEvents.data), validated on read by fromEventRow.
 //

--- a/src/systems/match-history.server.ts
+++ b/src/systems/match-history.server.ts
@@ -446,7 +446,7 @@ export const matchHistoryRouter = {
 
 export const addNewCurrentMatch = C.spanOp(
 	'addNewCurrentMatch',
-	{ module, levels: { event: 'info' }, mutexes: (ctx) => [ctx.matchHistory.mtx, ctx.server.savingEventsMtx] },
+	{ module, levels: { event: 'info' }, mutexes: (ctx) => [ctx.matchHistory.mtx] },
 	async (
 		ctx: C.Db & C.MatchHistory & C.SquadServer & CS.AbortSignal,
 		entry: Omit<SchemaModels.NewMatchHistory, 'ordinal' | 'serverId'>,
@@ -458,11 +458,8 @@ export const addNewCurrentMatch = C.spanOp(
 				superjsonify(Schema.matchHistory, { ...entry, ordinal, serverId: ctx.serverId }),
 			)
 
-			// write event buffer since we're about to flush it
-			await SquadServer.saveEvents(ctx)
-			ctx.server.lastSavedEventId = null
-			// flush the events buffer
-
+			// events are persisted as they're emitted, so the in-memory cache is just dropped; it only ever
+			// holds the current match
 			ctx.server.emittedEvents = []
 
 			await loadState(ctx, { startAtOrdinal: ordinal })

--- a/src/systems/squad-server.server.ts
+++ b/src/systems/squad-server.server.ts
@@ -93,7 +93,6 @@ type State = {
 	sliceLifecycleMtxs: Map<string, MutexInterface>
 	// emits a serverId whenever that server's slice is added to or removed from `slices`
 	sliceLifecycleUpdate$: Rx.Subject<string>
-	serverEventIdCounter: Generator<number, never, unknown>
 	squadIdCounter: Generator<number, never, unknown>
 
 	debug__ticketOutcome?: { team1: number; team2: number }
@@ -111,13 +110,8 @@ export type SquadServer = {
 	// latest "Server Tick Rate" reported in the game logs; null until the first sample is seen
 	tickRate$: Rx.BehaviorSubject<number | null>
 
-	// if null, we haven't saved yet in this instantiation of the server
-	lastSavedEventId: number | null
-
-	// ids saveEvents has already processed (saved or skipped); guards against double-persisting an event id.
-	// Pruned alongside the emittedEvents rotation on match rollover.
-	savedEventIds: Set<number>
-
+	// events of the current match, kept in memory purely to serve the chat feed without a query. Every one of
+	// them is already persisted (see the createEvent hook); this is a cache, not a write buffer.
 	emittedEvents: SE.Event[]
 	// TODO we should slim down the context we provide here so that we're just transmitting span & logging info, and leave the listener to construct everything else
 	event$: Rx.Subject<[C.Db & C.ServerSlice, SE.Event]>
@@ -133,7 +127,6 @@ export type SquadServer = {
 	cleanupId: number | null
 
 	processEventsMtx: MutexInterface
-	savingEventsMtx: MutexInterface
 } & SquadRcon.SquadRcon
 
 export type MatchHistoryState = {
@@ -591,20 +584,9 @@ export async function setup() {
 	globalState = {
 		slices: new Map(),
 		sliceLifecycleUpdate$: new IsolatedSubject(),
-		serverEventIdCounter: undefined!,
 		squadIdCounter: undefined!,
 		sliceLifecycleMtxs: new Map(),
 	}
-
-	const lastEventRes = await ctx
-		.db()
-		.select({ id: Schema.serverEvents.id })
-		.from(Schema.serverEvents)
-		.orderBy(E.desc(Schema.serverEvents.id))
-		.limit(1)
-	// driver sometimes returns strings so just to be safe
-	const nextEventId = lastEventRes.length > 0 ? lastEventRes[0].id + 1 : 0
-	globalState.serverEventIdCounter = Gen.counter(nextEventId)
 
 	const lastSquadRes = await ctx
 		.db()
@@ -739,7 +721,6 @@ async function setupSlice(ctx: C.Db & CS.AbortSignal, serverState: SS.ServerStat
 	cleanup.push(() => adminList.dispose())
 	const eventState: PendingEvents.State = PendingEvents.init({
 		counters: {
-			eventId: globalState.serverEventIdCounter,
 			squadId: globalState.squadIdCounter,
 		},
 		currentMatch: 'PENDING',
@@ -747,6 +728,7 @@ async function setupSlice(ctx: C.Db & CS.AbortSignal, serverState: SS.ServerStat
 		hooks: {
 			onNewGameDuringRoll: onNewGameDuringRoll(serverId),
 			onNewGameDuringSync: onNewGameDuringSync(serverId),
+			createEvent: createEvent(serverId),
 			fetchLayersStatus: async () => {
 				const ctx = resolveSliceCtx(getBaseCtx(), serverId)
 				const data = await Rx.firstValueFrom(
@@ -789,12 +771,8 @@ async function setupSlice(ctx: C.Db & CS.AbortSignal, serverState: SS.ServerStat
 		chatState: CHAT.getInitialChatState(),
 		emittedEvents: [],
 		emittedAppEvents: [],
-		lastSavedEventId: null,
-		savedEventIds: new Set(),
 		destroyed: false,
 		cleanupId: null,
-
-		savingEventsMtx: new Mutex(),
 
 		...SquadRcon.initSquadRcon({ ...ctx, rcon, adminList, serverId }, cleanup, { onFatalError: onResourceFatalError }),
 	}
@@ -805,7 +783,6 @@ async function setupSlice(ctx: C.Db & CS.AbortSignal, serverState: SS.ServerStat
 		server.tickRate$,
 		server.event$,
 		server.appEvent$,
-		server.savingEventsMtx,
 		server.processEventsMtx,
 	)
 
@@ -1080,34 +1057,6 @@ async function setupSlice(ctx: C.Db & CS.AbortSignal, serverState: SS.ServerStat
 			)
 			.subscribe(),
 	)
-
-	{
-		// -------- periodically save events  --------
-		const saveEventSub = Rx.interval(10_000)
-			.pipe(
-				Rx.filter(() => {
-					const ctx = resolveSliceCtx(getBaseCtx(), serverId)
-					return ctx.server.emittedEvents.length > 0
-						&& ctx.server.lastSavedEventId !== ctx.server.emittedEvents[ctx.server.emittedEvents.length - 1].id
-				}),
-				C.durableSub(
-					'save-events-interval',
-					{ module, root: true, taskScheduling: 'exhaust' },
-					async () => {
-						const ctx = resolveSliceCtx(getBaseCtx(), serverId)
-						return saveEvents(ctx)
-					},
-				),
-			)
-			.subscribe()
-
-		// -------- save remaining events on cleanup  --------
-		cleanup.push(async () => {
-			const ctx = resolveSliceCtx(getBaseCtx(), serverId)
-			saveEventSub.unsubscribe()
-			await saveEvents(ctx)
-		})
-	}
 
 	void LayerQueue.setupInstance({ ...ctx, ...slice })
 	Battlemetrics.setupSquadServerInstance({ ...ctx, ...slice })
@@ -1854,10 +1803,7 @@ const loadSavedEvents = C.spanOp(
 				.where(E.eq(Schema.serverEvents.matchId, lastMatch.id))
 				.orderBy(E.asc(Schema.serverEvents.id))
 			: []
-		const events = SE.fromEventRows({ ...ctx, log }, rowsRaw.map((r) => r.event))
-		server.lastSavedEventId = events[events.length - 1]?.id ?? null
-		server.emittedEvents = events
-		server.savedEventIds = new Set(events.map((e) => e.id))
+		server.emittedEvents = SE.fromEventRows({ ...ctx, log }, rowsRaw.map((r) => r.event))
 
 		const appEventRows = lastMatch
 			? await ctx
@@ -1871,27 +1817,28 @@ const loadSavedEvents = C.spanOp(
 	},
 )
 
-type EventInsertRows = {
-	eventRow: SchemaModels.NewServerEvent
+// the rows that hang off an event, and so can only be built once the insert has allocated its id
+type EventAssociationRows = {
 	playerRows: SchemaModels.NewPlayer[]
 	playerAssociationRows: SchemaModels.NewPlayerEventAssociation[]
 	squadRows: SchemaModels.NewSquad[]
 	squadAssociationRows: SchemaModels.NewSquadEventAssociation[]
 }
 
-function buildEventRows(ctx: CS.Log, event: SE.Event): EventInsertRows {
-	const persisted = Obj.omit(event, ['id', 'type', 'time', 'matchId'])
+function buildEventRow(event: SE.NewEvent): SchemaModels.NewServerEvent {
+	const persisted = Obj.omit(event, ['type', 'time', 'matchId'])
 	// queryable projection of source when it links to an app event
 	const source = (event as { source?: { type: string; id?: string } }).source
-	const eventRow: SchemaModels.NewServerEvent = {
-		id: event.id,
+	return {
 		type: event.type,
 		time: new Date(event.time),
 		matchId: event.matchId,
 		appEventId: source?.type === 'event' ? source.id! : null,
 		data: superjson.serialize(persisted),
 	}
+}
 
+function buildAssociationRows(ctx: CS.Log, event: SE.Event): EventAssociationRows {
 	const playerRows: SchemaModels.NewPlayer[] = []
 	const playerAssociationRows: SchemaModels.NewPlayerEventAssociation[] = []
 	for (const [player, assocType] of SE.iterAssocPlayers(event)) {
@@ -1929,18 +1876,10 @@ function buildEventRows(ctx: CS.Log, event: SE.Event): EventInsertRows {
 		squadAssociationRows.push({ squadId: uniqueSquadId, serverEventId: event.id })
 	}
 
-	return { eventRow, playerRows, playerAssociationRows, squadRows, squadAssociationRows }
+	return { playerRows, playerAssociationRows, squadRows, squadAssociationRows }
 }
 
-// Persists the rows for a single event. Kept as one unit so a caller can wrap it in a per-event transaction:
-// any statement here that throws (a constraint violation, a bad steamId, an unknown-player FK) aborts only this
-// event, letting the caller log it and move on rather than rolling back an entire batch.
-async function insertEventRows(ctx: C.Db, rows: EventInsertRows) {
-	await ctx
-		.db()
-		.insert(Schema.serverEvents)
-		.values([rows.eventRow])
-
+async function insertAssociationRows(ctx: C.Db, rows: EventAssociationRows) {
 	if (rows.playerRows.length > 0) {
 		await ctx
 			.db()
@@ -2042,86 +1981,31 @@ async function insertEventRows(ctx: C.Db, rows: EventInsertRows) {
 	}
 }
 
-// Persists buffered events one at a time, each in its own transaction. If any row insert for an event throws
-// (a constraint violation, a malformed steamId, etc.) the event is logged in full and skipped, so a single bad
-// event can neither roll back the rest of the batch nor silently drop it. The in-memory cursor advances only
-// after each event is dealt with, keeping it in step with the DB even across a crash mid-batch.
+// Persists a single event and returns it with the id the insert allocated -- the createEvent hook every event
+// PendingEvents emits goes through. serverEvents.id is autoincrement, so the db, not the app, hands out ids and
+// they can't drift from what's on disk.
 //
-// NOTE: a failing event is skipped (its cursor advances) after being logged, so its data is dropped on purpose
-// rather than becoming a poison pill that blocks every later event. The error log is the record of what was lost.
-export const saveEvents = C.spanOp(
-	'saveEvents',
-	{ module, mutexes: (ctx) => ctx.server.savingEventsMtx },
-	async (ctx: C.SquadServer & C.Db) => {
-		const server = ctx.server
-
-		let events: SE.Event[] = []
-		if (server.lastSavedEventId === null) {
-			events = server.emittedEvents.slice()
-		} else {
-			const lastSavedIndex = server.emittedEvents.findIndex((e) => e.id === server.lastSavedEventId)
-			if (lastSavedIndex === -1) {
-				throw new Error(`CRITICAL: Unable to resolve last saved event ${server.lastSavedEventId}`)
-			}
-			events = server.emittedEvents.slice(lastSavedIndex + 1)
-		}
-
-		if (events.length === 0) {
-			log.debug('No events to save')
-			return
-		}
-
-		let savedCount = 0
-		let failedCount = 0
-		for (const event of events) {
-			if (server.savedEventIds.has(event.id)) {
-				log.error('saveEvents: duplicate event id %d (%s), skipping', event.id, event.type)
-				server.lastSavedEventId = event.id
-				continue
-			}
-
-			const rows = buildEventRows({ ...CS.init(), log }, event)
-			try {
-				await DB.runTransaction(ctx, { redactParams: true }, (txCtx) => insertEventRows(txCtx, rows))
-				savedCount++
-			} catch (err) {
-				failedCount++
-				// err in the merge object so pino's error serializer includes message/stack (a %o format drops
-				// non-enumerable Error props, leaving just the code)
-				log.error(
-					{ err, event, playerRows: rows.playerRows, squadRows: rows.squadRows },
-					'saveEvents: failed to persist event %d (%s); skipping it so the rest of the batch is not lost',
-					event.id,
-					event.type,
-				)
-			}
-			// Advance past the event whether it committed or failed. Leaving the cursor behind a failed event would
-			// re-fail it on every flush and block every later event from ever being saved.
-			server.savedEventIds.add(event.id)
-			server.lastSavedEventId = event.id
-		}
-
-		if (failedCount > 0) {
-			log.warn('saveEvents: persisted %d event(s), %d failed and were skipped', savedCount, failedCount)
-		}
-
-		// Everything before the current match is persisted and no longer served from memory; rotate it out so
-		// emittedEvents (and the duplicate-id set) don't grow for the life of the process. Mirrors what
-		// loadEventState keeps on slice boot. The cut is bounded by the save cursor: events can land for a NEW
-		// match while this flush's inserts are in flight, and cutting past the cursor would strand it (the next
-		// flush resolves lastSavedEventId by index).
-		const currentMatchId = server.emittedEvents[server.emittedEvents.length - 1]?.matchId
-		if (currentMatchId !== undefined && server.lastSavedEventId !== null) {
-			const firstCurrentIdx = server.emittedEvents.findIndex((e) => e.matchId === currentMatchId)
-			const cursorIdx = server.emittedEvents.findIndex((e) => e.id === server.lastSavedEventId)
-			const cutoff = Math.min(firstCurrentIdx, cursorIdx)
-			if (cutoff > 0) {
-				const dropped = server.emittedEvents.splice(0, cutoff)
-				for (const e of dropped) server.savedEventIds.delete(e.id)
-			}
-		}
-	},
-)
+// One transaction per event: a statement that throws (a constraint violation, a bad steamId, an unknown-player
+// FK) rolls back only this event, and the throw propagates so the caller never emits an event we failed to
+// record. PendingEvents.process() logs it and moves on to the next pending event.
+const createEvent = (serverId: string): PendingEvents.State['hooks']['createEvent'] => async (newEvent) => {
+	const ctx = resolveSliceCtx(getBaseCtx(), serverId)
+	return C.spanOp(
+		'createEvent',
+		{ module },
+		async () =>
+			await DB.runTransaction(ctx, { redactParams: true }, async (ctx) => {
+				const [inserted] = await ctx
+					.db()
+					.insert(Schema.serverEvents)
+					.values(buildEventRow(newEvent))
+					.returning({ id: Schema.serverEvents.id })
+				const event = { ...newEvent, id: inserted.id } as SE.Event
+				await insertAssociationRows(ctx, buildAssociationRows({ ...ctx, log }, event))
+				return event
+			}),
+	)()
+}
 
 const onNewGameDuringSync = (serverId: string): PendingEvents.State['hooks']['onNewGameDuringSync'] => async (currentLayerId, _time) => {
 	const ctx = resolveSliceCtx(getBaseCtx(), serverId)
@@ -2129,7 +2013,7 @@ const onNewGameDuringSync = (serverId: string): PendingEvents.State['hooks']['on
 		'onNewGameDuringSync',
 		{
 			module,
-			mutexes: () => [ctx.matchHistory.mtx, ctx.server.savingEventsMtx],
+			mutexes: () => [ctx.matchHistory.mtx],
 			levels: { event: 'info' },
 		},
 		async () => {
@@ -2145,7 +2029,7 @@ const onNewGameDuringRoll = (serverId: string): PendingEvents.State['hooks']['on
 		'onNewGameDuringRoll',
 		{
 			module,
-			mutexes: () => [ctx.matchHistory.mtx, ctx.server.savingEventsMtx, ctx.layerQueue.updateLayerMtx],
+			mutexes: () => [ctx.matchHistory.mtx, ctx.layerQueue.updateLayerMtx],
 			levels: { event: 'info' },
 		},
 		async () =>


### PR DESCRIPTION
`PendingEvents` used to emit events with an id from an in-memory counter and let a 10s interval flush them to the db. A crash lost everything since the last flush, and the app handed out ids the db then had to agree with.

## What changed

`PendingEvents.State['hooks']` gains **`createEvent(event: SE.NewEvent): Promise<SE.Event>`** -- it takes the event without an id and returns it with the one the insert allocated. `serverEvents.id` was already autoincrement, so the db hands out ids now and they can't drift from what's on disk.

Every site that used to do `id: Gen.next(state.counters.eventId)` now builds the event and calls `createEvent(state, ...)` in place. An event is persisted where it is constructed, so from the yield onwards it already carries its real id.

`createEvent(state, event)` stamps expectation attribution before calling the hook -- `source` is part of the persisted event (and of its `appEventId` column), so stamping it after the insert would silently drop it. The caller still applies the created event to team state via `applyEventToState`.

The sub-generators that emit events (`reconcileTeamsUpdate`, `emitLeaveSquadEvents`) are async now, since they create events themselves. `reconcileTeamsUpdate` is still drained before any of it is yielded, so its events are all computed against the pre-mutation roster as before.

Removed with the deferral: `serverEventIdCounter` + its boot seeding query, `saveEvents`, `lastSavedEventId`, `savedEventIds`, `savingEventsMtx`, the save interval + cleanup flush, and the flush inside `addNewCurrentMatch`. `emittedEvents` stays, but purely as the current match's in-memory cache for the chat feed.

## Behaviour change worth a look

A failed insert used to be logged and skipped while the event stayed emitted in memory. Now the throw propagates: `process()` logs it and moves to the next pending event, and the event is never emitted. The db is the record; we don't publish what we failed to write.

## Verification

Types, lint and the full unit suite (558 tests, incl. all 69 pending-events tests unchanged) pass. Driven against the emulator on a worktree dev instance -- a join, a chat message, a squad creation and two full `AdminChangeLayer` rolls:

- events land within seconds, no flush, ids allocated by the db and continuing from the existing max
- `ROUND_ENDED` on the outgoing match, `NEW_GAME`/`RESET` on the match created mid-`process()` -- the FK ordering holds
- `MAP_SET` kept its app-event attribution end to end (`appEventId` joins to a real `appEvents` row)
- player/squad association rows resolve against the allocated id; `pragma foreign_key_check` clean

## Note

No migration and no persisted-shape change: the `data` payload is byte-identical (it never contained `id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)