### PR TITLE
Enforce the query-only rule in runTransaction

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -713,6 +713,14 @@ when it's a side effect of the write (`LayerQueue.saveQueueAndUpdateServer` defe
 that `unlockTasks` belong to the _outermost_ transaction, so a deferred task escapes an enclosing transaction too; it
 runs after `COMMIT` with the mutex context still ambient, but with `tx` spent.
 
+**That rule is enforced, not just documented.** `runTransaction` races every callback against a `setImmediate`: because
+the driver is synchronous an awaited query settles on a microtask, and microtasks all drain before the loop reaches the
+check phase, so a query-only callback always wins. A callback that reaches the network, the disk or a timer has to yield
+and loses. Losing throws in development and test (loudly, rolling the transaction back), and warns in production, where
+a violation is a latency bug and failing the write would be the worse outcome. The report carries the stack of the
+offending `runTransaction` call, and a joined inner transaction reports before its outer one, so the innermost violator
+is named rather than the whole roll.
+
 **Migrations** use a custom runner (`src/server/migrate.ts`, `pnpm db:migrate`) that merges drizzle-kit
 generated `.sql` files with hand-written `.ts` data migrations into one filename-ordered sequence tracked in
 `_slm_migrations`. Two constraints shape it:

--- a/src/server/db.test.ts
+++ b/src/server/db.test.ts
@@ -1,0 +1,55 @@
+import { runDetectingYield } from '@/server/db'
+import { describe, expect, test } from 'vitest'
+
+// what an awaited drizzle query looks like to the runtime: better-sqlite3 runs the statement synchronously, and the
+// query builder is a thenable that resolves from inside .then() rather than from an IO completion
+function syncThenable<T>(value: T): PromiseLike<T> {
+	return { then: (resolve, reject) => Promise.resolve().then(() => resolve!(value), reject) }
+}
+
+describe('runDetectingYield', () => {
+	test('a callback that only awaits queries does not yield', async () => {
+		const { res, yielded } = await runDetectingYield(async () => {
+			const a = await syncThenable(1)
+			const b = await syncThenable(2)
+			return a + b
+		})
+		expect(res).toBe(3)
+		expect(yielded).toBe(false)
+	})
+
+	test('awaiting settled promises and draining microtasks does not count as yielding', async () => {
+		// a long microtask chain never hands control back to the event loop, so no other transaction can interleave
+		// with it -- it is CPU-bound, not a lock-holding wait, and must not be reported
+		const { yielded } = await runDetectingYield(async () => {
+			for (let i = 0; i < 500; i++) await Promise.resolve()
+			await queueMicrotaskP()
+		})
+		expect(yielded).toBe(false)
+	})
+
+	test('a timer yields', async () => {
+		const { yielded } = await runDetectingYield(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 1))
+		})
+		expect(yielded).toBe(true)
+	})
+
+	test('real IO yields', async () => {
+		const { yielded } = await runDetectingYield(async () => {
+			await import('node:fs/promises').then((fs) => fs.readFile(import.meta.filename, 'utf8'))
+		})
+		expect(yielded).toBe(true)
+	})
+
+	test('reports the yield rather than swallowing the callback failure', async () => {
+		await expect(runDetectingYield(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 1))
+			throw new Error('boom')
+		})).rejects.toThrow('boom')
+	})
+})
+
+function queueMicrotaskP() {
+	return new Promise<void>((resolve) => queueMicrotask(resolve))
+}

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1,3 +1,4 @@
+import { assertNever } from '@/lib/type-guards'
 import { tsMigrations } from '@/migrations/registry'
 import type * as CS from '@/models/context-shared'
 import { initModule } from '@/server/logger'
@@ -133,6 +134,65 @@ async function acquireTxLock(): Promise<() => void> {
 	return release
 }
 
+// Only queries may be awaited inside a transaction: the lock above is process-wide, so a callback that waits on
+// anything else stalls every other write in the process for as long as it waits (and whatever it waited on is not
+// rolled back with the transaction anyway). See docs/ARCHITECTURE.md.
+//
+// That property is detectable rather than merely conventional. better-sqlite3 is synchronous, so an awaited drizzle
+// query settles on a microtask, and the microtask queue always drains before the loop reaches the check phase --
+// a query-only callback therefore always beats a setImmediate scheduled alongside it. Anything that reaches the
+// network, the disk or a timer has to yield first, and loses the race.
+//
+// exported for its test: the race is the whole mechanism, and it is not otherwise observable from outside.
+export async function runDetectingYield<V>(run: () => Promise<V>): Promise<{ res: V; yielded: boolean }> {
+	let yielded = false
+	const immediate = setImmediate(() => {
+		yielded = true
+	})
+	try {
+		return { res: await run(), yielded }
+	} finally {
+		clearImmediate(immediate)
+	}
+}
+
+// keyed on the tx handle, which a joined inner transaction shares with its outer one, so a violation is reported once
+// at the innermost transaction that saw it -- the precise one -- rather than again at every transaction enclosing it.
+const asyncTxReported = new WeakSet<object>()
+
+async function runTxCallback<V>(txHandle: object, callback: () => Promise<V>): Promise<V> {
+	// constructed eagerly because the offending call site is gone by the time the violation is detectable. V8 formats
+	// .stack lazily, so this costs an allocation unless it's actually reported.
+	const callSite = new Error()
+	const { res, yielded } = await runDetectingYield(callback)
+	// deliberately after the await rather than around it: a callback that threw is already loud, and throwing this on
+	// top of it would bury the actual failure
+	if (yielded && !asyncTxReported.has(txHandle)) {
+		asyncTxReported.add(txHandle)
+		reportAsyncTx(callSite)
+	}
+	return res
+}
+
+function reportAsyncTx(callSite: Error): void {
+	const msg = 'transaction callback yielded to the event loop: only queries may be awaited inside runTransaction, '
+		+ 'because the transaction lock is process-wide. Hoist the call above runTransaction if the write needs its '
+		+ 'result, or defer it with ctx.tx.unlockTasks if it is a side effect of the write. See docs/ARCHITECTURE.md.'
+	switch (ENV.NODE_ENV) {
+		// a violation is a latency bug rather than a correctness one, and rolling a transaction back over it in prod
+		// would turn slow writes into failed ones
+		case 'production':
+			log.warn({ err: callSite }, msg)
+			return
+		case 'development':
+		case 'test':
+			callSite.message = msg
+			throw callSite
+		default:
+			assertNever(ENV.NODE_ENV)
+	}
+}
+
 export async function runTransaction<T extends C.Db, V>(
 	ctx: T & { tx?: { rollback: () => void } },
 	opts: { redactParams?: boolean },
@@ -151,25 +211,27 @@ export async function runTransaction<T extends C.Db, V>(
 	const callback = (typeof secondArg === 'function' ? secondArg : thirdArg)!
 
 	// already inside a transaction: join it. an inner rollback() rolls back the outer transaction
-	if (ctx.tx) return callback(ctx as T & C.Tx)
+	if (ctx.tx) return await runTxCallback(ctx.tx, () => callback(ctx as T & C.Tx))
 
 	let res!: Awaited<V>
 	let shouldRollback = false
 	const unlockTasks: C.Tx['tx']['unlockTasks'] = []
+	const txHandle: C.Tx['tx'] = {
+		rollback: () => {
+			shouldRollback = true
+		},
+		unlockTasks,
+	}
 	const release = await acquireTxLock()
 	try {
 		driver.exec('BEGIN IMMEDIATE')
 		try {
-			res = await callback({
-				...ctx,
-				tx: {
-					rollback: () => {
-						shouldRollback = true
-					},
-					unlockTasks,
-				},
-				db: () => ctx.db(opts),
-			})
+			res = await runTxCallback(txHandle, () =>
+				callback({
+					...ctx,
+					tx: txHandle,
+					db: () => ctx.db(opts),
+				}))
 			driver.exec(shouldRollback ? 'ROLLBACK' : 'COMMIT')
 		} catch (err) {
 			if (driver.inTransaction) driver.exec('ROLLBACK')


### PR DESCRIPTION
Follow-up to #46, which fixed four transaction callbacks that awaited network IO. That rule ("only queries may be awaited inside `runTransaction`") was documented but unenforced -- which is how those four got there.

It turns out to be **detectable** rather than merely conventional. better-sqlite3 is synchronous, so an awaited drizzle query settles on a microtask, and the microtask queue always drains before the event loop reaches the check phase. So a query-only callback always beats a `setImmediate` scheduled alongside it; anything that reaches the network, the disk, or a timer has to yield first and loses the race.

## Behaviour

- **development / test:** throws, rolling the transaction back. Loud, where you can fix it.
- **production:** warns. A violation is a latency bug, and rolling the write back over it would turn a slow write into a failed one.

The report carries the stack of the offending `runTransaction` call (the call site is gone by the time the violation is detectable, so the `Error` is constructed eagerly -- V8 formats `.stack` lazily, so it costs an allocation unless actually reported).

Reports are deduped on the tx handle, which a joined inner transaction shares with its outer one, so the **innermost** violator is named rather than every transaction enclosing it. In dev that also means exactly one error: the innermost throws, and the enclosing transactions never reach their own check.

The check sits after the callback's await rather than around it, so a callback that threw keeps its own error instead of having this one buried on top of it.

## Verified

The failure mode to worry about with a guard like this is a vacuous pass -- if the race never fires, everything goes green and the guard does nothing. So:

- **The race is unit tested directly** (`src/server/db.test.ts`): a drizzle-shaped sync thenable and a 500-deep microtask chain both count as *not* yielding; a timer and real file IO both do. Plus the error-passthrough case.
- **End-to-end, by mutation:** planting `await setTimeout(1)` in the `saveEvents` transaction fails the boot integration test (0 events persisted, all rolled back). Re-running with the report routed to the warn branch, violation still planted, passes 5/5 -- which isolates the guard as the cause rather than anything the timer did to sqlite.
- **No false positives** with the guard live and throwing: 577 unit, 25 integration (2 skipped), 20 e2e.

That last run also settles an open question from the #46 audit: the layer generation inside the map-roll transaction (`queryLayersStreamed`) does *not* trip the guard, so the wasm engine resolves without yielding.

Rule and mechanism documented in ARCHITECTURE.md alongside the transaction-lock section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)