### PR TITLE
Quick reference cards, per-command links, and a shared margin-scroll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ pnpm dev        # the app + client
 pnpm dev:slots  # which worktree owns which ports
 ```
 
+`pnpm dev` and `pnpm dev:emu` are long-lived; an agent must start them as tracked background jobs (`run_in_background`).
+
 Log in with `?login=<username>` (discord oauth is off for dev instances -- `dev`'s env sets `QUERY_PARAM_AUTH_BYPASS`/`DISCORD_ENABLED=false` for you; any username in the cloned db works). Wait for the app port to be listening before you hit `?login=`: navigating during boot fails the bypass request and bounces you into the real Discord oauth flow, which looks like the bypass is broken when it is not. Drive the emulated server with `pnpm emuctl <command>` (`pnpm emuctl help`) rather than trying to reach a real squad server -- e.g. `pnpm emuctl join Alice`, `pnpm emuctl chat Alice '!vote 1'`, `pnpm emuctl end 1`.
 
 Never point a worktree at a real squad server or the real battlemetrics org; `dev:init` deliberately scrubs those, and re-adding them means an experiment drives production.

--- a/src/components/commands-page.tsx
+++ b/src/components/commands-page.tsx
@@ -446,6 +446,7 @@ export default function CommandsPage() {
 	// together within it, and the table of contents sticks once it reaches the top
 	const scrollRef = React.useRef<HTMLDivElement>(null)
 	const navRef = React.useRef<HTMLElement>(null)
+	const searchRef = React.useRef<HTMLInputElement>(null)
 	// set while scrollToEntry runs, so the page's own scrolling isn't mistaken for the user taking over
 	const scrollingToEntry = React.useRef(false)
 	const stickyZIndex = useZIndex(ZI_OFFSETS.STICKYGROUP_FLOOR)
@@ -471,6 +472,13 @@ export default function CommandsPage() {
 		return true
 	}, [])
 
+	// focus the search box on arrival, as the settings page does -- unless a fragment is taking the user somewhere
+	// specific, where stealing focus would fight the landing
+	React.useEffect(() => {
+		if (!settings || currentAnchor()) return
+		searchRef.current?.focus({ preventScroll: true })
+	}, [settings])
+
 	// a fragment on arrival (someone followed a link) lands on it once the list has rendered. A category anchor has no
 	// `/`; it scrolls but isn't ringed or given the cursor, matching an in-page category-link click.
 	React.useEffect(() => {
@@ -478,7 +486,7 @@ export default function CommandsPage() {
 		if (!settings || !id) return
 		pendingAnchor.current = null
 		const isEntry = id.includes('/')
-		if (landOnEntry(id, { highlight: isEntry }) && isEntry) setCursorId(id)
+		if (landOnEntry(id, { highlight: true }) && isEntry) setCursorId(id)
 	}, [settings, landOnEntry])
 
 	// A hash pasted or edited on a page that's already open. In-app navigation uses replaceState, which fires no
@@ -488,7 +496,7 @@ export default function CommandsPage() {
 			const id = currentAnchor()
 			if (!id) return
 			const isEntry = id.includes('/')
-			if (landOnEntry(id, { highlight: isEntry }) && isEntry) setCursorId(id)
+			if (landOnEntry(id, { highlight: true }) && isEntry) setCursorId(id)
 		}
 		window.addEventListener('hashchange', onHash)
 		return () => window.removeEventListener('hashchange', onHash)
@@ -521,18 +529,15 @@ export default function CommandsPage() {
 
 	if (!settings) return null
 
-	// Following a link to an entry: record it in the URL, scroll to it, and (for a command) ring it and put the cursor
-	// on it. The cursor matters at the end of the list, where the target can't be centred -- the scroll-derived
-	// highlight would land on whatever the fold stopped at, so linking to one of the last commands would highlight a
-	// different one. A category link passes highlight:false: it's a whole section header, and a persistent ring on a
-	// full-width sticky bar reads as an error state rather than a landing mark.
-	function navigateToEntry(id: string, opts?: { highlight?: boolean; scroll?: boolean }) {
-		const highlight = opts?.highlight !== false
+	// Records the target in the URL, scrolls to it (unless scroll:false) and rings it, as the settings page does for
+	// both fields and sections. Only a command/alias (its id carries a `/`) also takes the table-of-contents cursor:
+	// that cursor drives the command highlight in the list, and a whole section isn't one of those rows.
+	function navigateToEntry(id: string, opts?: { scroll?: boolean }) {
 		const scroll = opts?.scroll !== false
 		// replaceState keeps the history stack clean and skips the browser's own jump; a no-op when the hash matches
 		history.replaceState(history.state, '', `#${encodeURIComponent(id)}`)
-		if (highlight) setCursorId(id)
-		landOnEntry(id, { highlight, scroll })
+		if (id.includes('/')) setCursorId(id)
+		landOnEntry(id, { highlight: true, scroll })
 	}
 
 	// what a link icon on an entry does: exactly what its table-of-contents row does (record the URL, ring it, put the
@@ -571,7 +576,7 @@ export default function CommandsPage() {
 		// window scrolling instead. 6rem = the nav bar + _app's padding.
 		<div
 			ref={scrollRef}
-			className="h-[calc(100dvh-6rem)] overflow-y-auto"
+			className="h-[calc(100dvh-6rem)] w-full overflow-y-auto"
 			onScroll={() => {
 				if (!scrollingToEntry.current) setCursorId(null)
 			}}
@@ -609,6 +614,7 @@ export default function CommandsPage() {
 						<div className="relative shrink-0 bg-background pt-2 pb-2">
 							<Icons.Search className="absolute left-2 top-[1.15rem] -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
 							<Input
+								ref={searchRef}
 								className="h-8 pl-7"
 								placeholder="Search commands…"
 								onChange={(e) => {
@@ -627,7 +633,7 @@ export default function CommandsPage() {
 											<li key={section.id} className="pt-4 first:pt-0">
 												<button
 													type="button"
-													onClick={() => navigateToEntry(section.id, { highlight: false })}
+													onClick={() => navigateToEntry(section.id)}
 													className="block w-full border-b border-border px-1 pb-1 text-left text-xs font-semibold uppercase tracking-wide text-foreground hover:text-foreground/70"
 												>
 													{section.label}
@@ -667,7 +673,7 @@ export default function CommandsPage() {
 									{section.label}
 									<AnchorLinkIcon
 										id={section.id}
-										onNavigate={(id) => navigateToEntry(id, { highlight: false, scroll: false })}
+										onNavigate={(id) => navigateToEntry(id, { scroll: false })}
 										label={`Link to ${section.label}`}
 									/>
 								</h2>

--- a/src/components/commands-page.tsx
+++ b/src/components/commands-page.tsx
@@ -2,7 +2,6 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Input } from '@/components/ui/input'
-import { useForwardWheelToScroller } from '@/lib/browser'
 import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 import * as ZusUtils from '@/lib/zustand'
@@ -443,17 +442,15 @@ export default function CommandsPage() {
 	// follows whatever sits at the top of the body, which only updates on a real user scroll -- so each press would
 	// re-read the entry it started from and the cursor would never leave it.
 	const [cursorId, setCursorId] = React.useState<string | null>(null)
+	// the whole page is one scroll container; the header, quick reference, table of contents and listings scroll
+	// together within it, and the table of contents sticks once it reaches the top
 	const scrollRef = React.useRef<HTMLDivElement>(null)
-	const rootRef = React.useRef<HTMLDivElement>(null)
-	// set while scrollToEntry runs, so the body's own scrolling isn't mistaken for the user taking over
+	const navRef = React.useRef<HTMLElement>(null)
+	// set while scrollToEntry runs, so the page's own scrolling isn't mistaken for the user taking over
 	const scrollingToEntry = React.useRef(false)
 	const stickyZIndex = useZIndex(ZI_OFFSETS.STICKYGROUP_FLOOR)
 	// latched: read once on mount, consumed by the effect below, so a later hash rewrite can't re-trigger it
 	const pendingAnchor = React.useRef<string | null>(currentAnchor())
-
-	// the margins either side of the centred column, the page header and the search box all sit outside the body's
-	// scroll container, so without this their wheel events land on nothing. `settings` gates the refs being attached.
-	useForwardWheelToScroller(rootRef, scrollRef, settings)
 
 	// Puts an entry in the middle of the body -- so it arrives with its neighbours for context, rather than tucked under
 	// the sticky section header. Instant, never smooth: a smooth scroll is still travelling when the next keypress or
@@ -500,30 +497,29 @@ export default function CommandsPage() {
 	const sections = React.useMemo(() => settings ? buildSections(settings, pinnedCommands) : [], [settings, pinnedCommands])
 	const pinnedSet = React.useMemo(() => new Set(pinnedCommands), [pinnedCommands])
 
+	// Pinned and Quick Reference render as one block above the menu, never as body sections or table-of-contents rows --
+	// they're a scan of the everyday commands, and the body below is the full menu.
+	const pinnedShortcut = sections.find((s) => s.id === PINNED_SECTION_ID)
+	const quickRefShortcut = sections.find((s) => s.id === QUICK_REF_SECTION_ID)
+	// the body always lists every section; the search narrows only the table of contents
+	const contentSections = sections.filter((s) => !SHORTCUT_SECTION_IDS.has(s.id))
+
 	const q = query.trim().toLowerCase()
 	// a section-label match keeps the whole section, so searching "moderation" lists everything under it
-	const visible = q
-		// Pinned and quick reference are shortcuts into the sections below, not content of their own, so a search hit
-		// lands in each of them as well as its real section -- three copies of one command. Searching is already the
-		// direct way to find something, so the shortcuts drop out and every hit appears exactly once.
-		? sections
-			.filter((s) => !SHORTCUT_SECTION_IDS.has(s.id))
+	const tocSections = q
+		? contentSections
 			.map((s) => (s.label.toLowerCase().includes(q) ? s : { ...s, entries: s.entries.filter((e) => e.search.includes(q)) }))
 			.filter((s) => s.entries.length > 0)
-		: sections
+		: contentSections
+	const tocEntryIds = tocSections.flatMap((s) => s.entries.map((e) => e.id))
 
-	const activeId = useActiveEntry(scrollRef, visible.map((s) => s.id).join(','))
-	// the cursor owns the highlight while arrowing; otherwise it follows the entry at the top of the body
-	const highlightId = cursorId ?? activeId
+	const activeId = useActiveEntry(scrollRef, contentSections.map((s) => s.id).join(','))
+	// the table of contents highlights the entry the keyboard is on -- the one Enter jumps to -- or the first match
+	// while searching; with neither, it follows the section the page is scrolled to
+	const focusId = cursorId ?? (q ? tocEntryIds[0] ?? null : null)
+	const tocHighlightId = focusId ?? activeId
 
 	if (!settings) return null
-
-	// Pinned and Quick Reference render as one block above the columns rather than as sections in the body or rows in
-	// the table of contents -- they're a scan of the everyday commands, and the body below is the full menu. Absent
-	// while searching (the shortcut sections are filtered out of `visible` then), so a search shows only real hits.
-	const pinnedShortcut = visible.find((s) => s.id === PINNED_SECTION_ID)
-	const quickRefShortcut = visible.find((s) => s.id === QUICK_REF_SECTION_ID)
-	const contentSections = visible.filter((s) => !SHORTCUT_SECTION_IDS.has(s.id))
 
 	// Following a link to an entry: record it in the URL, scroll to it, and (for a command) ring it and put the cursor
 	// on it. The cursor matters at the end of the list, where the target can't be centred -- the scroll-derived
@@ -543,42 +539,52 @@ export default function CommandsPage() {
 	// cursor on it), minus the scroll -- the user is already looking at the entry the icon sits on
 	const linkToEntry = (id: string) => navigateToEntry(id, { scroll: false })
 
-	// Up/down walk the results from the search box, so a search can be narrowed and swept without leaving the input.
-	// Instant rather than smooth: a smooth scroll is still travelling when the next press lands, and holding a key
-	// would then be scheduling scrolls faster than they finish.
+	// The search box drives the table of contents, not the page: up/down move the focused row, Enter jumps to it. Enter
+	// with nothing arrowed jumps to the first match. Arrowing only moves the focus (and keeps that row in view within
+	// the list); it doesn't scroll the page -- that's what Enter is for.
 	function onSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+		if (e.key === 'Enter') {
+			const target = focusId ?? tocEntryIds[0]
+			if (target) {
+				e.preventDefault()
+				navigateToEntry(target)
+			}
+			return
+		}
 		if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
-		// only the body's entries; the compact shortcuts above aren't scroll targets
-		const ids = contentSections.flatMap((section) => section.entries.map((entry) => entry.id))
-		if (ids.length === 0) return
+		if (tocEntryIds.length === 0) return
 		// otherwise the caret jumps to either end of the query
 		e.preventDefault()
 		const delta = e.key === 'ArrowDown' ? 1 : -1
-		// picks up from wherever the body was scrolled to, so arrowing after a scroll continues from what's on screen
-		const current = highlightId ? ids.indexOf(highlightId) : -1
-		// with nothing highlighted yet, down starts at the top of the list and up starts at the bottom
-		const next = current === -1
-			? (delta === 1 ? 0 : ids.length - 1)
-			: Math.min(Math.max(current + delta, 0), ids.length - 1)
-		setCursorId(ids[next])
-		landOnEntry(ids[next])
+		const from = tocEntryIds.indexOf(focusId ?? '')
+		const next = from === -1
+			? (delta === 1 ? 0 : tocEntryIds.length - 1)
+			: Math.min(Math.max(from + delta, 0), tocEntryIds.length - 1)
+		const nextId = tocEntryIds[next]
+		setCursorId(nextId)
+		navRef.current?.querySelector(`[data-toc-id="${CSS.escape(nextId)}"]`)?.scrollIntoView({ block: 'nearest' })
 	}
 
 	return (
-		// the height has to be pinned here, as the settings page does: _app only bounds its own height on the dashboard
-		// route, so flex-1/min-h-0 alone leaves this growing to fit and the body scrolling the window instead of itself
-		// -- which silently costs the sticky headers and the scroll-tracked highlight. 6rem = the nav bar + _app's padding.
-		<div ref={rootRef} className="flex h-[calc(100dvh-6rem)] w-full justify-center">
-			<div className="flex h-full w-full max-w-6xl flex-col">
-				<header className="shrink-0 pb-3">
+		// One scroll container for the whole page. The height is pinned as the settings page does: _app only bounds its
+		// own height on the dashboard route, so flex-1/min-h-0 alone would leave this growing to fit its content and the
+		// window scrolling instead. 6rem = the nav bar + _app's padding.
+		<div
+			ref={scrollRef}
+			className="h-[calc(100dvh-6rem)] overflow-y-auto"
+			onScroll={() => {
+				if (!scrollingToEntry.current) setCursorId(null)
+			}}
+		>
+			<div className="mx-auto w-full max-w-6xl px-1">
+				<header className="pt-1 pb-3">
 					<h1 className="text-xl font-semibold">Ingame Commands</h1>
 					<p className="pt-1 text-sm text-muted-foreground">
 						Everything you type is case-insensitive. Player, squad and flag names match on any part of the name, ignoring spaces.
 					</p>
 				</header>
-				{/* the everyday commands sit above the whole menu -- search box, table of contents and listings all start below */}
 				{(pinnedShortcut || quickRefShortcut) && (
-					<div className="shrink-0 space-y-4 pb-6">
+					<div className="space-y-4 pb-6">
 						{pinnedShortcut && (
 							<CompactSection
 								title="Your Pinned Commands"
@@ -590,10 +596,18 @@ export default function CommandsPage() {
 						{quickRefShortcut && <CompactSection title="Quick Reference" section={quickRefShortcut} onDetails={navigateToEntry} />}
 					</div>
 				)}
-				<div className="flex gap-4 flex-1 min-h-0">
-					<aside className="flex flex-col w-52 shrink-0 min-h-0 border-r pr-2">
-						<div className="relative shrink-0 pb-2">
-							<Icons.Search className="absolute left-2 top-[0.9rem] -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+				<div className="flex gap-4">
+					{
+						/* the table of contents is the one thing that stays put: it sticks once the header and quick reference
+					    have scrolled off, capped to the viewport with its own scroll for a long list. bg so the everyday
+					    commands pass behind it as they scroll away. */
+					}
+					<aside
+						style={{ zIndex: stickyZIndex }}
+						className="sticky top-0 flex max-h-[calc(100dvh-6rem)] w-52 shrink-0 flex-col self-start border-r bg-background pr-2"
+					>
+						<div className="relative shrink-0 bg-background pt-2 pb-2">
+							<Icons.Search className="absolute left-2 top-[1.15rem] -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
 							<Input
 								className="h-8 pl-7"
 								placeholder="Search commands…"
@@ -604,13 +618,12 @@ export default function CommandsPage() {
 								onKeyDown={onSearchKeyDown}
 							/>
 						</div>
-						<nav className="flex-1 min-h-0 overflow-y-auto">
-							{contentSections.length === 0
-								? <p className="text-sm text-muted-foreground px-1">No matches.</p>
+						<nav ref={navRef} className="min-h-0 flex-1 overflow-y-auto">
+							{tocSections.length === 0
+								? <p className="px-1 text-sm text-muted-foreground">No matches.</p>
 								: (
 									<ul>
-										{contentSections.map((section) => (
-											// mirrors the body's sections -- label, rule, indented entries -- so the two columns read as the same split
+										{tocSections.map((section) => (
 											<li key={section.id} className="pt-4 first:pt-0">
 												<button
 													type="button"
@@ -624,10 +637,11 @@ export default function CommandsPage() {
 														<li key={entry.id}>
 															<button
 																type="button"
+																data-toc-id={entry.id}
 																onClick={() => navigateToEntry(entry.id)}
 																className={cn(
 																	'block w-full truncate rounded px-1 py-0.5 text-left font-mono text-sm hover:text-foreground',
-																	entry.id === highlightId ? 'bg-accent text-accent-foreground font-medium' : 'text-muted-foreground',
+																	entry.id === tocHighlightId ? 'bg-accent text-accent-foreground font-medium' : 'text-muted-foreground',
 																)}
 																title={entry.label}
 															>
@@ -642,26 +656,13 @@ export default function CommandsPage() {
 								)}
 						</nav>
 					</aside>
-					<div
-						ref={scrollRef}
-						// pl-1 is for the anchor highlight: it's a box-shadow ring, so it paints outside the entry's box and
-						// the entries run flush to this container's content edge -- without the padding, overflow clips the
-						// ring's left side away. pr-4 already leaves the right side room.
-						className="flex-1 min-w-0 overflow-y-auto pl-1 pr-4"
-						onScroll={() => {
-							if (!scrollingToEntry.current) setCursorId(null)
-						}}
-					>
+					<div className="min-w-0 flex-1">
 						{contentSections.map((section) => (
 							<section key={section.id} className="pb-8 last:pb-2">
-								{
-									/* the header stays legible over the entries it scrolls across, so it needs to be opaque and to own the
-							    full width -- hence the negative margin pulling it out to the scroll container's padding */
-								}
 								<h2
 									id={section.id}
 									style={{ zIndex: stickyZIndex }}
-									className="group sticky top-0 -mx-1 mb-2 flex scroll-mt-2 items-center gap-2 border-b-2 border-border bg-background px-1 pb-1.5 pt-1 text-base font-semibold tracking-tight"
+									className="group sticky top-0 mb-2 flex scroll-mt-1 items-center gap-2 border-b-2 border-border bg-background pb-1.5 pt-1 text-base font-semibold tracking-tight"
 								>
 									{section.label}
 									<AnchorLinkIcon
@@ -671,10 +672,7 @@ export default function CommandsPage() {
 									/>
 								</h2>
 								{section.blurb && <p className="pb-3 text-sm text-muted-foreground">{section.blurb}</p>}
-								{
-									/* dividers between commands: a section is a long stack of similar-looking rows, and the arg signatures
-							    wrap, which left the boundary between two commands ambiguous on spacing alone */
-								}
+								{/* dividers between commands: the arg signatures wrap, which left the boundary between two ambiguous on spacing alone */}
 								<div className="divide-y divide-border/70">
 									{section.entries.map((entry) => (
 										<div key={entry.id} className="py-3 first:pt-0 last:pb-0">

--- a/src/components/commands-page.tsx
+++ b/src/components/commands-page.tsx
@@ -194,14 +194,36 @@ function currentAnchor(): string | null {
 	return hash ? decodeURIComponent(hash) : null
 }
 
-// Marks one entry as the linked target. Exclusive, and persists until the next navigation, so the command you followed
-// a link to stays identifiable once the scroll has finished. index.css styles [data-anchor-highlight] (a ring plus a
-// flash on apply) for the settings page; reused verbatim here so a link lands the same way in both places.
-function highlightEntry(el: HTMLElement) {
+// Clears any existing anchor mark, then marks `el` when `mark` is set. Landing somewhere always supersedes the
+// previous mark, even when the new target isn't itself ringed (a category), so an old command's ring doesn't linger.
+// The mark is exclusive and persists until the next navigation. index.css styles [data-anchor-highlight] (a ring plus
+// a flash on apply) for the settings page; reused verbatim here so a link lands the same way in both places.
+function setAnchorHighlight(el: HTMLElement, mark: boolean) {
 	for (const other of document.querySelectorAll('[data-anchor-highlight]')) {
 		if (other !== el) other.removeAttribute('data-anchor-highlight')
 	}
-	el.setAttribute('data-anchor-highlight', 'true')
+	if (mark) el.setAttribute('data-anchor-highlight', 'true')
+	else el.removeAttribute('data-anchor-highlight')
+}
+
+// A hover-revealed link to a fragment on the page, mirroring the settings page's AnchorLink: a real href (so it can be
+// copied or opened in a new tab) that on plain click scrolls in-place rather than letting the browser jump. Its row
+// must carry `group` for the hover reveal.
+function AnchorLinkIcon({ id, onNavigate, label }: { id: string; onNavigate: (id: string) => void; label: string }) {
+	return (
+		<a
+			href={`#${encodeURIComponent(id)}`}
+			className="shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+			title={label}
+			aria-label={label}
+			onClick={(e) => {
+				e.preventDefault()
+				onNavigate(id)
+			}}
+		>
+			<Icons.Link className="h-3.5 w-3.5" />
+		</a>
+	)
 }
 
 // the full listing a compact card's "Details" jumps to: a command under its own declared section, an alias under
@@ -216,13 +238,14 @@ function detailsAnchorId(entry: Entry): string {
 // A command or alias reduced to its first string, its one-line description, and a link to the full listing. Small
 // enough to pack many per row -- the Pinned and Quick Reference sections are for scanning what exists, not reading the
 // detail. Not itself a scroll target: it lives above the scrolling body, and Details is what jumps into the body.
-function CompactEntry({ entry, onDetails }: { entry: Entry; onDetails: (id: string) => void }) {
+// `onUnpin` is set for the pinned cards (which are always commands), adding an unpin control at the bottom-left.
+function CompactEntry({ entry, onDetails, onUnpin }: { entry: Entry; onDetails: (id: string) => void; onUnpin?: () => void }) {
 	const string = entry.kind === 'command' ? entry.cmd.strings[0] ?? entry.cmdId : entry.alias.alias
 	const description = entry.kind === 'command'
 		? Messages.GENERAL.command.descriptions[entry.cmdId]
 		: Messages.GENERAL.command.aliasDescription(entry.alias.command)
 	return (
-		<div className="flex flex-col gap-1 rounded-md border bg-background px-2.5 py-1.5">
+		<div className="flex h-full flex-col gap-1 rounded-md border bg-background px-2.5 py-1.5">
 			<div className="flex items-center justify-between gap-1">
 				<code className="truncate font-mono text-sm font-medium" title={string}>{string}</code>
 				<Button
@@ -235,34 +258,53 @@ function CompactEntry({ entry, onDetails }: { entry: Entry; onDetails: (id: stri
 				</Button>
 			</div>
 			<p className="line-clamp-2 text-xs text-muted-foreground">{description}</p>
+			{onUnpin && (
+				// mt-auto keeps it on the card's bottom edge even when a shorter description leaves the card taller than its
+				// content (grid rows stretch every card to the tallest in the row)
+				<Button
+					variant="ghost"
+					size="sm"
+					className="mt-auto h-5 shrink-0 gap-0.5 self-end px-1 text-xs text-muted-foreground hover:text-foreground"
+					onClick={onUnpin}
+				>
+					<Icons.PinOff className="h-3 w-3" /> Unpin
+				</Button>
+			)}
 		</div>
 	)
 }
 
-function CompactGrid({ entries, onDetails }: { entries: Entry[]; onDetails: (id: string) => void }) {
-	return (
-		<div className="grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(13rem,1fr))]">
-			{entries.map((entry) => <CompactEntry key={entry.id} entry={entry} onDetails={onDetails} />)}
-		</div>
-	)
-}
-
-// The Pinned and Quick Reference sections, rendered together as one block on a secondary background: the everyday
-// commands, with the ones this browser pinned called out at the top. Both are shortcuts into the sections below, so
-// they use compact cards whose Details link jumps there.
-function QuickReferenceBlock(
-	{ pinned, quickRef, onDetails }: { pinned?: Section; quickRef?: Section; onDetails: (id: string) => void },
+function CompactGrid(
+	{ entries, onDetails, onUnpin }: { entries: Entry[]; onDetails: (id: string) => void; onUnpin?: (cmdId: CMD.CommandId) => void },
 ) {
 	return (
-		<section className="mb-8 rounded-lg bg-secondary/60 p-4">
-			<h2 className="mb-3 text-base font-semibold tracking-tight">Quick Reference</h2>
-			{pinned && (
-				<div className="mb-4">
-					<h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pinned</h3>
-					<CompactGrid entries={pinned.entries} onDetails={onDetails} />
-				</div>
-			)}
-			{quickRef && <CompactGrid entries={quickRef.entries} onDetails={onDetails} />}
+		<div className="grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(13rem,1fr))]">
+			{entries.map((entry) => (
+				<CompactEntry
+					key={entry.id}
+					entry={entry}
+					onDetails={onDetails}
+					onUnpin={onUnpin && entry.kind === 'command' ? () => onUnpin(entry.cmdId) : undefined}
+				/>
+			))}
+		</div>
+	)
+}
+
+// A titled block of compact cards on a secondary background: the "Your Pinned Commands" and "Quick Reference"
+// scans that sit above the menu. Both are shortcuts into the sections below, so their cards' Details link jumps there.
+function CompactSection(
+	{ title, section, onDetails, onUnpin }: {
+		title: string
+		section: Section
+		onDetails: (id: string) => void
+		onUnpin?: (cmdId: CMD.CommandId) => void
+	},
+) {
+	return (
+		<section className="rounded-lg bg-secondary/60 p-4">
+			<h2 className="mb-3 text-base font-semibold tracking-tight">{title}</h2>
+			<CompactGrid entries={section.entries} onDetails={onDetails} onUnpin={onUnpin} />
 		</section>
 	)
 }
@@ -415,16 +457,18 @@ export default function CommandsPage() {
 		requestAnimationFrame(() => {
 			scrollingToEntry.current = false
 		})
-		if (opts?.highlight) highlightEntry(el)
+		setAnchorHighlight(el, opts?.highlight ?? false)
 		return true
 	}, [])
 
-	// a fragment on arrival (someone followed a link to a command) lands on it once the list has rendered
+	// a fragment on arrival (someone followed a link) lands on it once the list has rendered. A category anchor has no
+	// `/`; it scrolls but isn't ringed or given the cursor, matching an in-page category-link click.
 	React.useEffect(() => {
 		const id = pendingAnchor.current
 		if (!settings || !id) return
 		pendingAnchor.current = null
-		if (landOnEntry(id, { highlight: true })) setCursorId(id)
+		const isEntry = id.includes('/')
+		if (landOnEntry(id, { highlight: isEntry }) && isEntry) setCursorId(id)
 	}, [settings, landOnEntry])
 
 	// A hash pasted or edited on a page that's already open. In-app navigation uses replaceState, which fires no
@@ -432,7 +476,9 @@ export default function CommandsPage() {
 	React.useEffect(() => {
 		const onHash = () => {
 			const id = currentAnchor()
-			if (id && landOnEntry(id, { highlight: true })) setCursorId(id)
+			if (!id) return
+			const isEntry = id.includes('/')
+			if (landOnEntry(id, { highlight: isEntry }) && isEntry) setCursorId(id)
 		}
 		window.addEventListener('hashchange', onHash)
 		return () => window.removeEventListener('hashchange', onHash)
@@ -466,14 +512,17 @@ export default function CommandsPage() {
 	const quickRefShortcut = visible.find((s) => s.id === QUICK_REF_SECTION_ID)
 	const contentSections = visible.filter((s) => !SHORTCUT_SECTION_IDS.has(s.id))
 
-	// Following a link to an entry: record it, mark it, and put the cursor on it. The cursor matters at the end of the
-	// list, where the target can't be centred -- the scroll-derived highlight would land on whatever the fold stopped
-	// at, so linking to one of the last commands would highlight a different one.
-	function navigateToEntry(id: string) {
+	// Following a link to an entry: record it in the URL, scroll to it, and (for a command) ring it and put the cursor
+	// on it. The cursor matters at the end of the list, where the target can't be centred -- the scroll-derived
+	// highlight would land on whatever the fold stopped at, so linking to one of the last commands would highlight a
+	// different one. A category link passes highlight:false: it's a whole section header, and a persistent ring on a
+	// full-width sticky bar reads as an error state rather than a landing mark.
+	function navigateToEntry(id: string, opts?: { highlight?: boolean }) {
+		const highlight = opts?.highlight !== false
 		// replaceState keeps the history stack clean and skips the browser's own jump; a no-op when the hash matches
 		history.replaceState(history.state, '', `#${encodeURIComponent(id)}`)
-		setCursorId(id)
-		landOnEntry(id, { highlight: true })
+		if (highlight) setCursorId(id)
+		landOnEntry(id, { highlight })
 	}
 
 	// Up/down walk the results from the search box, so a search can be narrowed and swept without leaving the input.
@@ -511,8 +560,16 @@ export default function CommandsPage() {
 				</header>
 				{/* the everyday commands sit above the whole menu -- search box, table of contents and listings all start below */}
 				{(pinnedShortcut || quickRefShortcut) && (
-					<div className="shrink-0">
-						<QuickReferenceBlock pinned={pinnedShortcut} quickRef={quickRefShortcut} onDetails={navigateToEntry} />
+					<div className="shrink-0 space-y-4 pb-6">
+						{pinnedShortcut && (
+							<CompactSection
+								title="Your Pinned Commands"
+								section={pinnedShortcut}
+								onDetails={navigateToEntry}
+								onUnpin={ClientOnlySettings.Actions.toggleCommandPinned}
+							/>
+						)}
+						{quickRefShortcut && <CompactSection title="Quick Reference" section={quickRefShortcut} onDetails={navigateToEntry} />}
 					</div>
 				)}
 				<div className="flex gap-4 flex-1 min-h-0">
@@ -580,10 +637,16 @@ export default function CommandsPage() {
 							    full width -- hence the negative margin pulling it out to the scroll container's padding */
 								}
 								<h2
+									id={section.id}
 									style={{ zIndex: stickyZIndex }}
-									className="sticky top-0 -mx-1 mb-2 border-b-2 border-border bg-background px-1 pb-1.5 pt-1 text-base font-semibold tracking-tight"
+									className="group sticky top-0 -mx-1 mb-2 flex scroll-mt-2 items-center gap-2 border-b-2 border-border bg-background px-1 pb-1.5 pt-1 text-base font-semibold tracking-tight"
 								>
 									{section.label}
+									<AnchorLinkIcon
+										id={section.id}
+										onNavigate={(id) => navigateToEntry(id, { highlight: false })}
+										label={`Link to ${section.label}`}
+									/>
 								</h2>
 								{section.blurb && <p className="pb-3 text-sm text-muted-foreground">{section.blurb}</p>}
 								{

--- a/src/components/commands-page.tsx
+++ b/src/components/commands-page.tsx
@@ -126,7 +126,12 @@ function CommandDetails({ cmdId, cmd, settings }: { cmdId: CMD.CommandId; cmd: C
 }
 
 function CommandEntry(
-	{ entry, settings, pinned }: { entry: Extract<Entry, { kind: 'command' }>; settings: PublicSettings; pinned: boolean },
+	{ entry, settings, pinned, onLink }: {
+		entry: Extract<Entry, { kind: 'command' }>
+		settings: PublicSettings
+		pinned: boolean
+		onLink: (id: string) => void
+	},
 ) {
 	const { cmdId, cmd } = entry
 	const [open, setOpen] = React.useState(false)
@@ -135,13 +140,15 @@ function CommandEntry(
 	const chatScope = cmd.scopes.includes('admin') ? 'ChatToAdmin' : 'ChatToAll'
 	return (
 		<Collapsible open={open} onOpenChange={setOpen} id={entry.id} data-cmd-anchor className="space-y-2">
-			<div className="flex items-center gap-2">
+			<div className="group flex items-center gap-2">
 				<PinButton cmdId={cmdId} pinned={pinned} />
-				<div className="flex flex-1 flex-wrap items-center gap-1">
+				<div className="flex flex-wrap items-center gap-1">
 					{CMD.buildCommand(cmdId, argObject, settings.commands, true).map((cmdString) => (
 						<CopyableCommand key={cmdString} cmdString={cmdString} chatScope={chatScope} />
 					))}
+					<AnchorLinkIcon id={entry.id} onNavigate={onLink} label="Link to this command" />
 				</div>
+				<div className="flex-1" />
 				{!cmd.enabled && <Badge variant="destructive" className="text-xs">Disabled</Badge>}
 				{cmd.scopes.map((scope) => {
 					const { icon: ScopeIcon, className } = SCOPE_BADGES[scope]
@@ -169,15 +176,18 @@ function CommandEntry(
 
 // an alias takes no arguments, so its listing is the shortcut itself, what it expands to, and (when the command it
 // points at is disabled or no longer exists) why it currently does nothing
-function AliasEntry({ entry, settings }: { entry: Extract<Entry, { kind: 'alias' }>; settings: PublicSettings }) {
+function AliasEntry(
+	{ entry, settings, onLink }: { entry: Extract<Entry, { kind: 'alias' }>; settings: PublicSettings; onLink: (id: string) => void },
+) {
 	const res = CMD.resolveAliasCommand(entry.alias.command, settings.commands)
 	const target = res.code === 'ok' ? settings.commands[res.cmdId] : undefined
 	const unusable = res.code !== 'ok' ? 'Unavailable' : !target!.enabled ? 'Disabled' : undefined
 	const chatScope = target?.scopes.includes('public') && !target.scopes.includes('admin') ? 'ChatToAll' : 'ChatToAdmin'
 	return (
 		<div id={entry.id} data-cmd-anchor className="space-y-1">
-			<div className="flex items-center gap-2">
+			<div className="group flex items-center gap-2">
 				<CopyableCommand cmdString={entry.alias.alias} chatScope={chatScope} />
+				<AnchorLinkIcon id={entry.id} onNavigate={onLink} label="Link to this alias" />
 				{unusable && <Badge variant="destructive" className="text-xs">{unusable}</Badge>}
 			</div>
 			<p className="text-sm text-muted-foreground">{Messages.GENERAL.command.aliasDescription(entry.alias.command)}</p>
@@ -206,9 +216,9 @@ function setAnchorHighlight(el: HTMLElement, mark: boolean) {
 	else el.removeAttribute('data-anchor-highlight')
 }
 
-// A hover-revealed link to a fragment on the page, mirroring the settings page's AnchorLink: a real href (so it can be
-// copied or opened in a new tab) that on plain click scrolls in-place rather than letting the browser jump. Its row
-// must carry `group` for the hover reveal.
+// A link to a fragment on the page, mirroring the settings page's AnchorLink: a real href (so it can be copied or
+// opened in a new tab) that on plain click scrolls/records in-place rather than letting the browser jump. Revealed on
+// hover of its row, which must carry `group`.
 function AnchorLinkIcon({ id, onNavigate, label }: { id: string; onNavigate: (id: string) => void; label: string }) {
 	return (
 		<a
@@ -449,14 +459,17 @@ export default function CommandsPage() {
 	// the sticky section header. Instant, never smooth: a smooth scroll is still travelling when the next keypress or
 	// click lands, so the cursor ends up scheduling scrolls faster than they finish. Returns false for an id that isn't
 	// on the page (a stale link), leaving the body where it was.
-	const landOnEntry = React.useCallback((id: string, opts?: { highlight?: boolean }) => {
+	const landOnEntry = React.useCallback((id: string, opts?: { highlight?: boolean; scroll?: boolean }) => {
 		const el = scrollRef.current?.querySelector<HTMLElement>(`#${CSS.escape(id)}`)
 		if (!el) return false
-		scrollingToEntry.current = true
-		el.scrollIntoView({ block: 'center', behavior: 'instant' })
-		requestAnimationFrame(() => {
-			scrollingToEntry.current = false
-		})
+		// a link icon on an entry the user is already looking at rings and records it without scrolling (opts.scroll false)
+		if (opts?.scroll !== false) {
+			scrollingToEntry.current = true
+			el.scrollIntoView({ block: 'center', behavior: 'instant' })
+			requestAnimationFrame(() => {
+				scrollingToEntry.current = false
+			})
+		}
 		setAnchorHighlight(el, opts?.highlight ?? false)
 		return true
 	}, [])
@@ -517,13 +530,18 @@ export default function CommandsPage() {
 	// highlight would land on whatever the fold stopped at, so linking to one of the last commands would highlight a
 	// different one. A category link passes highlight:false: it's a whole section header, and a persistent ring on a
 	// full-width sticky bar reads as an error state rather than a landing mark.
-	function navigateToEntry(id: string, opts?: { highlight?: boolean }) {
+	function navigateToEntry(id: string, opts?: { highlight?: boolean; scroll?: boolean }) {
 		const highlight = opts?.highlight !== false
+		const scroll = opts?.scroll !== false
 		// replaceState keeps the history stack clean and skips the browser's own jump; a no-op when the hash matches
 		history.replaceState(history.state, '', `#${encodeURIComponent(id)}`)
 		if (highlight) setCursorId(id)
-		landOnEntry(id, { highlight })
+		landOnEntry(id, { highlight, scroll })
 	}
+
+	// what a link icon on an entry does: exactly what its table-of-contents row does (record the URL, ring it, put the
+	// cursor on it), minus the scroll -- the user is already looking at the entry the icon sits on
+	const linkToEntry = (id: string) => navigateToEntry(id, { scroll: false })
 
 	// Up/down walk the results from the search box, so a search can be narrowed and swept without leaving the input.
 	// Instant rather than smooth: a smooth scroll is still travelling when the next press lands, and holding a key
@@ -594,9 +612,13 @@ export default function CommandsPage() {
 										{contentSections.map((section) => (
 											// mirrors the body's sections -- label, rule, indented entries -- so the two columns read as the same split
 											<li key={section.id} className="pt-4 first:pt-0">
-												<p className="border-b border-border px-1 pb-1 text-xs font-semibold uppercase tracking-wide text-foreground">
+												<button
+													type="button"
+													onClick={() => navigateToEntry(section.id, { highlight: false })}
+													className="block w-full border-b border-border px-1 pb-1 text-left text-xs font-semibold uppercase tracking-wide text-foreground hover:text-foreground/70"
+												>
 													{section.label}
-												</p>
+												</button>
 												<ul className="space-y-px pl-2 pt-1">
 													{section.entries.map((entry) => (
 														<li key={entry.id}>
@@ -644,7 +666,7 @@ export default function CommandsPage() {
 									{section.label}
 									<AnchorLinkIcon
 										id={section.id}
-										onNavigate={(id) => navigateToEntry(id, { highlight: false })}
+										onNavigate={(id) => navigateToEntry(id, { highlight: false, scroll: false })}
 										label={`Link to ${section.label}`}
 									/>
 								</h2>
@@ -657,8 +679,8 @@ export default function CommandsPage() {
 									{section.entries.map((entry) => (
 										<div key={entry.id} className="py-3 first:pt-0 last:pb-0">
 											{entry.kind === 'command'
-												? <CommandEntry entry={entry} settings={settings} pinned={pinnedSet.has(entry.cmdId)} />
-												: <AliasEntry entry={entry} settings={settings} />}
+												? <CommandEntry entry={entry} settings={settings} pinned={pinnedSet.has(entry.cmdId)} onLink={linkToEntry} />
+												: <AliasEntry entry={entry} settings={settings} onLink={linkToEntry} />}
 										</div>
 									))}
 								</div>

--- a/src/components/commands-page.tsx
+++ b/src/components/commands-page.tsx
@@ -204,6 +204,69 @@ function highlightEntry(el: HTMLElement) {
 	el.setAttribute('data-anchor-highlight', 'true')
 }
 
+// the full listing a compact card's "Details" jumps to: a command under its own declared section, an alias under
+// Aliases. The Pinned / Quick Reference cards are shortcuts, so Details links to the real entry rather than repeating
+// its arguments and examples inline.
+function detailsAnchorId(entry: Entry): string {
+	return entry.kind === 'command'
+		? `section:${CMD.COMMAND_DECLARATIONS[entry.cmdId].section}/command:${entry.cmdId}`
+		: `${ALIASES_SECTION_ID}/alias:${entry.alias.alias}`
+}
+
+// A command or alias reduced to its first string, its one-line description, and a link to the full listing. Small
+// enough to pack many per row -- the Pinned and Quick Reference sections are for scanning what exists, not reading the
+// detail. Not itself a scroll target: it lives above the scrolling body, and Details is what jumps into the body.
+function CompactEntry({ entry, onDetails }: { entry: Entry; onDetails: (id: string) => void }) {
+	const string = entry.kind === 'command' ? entry.cmd.strings[0] ?? entry.cmdId : entry.alias.alias
+	const description = entry.kind === 'command'
+		? Messages.GENERAL.command.descriptions[entry.cmdId]
+		: Messages.GENERAL.command.aliasDescription(entry.alias.command)
+	return (
+		<div className="flex flex-col gap-1 rounded-md border bg-background px-2.5 py-1.5">
+			<div className="flex items-center justify-between gap-1">
+				<code className="truncate font-mono text-sm font-medium" title={string}>{string}</code>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="h-5 shrink-0 gap-0.5 px-1 text-xs text-muted-foreground"
+					onClick={() => onDetails(detailsAnchorId(entry))}
+				>
+					Details <Icons.ArrowRight className="h-3 w-3" />
+				</Button>
+			</div>
+			<p className="line-clamp-2 text-xs text-muted-foreground">{description}</p>
+		</div>
+	)
+}
+
+function CompactGrid({ entries, onDetails }: { entries: Entry[]; onDetails: (id: string) => void }) {
+	return (
+		<div className="grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(13rem,1fr))]">
+			{entries.map((entry) => <CompactEntry key={entry.id} entry={entry} onDetails={onDetails} />)}
+		</div>
+	)
+}
+
+// The Pinned and Quick Reference sections, rendered together as one block on a secondary background: the everyday
+// commands, with the ones this browser pinned called out at the top. Both are shortcuts into the sections below, so
+// they use compact cards whose Details link jumps there.
+function QuickReferenceBlock(
+	{ pinned, quickRef, onDetails }: { pinned?: Section; quickRef?: Section; onDetails: (id: string) => void },
+) {
+	return (
+		<section className="mb-8 rounded-lg bg-secondary/60 p-4">
+			<h2 className="mb-3 text-base font-semibold tracking-tight">Quick Reference</h2>
+			{pinned && (
+				<div className="mb-4">
+					<h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pinned</h3>
+					<CompactGrid entries={pinned.entries} onDetails={onDetails} />
+				</div>
+			)}
+			{quickRef && <CompactGrid entries={quickRef.entries} onDetails={onDetails} />}
+		</section>
+	)
+}
+
 // tracks which entry the body is scrolled to, so the matching TOC row can be highlighted
 function useActiveEntry(scrollRef: React.RefObject<HTMLDivElement | null>, deps: unknown): string | null {
 	const [activeId, setActiveId] = React.useState<string | null>(null)
@@ -272,16 +335,17 @@ function buildSections(settings: PublicSettings, pinnedCommands: string[]): Sect
 
 	// pins are per-browser, so an id can outlive the command it named (a downgrade, or a renamed id)
 	const pinned = pinnedCommands.filter((id): id is CMD.CommandId => id in settings.commands)
+	const pinnedSet = new Set(pinned)
 	if (pinned.length > 0) {
 		sections.push({
 			id: PINNED_SECTION_ID,
 			label: 'Pinned',
-			blurb: 'Commands you pinned. Saved in this browser only.',
 			entries: pinned.map((cmdId) => commandEntry(PINNED_SECTION_ID, cmdId, settings.commands[cmdId], 'Pinned')),
 		})
 	}
 
-	const quickRef = CMD.COMMAND_IDS.filter((id) => settings.commands[id].quickReference)
+	// a pinned command is already called out in the Pinned subsection above, so it drops out of the quick-reference grid
+	const quickRef = CMD.COMMAND_IDS.filter((id) => settings.commands[id].quickReference && !pinnedSet.has(id))
 	const quickRefAliases = settings.commandAliases.filter((a) => {
 		const res = CMD.resolveAliasCommand(a.command, settings.commands)
 		return res.code === 'ok' && settings.commands[res.cmdId].quickReference
@@ -395,6 +459,13 @@ export default function CommandsPage() {
 
 	if (!settings) return null
 
+	// Pinned and Quick Reference render as one block above the columns rather than as sections in the body or rows in
+	// the table of contents -- they're a scan of the everyday commands, and the body below is the full menu. Absent
+	// while searching (the shortcut sections are filtered out of `visible` then), so a search shows only real hits.
+	const pinnedShortcut = visible.find((s) => s.id === PINNED_SECTION_ID)
+	const quickRefShortcut = visible.find((s) => s.id === QUICK_REF_SECTION_ID)
+	const contentSections = visible.filter((s) => !SHORTCUT_SECTION_IDS.has(s.id))
+
 	// Following a link to an entry: record it, mark it, and put the cursor on it. The cursor matters at the end of the
 	// list, where the target can't be centred -- the scroll-derived highlight would land on whatever the fold stopped
 	// at, so linking to one of the last commands would highlight a different one.
@@ -410,7 +481,8 @@ export default function CommandsPage() {
 	// would then be scheduling scrolls faster than they finish.
 	function onSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
 		if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
-		const ids = visible.flatMap((section) => section.entries.map((entry) => entry.id))
+		// only the body's entries; the compact shortcuts above aren't scroll targets
+		const ids = contentSections.flatMap((section) => section.entries.map((entry) => entry.id))
 		if (ids.length === 0) return
 		// otherwise the caret jumps to either end of the query
 		e.preventDefault()
@@ -437,6 +509,12 @@ export default function CommandsPage() {
 						Everything you type is case-insensitive. Player, squad and flag names match on any part of the name, ignoring spaces.
 					</p>
 				</header>
+				{/* the everyday commands sit above the whole menu -- search box, table of contents and listings all start below */}
+				{(pinnedShortcut || quickRefShortcut) && (
+					<div className="shrink-0">
+						<QuickReferenceBlock pinned={pinnedShortcut} quickRef={quickRefShortcut} onDetails={navigateToEntry} />
+					</div>
+				)}
 				<div className="flex gap-4 flex-1 min-h-0">
 					<aside className="flex flex-col w-52 shrink-0 min-h-0 border-r pr-2">
 						<div className="relative shrink-0 pb-2">
@@ -452,11 +530,11 @@ export default function CommandsPage() {
 							/>
 						</div>
 						<nav className="flex-1 min-h-0 overflow-y-auto">
-							{visible.length === 0
+							{contentSections.length === 0
 								? <p className="text-sm text-muted-foreground px-1">No matches.</p>
 								: (
 									<ul>
-										{visible.map((section) => (
+										{contentSections.map((section) => (
 											// mirrors the body's sections -- label, rule, indented entries -- so the two columns read as the same split
 											<li key={section.id} className="pt-4 first:pt-0">
 												<p className="border-b border-border px-1 pb-1 text-xs font-semibold uppercase tracking-wide text-foreground">
@@ -495,7 +573,7 @@ export default function CommandsPage() {
 							if (!scrollingToEntry.current) setCursorId(null)
 						}}
 					>
-						{visible.map((section) => (
+						{contentSections.map((section) => (
 							<section key={section.id} className="pb-8 last:pb-2">
 								{
 									/* the header stays legible over the entries it scrolls across, so it needs to be opaque and to own the

--- a/src/components/settings-toc.tsx
+++ b/src/components/settings-toc.tsx
@@ -84,6 +84,20 @@ function filterNode(node: TocNode, query: string): TocNode | null {
 	return null
 }
 
+// the node ids the tree renders, in display order, for the search box's up/down/Enter navigation. A collapsed branch
+// contributes only its own id, matching what's on screen.
+function flattenVisible(nodes: TocNode[], expanded: Set<string>, forceOpen: boolean): string[] {
+	const out: string[] = []
+	const walk = (ns: TocNode[]) => {
+		for (const n of ns) {
+			out.push(n.id)
+			if ((forceOpen || expanded.has(n.id)) && n.children.length > 0) walk(n.children)
+		}
+	}
+	walk(nodes)
+	return out
+}
+
 function TocItem(
 	{ node, depth, expanded, toggle, forceOpen, activeId, showMarkers }: {
 		node: TocNode
@@ -233,6 +247,8 @@ export default function SettingsToc(
 	},
 ) {
 	const [query, setQuery] = React.useState('')
+	// the search box's keyboard focus: which TOC row Enter jumps to, moved by up/down. Reset when the query changes.
+	const [focusedId, setFocusedId] = React.useState<string | null>(null)
 	const [expanded, setExpanded] = React.useState<Set<string>>(new Set(['section:servers', 'section:global']))
 	const containerRef = React.useRef<HTMLDivElement>(null)
 	const searchRef = React.useRef<HTMLInputElement>(null)
@@ -367,12 +383,39 @@ export default function SettingsToc(
 		return cur
 	}, [activeAnchorId, parentById, expanded, forceOpen])
 
+	// the search box drives the table of contents: up/down move this focus, Enter jumps to it. It defaults to the first
+	// match while searching, so Enter jumps there with nothing arrowed. With neither, the highlight follows the scroll.
+	const flatIds = flattenVisible(visible, expanded, forceOpen)
+	const focusHighlightId = focusedId ?? (q ? flatIds[0] ?? null : null)
+	const highlightId = focusHighlightId ?? activeId
+
 	// keep the highlighted item in view within the (independently scrolling) sidebar
 	React.useEffect(() => {
-		if (!activeId) return
-		const el = containerRef.current?.querySelector(`[data-toc-id="${CSS.escape(activeId)}"]`)
+		if (!highlightId) return
+		const el = containerRef.current?.querySelector(`[data-toc-id="${CSS.escape(highlightId)}"]`)
 		el?.scrollIntoView({ block: 'nearest' })
-	}, [activeId])
+	}, [highlightId])
+
+	function onSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+		if (e.key === 'Enter') {
+			const target = focusHighlightId ?? flatIds[0]
+			if (target) {
+				e.preventDefault()
+				SettingsNav.navigateToAnchor(target)
+			}
+			return
+		}
+		if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+		if (flatIds.length === 0) return
+		// otherwise the caret jumps to either end of the query
+		e.preventDefault()
+		const delta = e.key === 'ArrowDown' ? 1 : -1
+		const from = flatIds.indexOf(focusHighlightId ?? '')
+		const next = from === -1
+			? (delta === 1 ? 0 : flatIds.length - 1)
+			: Math.min(Math.max(from + delta, 0), flatIds.length - 1)
+		setFocusedId(flatIds[next])
+	}
 
 	function toggle(id: string) {
 		setExpanded((prev) => {
@@ -394,7 +437,11 @@ export default function SettingsToc(
 						className="h-8 pl-7"
 						placeholder="Search settings…"
 						value={query}
-						onChange={(e) => setQuery(e.target.value)}
+						onChange={(e) => {
+							setQuery(e.target.value)
+							setFocusedId(null)
+						}}
+						onKeyDown={onSearchKeyDown}
 					/>
 				</div>
 			</div>
@@ -411,7 +458,7 @@ export default function SettingsToc(
 									expanded={expanded}
 									toggle={toggle}
 									forceOpen={forceOpen}
-									activeId={activeId}
+									activeId={highlightId}
 									showMarkers={showMarkers}
 								/>
 							))}

--- a/src/models/command.models.ts
+++ b/src/models/command.models.ts
@@ -290,7 +290,7 @@ export const COMMAND_DECLARATIONS = {
 	...declareCommand('disbandSquad', {
 		section: 'moderation',
 		args: [{ kind: 'squad', name: 'squad' }, { kind: 'reason', name: 'reason', action: 'disband-squad', optional: true }],
-		defaults: { scopes: ['admin'], strings: ['disband'], enabled: true, quickReference: true },
+		defaults: { scopes: ['admin'], strings: ['disband'], enabled: true, quickReference: false },
 	}),
 	...declareCommand('demoteCommander', {
 		section: 'moderation',


### PR DESCRIPTION
Follow-up to #49. Reworks the top of the commands page and makes the whole page linkable.

Dev server with the changes up: http://localhost:3151/commands?login=grey275

## Pinned and Quick Reference as compact cards

The everyday commands used to be full listings interleaved with the sections, so you scrolled past two copies of them before reaching the menu and saw each a third time in its own section. They are now compact cards at the top -- first string, one-line description, a Details link into the full listing -- packed many to a row.

- "Your Pinned Commands" is its own block above Quick Reference; each pinned card has an Unpin control in its corner. A pinned command drops out of the quick-reference grid so it isn't shown twice.
- Both sit on a secondary background. The search box, table of contents and listings all start beneath them, and neither appears in the table of contents (they're a scan; Details is how you cross into the menu).

## Linkable everywhere

- Each command and alias listing has a link icon (revealed on row hover, the settings page's AnchorLink pattern). Clicking it does exactly what the command's table-of-contents row does -- records the fragment, rings the entry, highlights its contents row -- minus the scroll, since you're already looking at it.
- Categories are linkable: section headers are fragment targets with a hover link icon, and the table-of-contents section labels are buttons that jump to the category. A category scrolls without the persistent ring a specific command gets.

## Shared margin scrolling

`useForwardWheelToScroller` (now in lib/browser, used by this page and settings) sends wheels that land on nothing -- the margins around the centred column, the page header, the empty space under a short table of contents -- to the real scroll container. The settings page is centred to match, its table of contents no longer against the viewport edge.

## Also

- Drop `disband` from the default quick reference (stays in Moderation and `help all`).
- The admin blue is a token (`--admin`), folding in a third hand-copy of it (ChatAdmin's feed colour). Scope badges carry an icon and the channel's colour: admin-only the admin blue with a shield, public ChatAll's white with a globe.

## Config shape

No migration. `quickReference` is additive per command and prefaults from the declaration, so the disband default and the others apply on a fresh install; on an installation that has saved global settings, the stored values already win, so the defaults are worth settling before this ships.

## Testing

Typecheck and lint clean; 629 unit tests pass. Driven end-to-end against a worktree dev instance: the cards, unpin, per-command and category links (click, cold-load deep link, hash edit), margin/header/dead-zone wheel forwarding on both pages, the settings checkbox round-tripping into `/help`, and `/help` / `/HELP` / `/help <section>` in game chat.