### PR TITLE
Fix tempo-config for Tempo 3 (otel-lgtm:0.29.0)

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -27,13 +27,13 @@ docker run --rm --entrypoint cat grafana/otel-lgtm:<tag> /otel-lgtm/tempo-config
 
 then re-applying the deltas in the table below. Diff it against what is here before you trust it.
 
-| File                                | Replaces                            | What we add                                                                                 |
-| ----------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------- |
-| `tempo-config.yaml`                 | `/otel-lgtm/tempo-config.yaml`      | `compactor.compaction.block_retention: 72h`, plus the `local-blocks` processor              |
-| `loki-config.yaml`                  | `/otel-lgtm/loki-config.yaml`       | `limits_config.retention_period: 336h` + a `compactor` block                                |
-| `grafana/provisioning/datasources/` | the image's datasource provisioning | `tracesToMetrics`, otherwise the image's own cross-links                                    |
-| `grafana/provisioning/dashboards/`  | the image's dashboard provisioning  | points at `grafana/dashboards/`; re-declares the image's two RED dashboards so they survive |
-| `grafana/dashboards/`               | nothing (new)                       | the two SLM dashboards                                                                      |
+| File                                | Replaces                            | What we add                                                                                  |
+| ----------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------- |
+| `tempo-config.yaml`                 | `/otel-lgtm/tempo-config.yaml`      | 72h `block_retention` on `backend_scheduler` + `backend_worker` (Tempo 3 has no `compactor`) |
+| `loki-config.yaml`                  | `/otel-lgtm/loki-config.yaml`       | `limits_config.retention_period: 336h` + a `compactor` block                                 |
+| `grafana/provisioning/datasources/` | the image's datasource provisioning | `tracesToMetrics`, otherwise the image's own cross-links                                     |
+| `grafana/provisioning/dashboards/`  | the image's dashboard provisioning  | points at `grafana/dashboards/`; re-declares the image's two RED dashboards so they survive  |
+| `grafana/dashboards/`               | nothing (new)                       | the two SLM dashboards                                                                       |
 
 ## Retention
 

--- a/observability/tempo-config.yaml
+++ b/observability/tempo-config.yaml
@@ -1,8 +1,14 @@
 # Overrides /otel-lgtm/tempo-config.yaml in the grafana/otel-lgtm image. Everything outside the
-# `compactor` block and the local-blocks additions noted below is the image's own config, reproduced
+# `backend_scheduler`/`backend_worker` retention blocks below is the image's own config, reproduced
 # verbatim: mounting this file replaces the original wholesale, so dropping a section here would
 # silently un-configure it. Reproduced from the 0.29.0 image, which is the tag docker-compose.yaml
 # pins and the reason it pins one at all. See README.md#the-mount-contract.
+#
+# 0.29.0 ships Tempo 3.0.2, which removed the compactor component (#6273) and the metrics-generator
+# local-blocks processor (#6555). So neither the old top-level `compactor:` block nor the
+# `metrics_generator.processor.local_blocks` / `metrics_generator.traces_storage` config exists any
+# more; a config carrying them fails to parse and Tempo exits silently (logging=false), taking traces
+# with it while every other component reports healthy. The two deltas below are the Tempo-3 forms.
 server:
   http_listen_port: 3200
   grpc_listen_port: 9096
@@ -32,36 +38,43 @@ storage:
     local:
       path: /data/tempo/blocks
 
-# 3 day trace retention. Tempo's default is 336h; traces are by far the highest-volume signal we emit
-# (one span per spanOp, plus auto-instrumented http/rcon/dns spans underneath each), so they get the
-# shortest window. The RED metrics derived from them by the metrics_generator below live in Prometheus
-# and outlive the spans themselves, so long-range trend queries still work after the traces age out.
-compactor:
-  compaction:
-    block_retention: 72h
-    compacted_block_retention: 1h
-
 metrics_generator:
   processor:
-    local_blocks:
-      filter_server_spans: false
     span_metrics:
       dimensions:
         - service_name
         - operation
         - status_code
-  traces_storage:
-    path: /data/tempo/generator/traces
   storage:
     path: /data/tempo/generator/wal
     remote_write:
       - url: http://127.0.0.1:9090/api/v1/write
         send_exemplars: true
 
+# 3 day trace retention (default is 336h). Traces are by far the highest-volume signal we emit (one span
+# per spanOp, plus auto-instrumented http/rcon/dns spans underneath each), so they get the shortest
+# window. The RED metrics derived from them by the metrics_generator above live in Prometheus and outlive
+# the spans themselves, so long-range trend queries still work after the traces age out.
+#
+# Tempo 3 replaced the compactor component with a backend-scheduler (decides which blocks to compact and
+# expire) and a backend-worker (runs the jobs), so `block_retention` lives on both instead of on a
+# top-level `compactor` block. The nested `provider.compaction.compaction` path is not a typo: the outer
+# is the scheduler's compaction provider, the inner its compaction settings (confirmed against Tempo's
+# own /status/config, since the -help flag paths are mangled for this struct).
+backend_scheduler:
+  provider:
+    compaction:
+      compaction:
+        block_retention: 72h
+backend_worker:
+  compaction:
+    block_retention: 72h
+
 # Must be the scoped form: Tempo 3 refuses to start on the legacy flat `metrics_generator_processors`
-# key. local-blocks is ours on top of the image's two, and is what backs TraceQL metrics queries
-# (`| rate() by(...)`), which the Traces Drilldown issues on open.
+# key. These are the image's own two processors. There is no `local-blocks` entry: that processor is gone
+# in Tempo 3, and TraceQL metrics (`{...} | rate() by(...)`, which the Traces Drilldown issues on open)
+# are served natively without it.
 overrides:
   defaults:
     metrics_generator:
-      processors: [service-graphs, span-metrics, local-blocks]
+      processors: [service-graphs, span-metrics]


### PR DESCRIPTION
## Problem

Found while running a from-scratch `docs/INSTALLING.md` install to vet the Grafana stack: **traces never reach Grafana on a clean deploy.**

The pinned `grafana/otel-lgtm:0.29.0` ships **Tempo 3.0.2**, which removed:
- the **compactor component** ([#6273](https://github.com/grafana/tempo/pull/6273))
- the metrics-generator **local-blocks processor** ([#6555](https://github.com/grafana/tempo/pull/6555))

But the committed `observability/tempo-config.yaml` still carried the Tempo-2.x forms of both deltas: a top-level `compactor:` block, `metrics_generator.processor.local_blocks`, `metrics_generator.traces_storage`, and a `local-blocks` entry in the overrides processors list. Tempo fails config parse:

```
line 39: field compactor not found in type app.Config
line 46: field local_blocks not found in type generator.ProcessorConfig
line 53: field traces_storage not found in type generator.Config
```

and **exits silently** (`logging=false`). The container stays healthy, the other five components report ready, logs and metrics keep flowing — the only symptom is traces going dark. Exactly the failure mode `observability/README.md` warns about. (PR #37 fixed the overrides *format* for Tempo 3 but not these three fields.)

## Fix

Re-author both deltas for Tempo 3:
- **72h `block_retention`** now lives on `backend_scheduler.provider.compaction.compaction` and `backend_worker.compaction` (the scheduler/worker that replaced the compactor). The nested `provider.compaction.compaction` path is confirmed against Tempo's own `/status/config` — the `-help` flag paths are mangled for this struct.
- **Drop** the local-blocks processor and `traces_storage`. TraceQL metrics (`{...} | rate() by(...)`, which the Traces Drilldown issues) are served natively in Tempo 3 without the processor.

Also updates the README mount-contract row to match.

## Verification

- `tempo -config.verify=true` on the committed file: **parses clean**
- `/status/config` after startup: `block_retention: 72h0m0s` on both scheduler and worker
- Applied to a live install: Tempo comes up ready, traces are searchable, `/api/metrics/query_range` with `{} | rate()` returns series
- Metrics (Prometheus `slm_*`) and logs (Loki) unaffected

Not a frontend change; no dev-server link. Reviewers can see it running in the vetting install at `http://localhost:3001` (Grafana admin/admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)