### PR TITLE
Stop chat.models.ts reading as binary, and correct the causeId docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -586,8 +586,10 @@ data by ~112MB.
 - **server events** are SLM's domain events derived from game server input (`NEW_GAME`, `PLAYER_CONNECTED`,
   `MAP_SET`). High volume, low level.
 - **app events** (`app-events.models.ts`) are SLM's **audit log**: one entry per user- or system-initiated
-  action, with an `actor` (`slm-user | ingame-user | system`) and a `causeId` chaining provenance
-  (`COMMAND_INVOKED` -> `VOTE_STARTED` -> `NEXT_LAYER_SET`).
+  action, with an `actor` (`slm-user | ingame-user | system`) and a `causeId` naming the app event that caused
+  this one. The only chain written today is `QUEUE_UPDATED` -> `MAP_SET`, and nothing reads `causeId` back.
+  Not every app event reaches the activity feed: see `isFeedVisible`, which both the emit path and the feed
+  backfill gate on.
 - **pending events** (`pending-events.models.ts`) is the **state machine that produces server events** out of
   raw input.
 

--- a/src/models/app-events.models.ts
+++ b/src/models/app-events.models.ts
@@ -47,7 +47,8 @@ const baseShape = {
 	serverId: z.string().nullable(),
 	// feed replay/join key; null for global (never enters a server activity feed)
 	matchId: z.number().nullable(),
-	// provenance chain: the app event that caused this one (COMMAND_INVOKED -> VOTE_STARTED -> NEXT_LAYER_SET)
+	// provenance: the app event that caused this one. Today the only chain written is QUEUE_UPDATED -> MAP_SET, and
+	// nothing reads it back -- no query, join or UI walks it -- so don't lean on it to make an event reachable.
 	causeId: z.string().nullable(),
 	// the SLM process (otel service.instance.id) that emitted this event; stamped at persist time. null on events
 	// created before this was introduced.

--- a/src/models/chat.models.ts
+++ b/src/models/chat.models.ts
@@ -305,7 +305,10 @@ export function handleEvent(
 // starts a fresh entry (so unrelated warns that happen to share text stay separate)
 const WARN_AGGREGATION_WINDOW_MS = 5000
 
-// dedup key: identical warn text AND the same acting source (a specific in-game admin, RCON, etc.)
+// dedup key: identical warn text AND the same acting source (a specific in-game admin, RCON, etc.).
+// NUL joins the two halves because it can't occur in either, so no actor/reason pair can spell another one's key.
+// It's written as an escape rather than the literal byte: inline, it makes this file read as binary to grep, which
+// then reports no matches here rather than an error.
 function warnDedupKey(reason: string, source: SE.PlayerWarned['source']): string {
 	const actor = !source
 		? 'none'
@@ -314,7 +317,7 @@ function warnDedupKey(reason: string, source: SE.PlayerWarned['source']): string
 		: source.type === 'event'
 		? `event:${source.id}`
 		: source.type
-	return `${actor} ${reason}`
+	return `${actor}\u0000${reason}`
 }
 
 // merge a standalone warn into a recent matching group, upgrading a lone prior warn in place if needed; else append.


### PR DESCRIPTION
Follow-ups to #43 that didn't make it in before the merge. No behaviour changes — encoding and comments only.

### `chat.models.ts` read as binary to grep

`warnDedupKey` joins actor and reason with a NUL byte, so that no actor/reason pair can spell another pair's key. That's a legitimate delimiter and it stays. But written as a **literal** byte it made the entire file binary as far as grep is concerned, and grep then reports *no matches* in it rather than an error — a silent false negative on every search of a 1000-line model.

It's now the same string via a unicode escape (identical value, file is text again), with a comment explaining the delimiter so nobody strips it as junk later.

This is not hypothetical: during #43 a grep of this file silently found nothing, and I reported on that basis that `collapsed` was populated but never read. It isn't — `iterAssocPlayers` and `iterAssocSquadUniqueIds` both recurse into it so a collapsed child's player/squad associations roll up into the parent entry.

### The `causeId` docs described a chain that doesn't exist

`ARCHITECTURE.md` and the schema comment both documented provenance as `COMMAND_INVOKED -> VOTE_STARTED -> NEXT_LAYER_SET`. Checked against the code:

- `COMMAND_INVOKED` — not an app event type.
- `NEXT_LAYER_SET` — not an app event type; it was renamed `MAP_SET`.
- `VOTE_STARTED` — exists, but is never used as a `causeId`.

The only chain written anywhere is `QUEUE_UPDATED -> MAP_SET` (`layer-queue.server.ts`), and **nothing reads `causeId` back** — no query, no join, no UI, unindexed text column, no FK.

Worth being blunt about in the docs, because "the audit-only MAP_SET stays reachable from the QUEUE_UPDATED via its causeId" is exactly the justification #43's own commit message leaned on. It's true of the data and false of the code. `ARCHITECTURE.md` now also points at `isFeedVisible`, which #43 made the single rule both the emit path and the feed backfill gate on.

### Verification

`pnpm run check` and `lint:fix` clean; 580 unit tests pass, including the warn burst-aggregation tests that exercise `warnDedupKey`. Confirmed no NUL bytes remain anywhere under `src/`, and that plain `grep` now finds symbols in `chat.models.ts`.

Separately: I re-ran #43's integration tests against current main (which gained #44/#45/#46 while that PR was open, including the `createEvent` rewrite it was never tested against). They pass, and the merged MAP_SET block composes correctly — my layer-matching computes `source`, `createEvent` inserts with it. So nothing was lost by merging early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
