### PR TITLE
Keep network IO out of runTransaction callbacks

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -697,11 +697,21 @@ state lives in JSON columns rather than being normalized. Those columns are **su
 handled by a `superjsonify`/`unsuperjsonify` pair that walks the drizzle table config and transforms only
 `json`-typed columns. This is what allows bigints (Discord snowflakes) and Dates to round-trip.
 
-**Transactions serialize globally.** better-sqlite3 is one synchronous connection, but callbacks 
+**Transactions serialize globally.** better-sqlite3 is one synchronous connection, but callbacks
 are still treated as though they could be async in the future, so
 `runTransaction` serializes logical transactions with a manual promise-chain lock around manual `BEGIN
 IMMEDIATE`/`COMMIT`/`ROLLBACK`. Re-entrant: an inner transaction joins the outer one, and an inner `rollback()`
 rolls back the outer. This is one process-wide lock, a deliberate simplicity-over-throughput call.
+
+Because that lock is process-wide, **a `runTransaction` callback must never await anything but a query.** Queries
+resolve immediately (the driver is synchronous), so a transaction that only queries holds the lock for microseconds.
+Awaiting rcon, discord, sftp, or any other network call inside one instead stalls every write in the process for the
+length of that round-trip, and the external call is not rolled back with the transaction anyway. Two ways out, both
+already used: hoist the call above the transaction when the write depends on its result (`Sessions.logInUser` resolves
+the discord member first; `filterEntity.updateFilter` does its rbac check first), or push it onto `ctx.tx.unlockTasks`
+when it's a side effect of the write (`LayerQueue.saveQueueAndUpdateServer` defers its rcon layer-set this way). Note
+that `unlockTasks` belong to the _outermost_ transaction, so a deferred task escapes an enclosing transaction too; it
+runs after `COMMIT` with the mutex context still ambient, but with `tx` spent.
 
 **Migrations** use a custom runner (`src/server/migrate.ts`, `pnpm db:migrate`) that merges drizzle-kit
 generated `.sql` files with hand-written `.ts` data migrations into one filename-ordered sequence tracked in

--- a/src/systems/filter-entity.server.ts
+++ b/src/systems/filter-entity.server.ts
@@ -226,14 +226,16 @@ export const filtersRouter = {
 		.input(z.tuple([F.FilterEntityIdSchema, F.UpdateFilterEntitySchema.partial()]))
 		.handler(async ({ input, context: ctx }) => {
 			const [id, update] = input
+			// resolved before the transaction, as createFilter and deleteFilter already do: the check reaches discord
+			// over the network to resolve the user's roles, and the tx lock is global
+			const deniedRes = await Rbac.tryDenyPermissionsForUser(ctx, RBAC.getWritePermReqForFilterEntity(id))
+			if (deniedRes) {
+				return deniedRes
+			}
 			const res = await DB.runTransaction(ctx, async (ctx) => {
 				const [rawFilter] = await ctx.db().select().from(Schema.filters).where(E.eq(Schema.filters.id, id))
 				if (!rawFilter) {
 					return { code: 'err:not-found' as const }
-				}
-				const deniedRes = await Rbac.tryDenyPermissionsForUser(ctx, RBAC.getWritePermReqForFilterEntity(id))
-				if (deniedRes) {
-					return deniedRes
 				}
 				const updateResult = await ctx.db().update(Schema.filters).set(update).where(E.eq(Schema.filters.id, id))
 

--- a/src/systems/layer-queue.server.ts
+++ b/src/systems/layer-queue.server.ts
@@ -334,33 +334,42 @@ export async function saveQueueAndUpdateServer(
 	queueUpdatedId?: string,
 ) {
 	await VoteSys.syncVoteStateWithQueueState(ctx, list)
-	return await DB.runTransaction(ctx, { redactParams: true }, async (ctx) => {
-		const serverState = await SquadServer.getServerState(ctx)
+	return await DB.runTransaction(ctx, { redactParams: true }, async (txCtx) => {
+		const serverState = await SquadServer.getServerState(txCtx)
 		const nextItemId = list[0]?.itemId || null
 		const nextLayerId = LL.getNextLayerId(list)
-		if (ctx.serverSettings.settings.warnOnChangeLayer && nextLayerId) {
-			const statusRes = await ctx.server.layersStatus.get(ctx)
-			if (statusRes.code === 'ok' && statusRes.data.nextLayer) {
-				if (!L.areLayersCompatible(statusRes.data.nextLayer.id, nextLayerId)) {
-					await warnShowNext(ctx, 'all-admins', { updated: true })
-				}
-			}
-		}
-		if (nextLayerId && nextItemId) {
-			await syncNextLayerToServer(
-				ctx,
-				serverState.settings,
-				nextLayerId,
-				nextItemId,
-				queueUpdatedId ? { reason: 'queue-updated', causeId: queueUpdatedId } : undefined,
-			)
-		} else {
-			log.error('No next layer to sync to server')
-		}
 
-		await SquadServer.updateServerState(ctx, { layerQueue: list }, {
+		await SquadServer.updateServerState(txCtx, { layerQueue: list }, {
 			type: 'system',
 			event: 'admin-change-layer',
+		})
+
+		// These reach the game server over rcon, so they're deferred rather than awaited under the (global) tx lock.
+		// unlockTasks are the outermost transaction's, so this also keeps them out of the map-roll tx that
+		// onNewGameDuringRoll wraps around this. The mutex context is ambient, so it still covers them; `tx` is dropped
+		// because it's spent by then, and a nested runTransaction would otherwise join a committed transaction and run
+		// in autocommit with a rollback() that does nothing.
+		const deferredCtx = { ...ctx, tx: undefined }
+		txCtx.tx.unlockTasks.push(async () => {
+			if (deferredCtx.serverSettings.settings.warnOnChangeLayer && nextLayerId) {
+				const statusRes = await deferredCtx.server.layersStatus.get(deferredCtx)
+				if (statusRes.code === 'ok' && statusRes.data.nextLayer) {
+					if (!L.areLayersCompatible(statusRes.data.nextLayer.id, nextLayerId)) {
+						await warnShowNext(deferredCtx, 'all-admins', { updated: true })
+					}
+				}
+			}
+			if (nextLayerId && nextItemId) {
+				await syncNextLayerToServer(
+					deferredCtx,
+					serverState.settings,
+					nextLayerId,
+					nextItemId,
+					queueUpdatedId ? { reason: 'queue-updated', causeId: queueUpdatedId } : undefined,
+				)
+			} else {
+				log.error('No next layer to sync to server')
+			}
 		})
 
 		return {

--- a/src/systems/sessions.server.ts
+++ b/src/systems/sessions.server.ts
@@ -220,6 +220,13 @@ export async function logInUser(ctx: C.Db & C.FastifyRequest & C.FastifyReply, d
 	const sessionId = createId(64)
 	const expiresAt = new Date(Date.now() + SESSION_MAX_AGE)
 
+	// resolved before the transaction: it fetches the discord member over the network, and the tx lock is global
+	const builtUser = await Users.buildUser({
+		discordId: discordUser.id,
+		username: discordUser.username,
+		nickname: null,
+	})
+
 	await DB.runTransaction(ctx, { redactParams: true }, async (ctx) => {
 		const [user] = await ctx.db()
 			.select()
@@ -241,11 +248,7 @@ export async function logInUser(ctx: C.Db & C.FastifyRequest & C.FastifyReply, d
 			id: sessionId,
 			userId: discordUser.id,
 			expiresAt,
-			user: await Users.buildUser({
-				discordId: discordUser.id,
-				username: discordUser.username,
-				nickname: null,
-			}),
+			user: builtUser,
 		})
 	})
 	await setSessionCookie(ctx, sessionId)


### PR DESCRIPTION
`runTransaction` takes one process-wide lock around `BEGIN IMMEDIATE`. better-sqlite3 is synchronous, so a callback that only queries holds that lock for microseconds -- but a callback that awaits a network round-trip holds it for as long as the round-trip takes, stalling **every other write in the process**. The external call isn't rolled back with the transaction anyway, so it was never buying atomicity.

I audited all 19 `runTransaction` call sites. Four were awaiting network IO inside the lock; the rest are queries-only and unchanged.

## The rcon one (the map-roll path)

`LayerQueue.saveQueueAndUpdateServer` held the lock across three rcon round-trips: the layers-status read, the admin warn, and the set-next-layer. These are side effects on the game server rather than part of the write, so they now go on `ctx.tx.unlockTasks` and run after `COMMIT`.

This is the fix that mattered most, because `unlockTasks` belong to the **outermost** transaction. `onNewGameDuringRoll` wraps a transaction around the whole map roll (`dispatchOp` -> `request-list-save` -> `saveQueueAndUpdateServer`), so the roll was holding the global lock across all of that rcon traffic. Deferring inside `saveQueueAndUpdateServer` lifts it out of the roll transaction too, so one change covers both entry points.

Two details worth a reviewer's eye:
- The deferred closure drops `tx`. It's spent by the time the closure runs, and a nested `runTransaction` would otherwise *join* a committed transaction, silently running in autocommit with a `rollback()` that does nothing.
- It keeps the ambient (AsyncLocalStorage) mutex context, so `syncNextLayerToServer` still sees `updateLayerMtx`/`matchHistory.mtx` as held and doesn't try to re-acquire them.

Ordering does change: the queue state now commits before the layer is pushed to the game server. Nothing downstream depends on the rcon having completed (`save-completed` and `schedulePostRollTasks` read in-memory state), and `syncNextLayerToServer` re-reads live rcon status when it runs.

## The discord ones

`Sessions.logInUser` (member fetch) and `filterEntity.updateFilter` (rbac role resolution) each held the lock across a discord call. Both only needed the result, so they resolve it before opening the transaction -- which is what `createFilter` and `deleteFilter` already did.

`updateFilter` now returns `err:permission-denied` ahead of `err:not-found` for an id that doesn't exist, matching `deleteFilter`'s existing ordering.

## Verified

- `pnpm run test` -- 568 passed
- `pnpm run test:integration` -- 25 passed, 2 skipped (drives the real emulator, covers the roll)
- `pnpm run test:e2e` -- 20 passed

The e2e suite is what actually proves the deferred rcon still fires: `queue.test.ts` ("keeps the game server on its head") and `queue-editing.test.ts` ("pushing the new head to the game server") assert the **emulator's real next layer** after a save. An earlier draft pushed to `ctx.tx?.unlockTasks`, which no-ops on the standalone save path where the outer ctx has no `tx` -- those two tests are what would have caught it.

Rule documented in ARCHITECTURE.md alongside the transaction-lock section.

No schema, config, or persisted-data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)