### PR TITLE
Fix flaky roster: track a squad created before its creator connects

### DIFF
--- a/src/models/chat.models.test.ts
+++ b/src/models/chat.models.test.ts
@@ -461,7 +461,19 @@ describe('chat.models recent squads', () => {
 	function joinedSquad(playerEos: SM.PlayerId, uniqueId: number, id: number): SE.PlayerJoinedSquad {
 		return { type: 'PLAYER_JOINED_SQUAD', id, time: 100 + id, matchId: 1, uniqueId, player: playerEos }
 	}
+	function promoted(playerEos: SM.PlayerId, uniqueId: number, id: number): SE.PlayerPromotedToLeader {
+		return { type: 'PLAYER_PROMOTED_TO_LEADER', id, time: 100 + id, matchId: 1, uniqueId, player: playerEos }
+	}
+	// synthesized SQUAD_CREATED: the create log never landed, so the poll invented the squad. It carries no
+	// creation-time membership; the join/promote events reconciled from the same poll establish it instead.
+	function synthesizedSquad(squad: SM.UniqueSquad, id: number): SE.SquadCreated {
+		return { type: 'SQUAD_CREATED', id, time: 100 + id, matchId: 1, squad, synthesized: true }
+	}
+	function resetEmpty(id: number): SE.Reset {
+		return { type: 'RESET', id, time: 100 + id, matchId: 1, source: 'rcon-reconnected', state: { players: [], squads: [] } }
+	}
 	const recentUniqueIds = (state: CHAT.ChatState) => state.interpolatedState.recentSquads.map(s => s.uniqueId)
+	const byEos = (state: CHAT.ChatState, eos: string) => state.interpolatedState.players.find(p => p.ids.eos === eos)!
 
 	function stateWithSquad() {
 		const state = CHAT.getInitialChatState()
@@ -514,6 +526,49 @@ describe('chat.models recent squads', () => {
 		const byEos = (eos: string) => state.interpolatedState.players.find(p => p.ids.eos === eos)
 		expect(byEos('a')?.squadId).toBe(1)
 		expect(byEos('b')?.squadId).toBe(1)
+	})
+
+	// A synthesized squad never resolves its creator through the create event (there's no membership on it); the
+	// creator's leadership arrives via the poll's join+promote, which can land after the synthesized create. The
+	// squad must be tracked so those land -- this is the reconnect/roll ordering the CI flake exposed.
+	it('tracks a synthesized squad and lands its poll-reconciled joins and promote', () => {
+		const state = CHAT.getInitialChatState()
+		CHAT.handleEvent(state, synthesizedSquad(makeSquad(1, 1, 'a', 101), 1))
+		CHAT.handleEvent(state, connected(makePlayer('a'), 2))
+		CHAT.handleEvent(state, connected(makePlayer('b'), 3))
+		CHAT.handleEvent(state, joinedSquad('a', 101, 4))
+		CHAT.handleEvent(state, promoted('a', 101, 5))
+		CHAT.handleEvent(state, joinedSquad('b', 101, 6))
+
+		expect(state.interpolatedState.squads.map(s => s.uniqueId)).toEqual([101])
+		expect(byEos(state, 'a')).toMatchObject({ squadId: 1, isLeader: true })
+		expect(byEos(state, 'b')).toMatchObject({ squadId: 1, isLeader: false })
+	})
+
+	// A same-match rcon reconnect wipes the roster with an empty RESET, taking the squad and its membership with it.
+	// The post-reconnect poll re-adds everyone and re-synthesizes the squad (new uniqueId); membership must re-form.
+	it('recovers a squad and its members after a RESET wipes them', () => {
+		const state = CHAT.getInitialChatState()
+		CHAT.handleEvent(state, connected(makePlayer('a'), 1))
+		CHAT.handleEvent(state, connected(makePlayer('b'), 2))
+		CHAT.handleEvent(state, squadCreated(makeSquad(1, 1, 'a', 101), 3))
+		CHAT.handleEvent(state, joinedSquad('b', 101, 4))
+		expect(byEos(state, 'a')).toMatchObject({ squadId: 1, isLeader: true })
+
+		CHAT.handleEvent(state, resetEmpty(5))
+		expect(state.interpolatedState.squads).toHaveLength(0)
+		expect(state.interpolatedState.players).toHaveLength(0)
+
+		CHAT.handleEvent(state, connected(makePlayer('a'), 6))
+		CHAT.handleEvent(state, connected(makePlayer('b'), 7))
+		CHAT.handleEvent(state, synthesizedSquad(makeSquad(1, 1, 'a', 102), 8))
+		CHAT.handleEvent(state, joinedSquad('a', 102, 9))
+		CHAT.handleEvent(state, promoted('a', 102, 10))
+		CHAT.handleEvent(state, joinedSquad('b', 102, 11))
+
+		expect(state.interpolatedState.squads.map(s => s.uniqueId)).toEqual([102])
+		expect(byEos(state, 'a')).toMatchObject({ squadId: 1, isLeader: true })
+		expect(byEos(state, 'b')).toMatchObject({ squadId: 1, isLeader: false })
 	})
 
 	it('clears recentSquads at a match boundary', () => {

--- a/src/models/chat.models.test.ts
+++ b/src/models/chat.models.test.ts
@@ -458,6 +458,9 @@ describe('chat.models recent squads', () => {
 	function newGame(id: number): SE.NewGame {
 		return { type: 'NEW_GAME', id, time: 100 + id, matchId: 1, source: 'new-game-detected', layerId: 'l1' }
 	}
+	function joinedSquad(playerEos: SM.PlayerId, uniqueId: number, id: number): SE.PlayerJoinedSquad {
+		return { type: 'PLAYER_JOINED_SQUAD', id, time: 100 + id, matchId: 1, uniqueId, player: playerEos }
+	}
 	const recentUniqueIds = (state: CHAT.ChatState) => state.interpolatedState.recentSquads.map(s => s.uniqueId)
 
 	function stateWithSquad() {
@@ -494,6 +497,23 @@ describe('chat.models recent squads', () => {
 		CHAT.handleEvent(state, squadCreated(makeSquad(1, 1, 'a', 102), 4))
 
 		expect(recentUniqueIds(state)).toEqual([101, 102])
+	})
+
+	// SQUAD_CREATED is parsed from the log stream while the creator's PLAYER_CONNECTED is reconciled from the teams
+	// poll, so the create can land before its creator is on the roster. The squad must still be tracked, or every
+	// later PLAYER_JOINED_SQUAD referencing it is dropped and its members are stuck as Unassigned.
+	it('tracks a squad created before its creator joins the roster, so joins still land', () => {
+		const state = CHAT.getInitialChatState()
+		CHAT.handleEvent(state, squadCreated(makeSquad(1, 1, 'a', 101), 1))
+		CHAT.handleEvent(state, connected(makePlayer('a'), 2))
+		CHAT.handleEvent(state, connected(makePlayer('b'), 3))
+		CHAT.handleEvent(state, joinedSquad('a', 101, 4))
+		CHAT.handleEvent(state, joinedSquad('b', 101, 5))
+
+		expect(state.interpolatedState.squads.map(s => s.uniqueId)).toEqual([101])
+		const byEos = (eos: string) => state.interpolatedState.players.find(p => p.ids.eos === eos)
+		expect(byEos('a')?.squadId).toBe(1)
+		expect(byEos('b')?.squadId).toBe(1)
 	})
 
 	it('clears recentSquads at a match boundary', () => {

--- a/src/models/chat.models.ts
+++ b/src/models/chat.models.ts
@@ -646,6 +646,13 @@ function interpolateEvent(
 				return noop(`Squad ${event.squad.uniqueId} already exists`)
 			}
 			const squad: SM.UniqueSquad = event.squad
+			// Track the squad even when its creator isn't on the roster yet. SQUAD_CREATED (parsed from the log
+			// stream) races the creator's PLAYER_CONNECTED (reconciled from the teams poll), so it can arrive first;
+			// dropping the squad here would strand every later PLAYER_JOINED_SQUAD referencing it (squad-not-found),
+			// leaving its members stuck as Unassigned. applyEventTeamMutations tracks it regardless and only skips
+			// establishing membership when the creator is unknown.
+			applyEventTeamMutations(chatLog, state, event)
+			InterpolableState.recordRecentSquad(state, squad)
 			const creatorIndex = SM.PlayerIds.indexOf(state.players, p => p.ids, event.squad.creator)
 			if (creatorIndex === -1) {
 				return noop(
@@ -661,8 +668,6 @@ function interpolateEvent(
 					}`,
 				)
 			}
-			applyEventTeamMutations(chatLog, state, event)
-			InterpolableState.recordRecentSquad(state, squad)
 			return { ...event, creator: state.players[creatorIndex] }
 		}
 


### PR DESCRIPTION
## Problem

Flaky e2e failure in `admin-actions.test.ts` -> "disbanding a squad" ([run 29600776980](https://github.com/Tactrigsds/squad-layer-manager/actions/runs/29600776980/job/87952077127)). The `Disband Squad` menu item stayed `aria-disabled` for the full 60s timeout, so the click never landed.

## Root cause

The item is disabled when `inSquad` is false. The captured trace showed the client roster listing sq_leader and sq_member as **Unassigned** even though the events feed clearly contained `SQUAD_CREATED` + `PLAYER_JOINED_SQUAD` for them.

The client chat fold (`chat.models.ts` `interpolateEvent`, `SQUAD_CREATED` case) bailed out via `noop` **before** calling `applyEventTeamMutations` whenever the creator wasn't yet on the roster. The squad was therefore never added to interpolated state, and every later `PLAYER_JOINED_SQUAD` referencing it failed its `state.squads.find(...)` lookup and was dropped, leaving members permanently Unassigned.

`SQUAD_CREATED` is parsed from the log stream while the creator's `PLAYER_CONNECTED` is reconciled from the teams poll. These are two async sources, so the create can arrive before the connect depending on timing, which is why it flaked rather than failing every run.

The server-side `applyEventTeamMutations` deliberately tracks the squad even when the creator can't be resolved (with a comment explaining that refusing to would deadlock poll reconciliation). The client fold diverged from that.

## Fix

Run `applyEventTeamMutations` (which tracks the squad regardless of creator resolvability and only skips establishing membership) up front, matching the server. The feed enrichment still `noop`s when the creator is unknown, so no "created by unknown player" line renders.

## Test

Added a regression test in `chat.models.test.ts` exercising the `SQUAD_CREATED` -> `PLAYER_CONNECTED` -> `PLAYER_JOINED_SQUAD` order. It fails on the old ordering and passes with the fix. Full unit suite (630) green; `tsc -b` and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)