### PR TITLE
Fix dashboard responsive breakpoints and column sizing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,14 @@ If we've completed a goal or feature, then run `pnpm run lint:fix` and fix all l
 If you are working in a git worktree, do not run `pnpm server:dev` / `pnpm client:dev` and do not use ports 3000/5173: those belong to the main checkout, and an app you reach there is not running your changes. Each worktree gets its own instance instead, on its own ports, with its own database and an emulated squad server:
 
 ```sh
+pnpm install    # a fresh worktree has no node_modules of its own; dev:init fails ("No preset version ... tsx") until this runs
 pnpm dev:init   # once per worktree: claims a port slot, links .env, clones the db. Prints your URL.
 pnpm dev:emu    # the emulated squad server. Leave it running, it is a separate process on purpose.
 pnpm dev        # the app + client
 pnpm dev:slots  # which worktree owns which ports
 ```
 
-Log in with `?login=<username>` (discord oauth is off for dev instances; any username in the cloned db works). Drive the emulated server with `pnpm emuctl <command>` (`pnpm emuctl help`) rather than trying to reach a real squad server -- e.g. `pnpm emuctl join Alice`, `pnpm emuctl chat Alice '!vote 1'`, `pnpm emuctl end 1`.
+Log in with `?login=<username>` (discord oauth is off for dev instances -- `dev`'s env sets `QUERY_PARAM_AUTH_BYPASS`/`DISCORD_ENABLED=false` for you; any username in the cloned db works). Wait for the app port to be listening before you hit `?login=`: navigating during boot fails the bypass request and bounces you into the real Discord oauth flow, which looks like the bypass is broken when it is not. Drive the emulated server with `pnpm emuctl <command>` (`pnpm emuctl help`) rather than trying to reach a real squad server -- e.g. `pnpm emuctl join Alice`, `pnpm emuctl chat Alice '!vote 1'`, `pnpm emuctl end 1`.
 
 Never point a worktree at a real squad server or the real battlemetrics org; `dev:init` deliberately scrubs those, and re-adding them means an experiment drives production.
 

--- a/src/components/match-history-panel.tsx
+++ b/src/components/match-history-panel.tsx
@@ -231,7 +231,7 @@ export function MatchHistoryPanelContent(props: { stores: SquadServerFrame.KeyPr
 						<TableRow className="font-medium">
 							<TableHead className="text-right px-0.5">
 							</TableHead>
-							<TableHead className="hidden min-[820px]:table-cell">
+							<TableHead className="hidden @[820px]:table-cell">
 								Time
 							</TableHead>
 							<TableHead>Layer</TableHead>
@@ -266,7 +266,7 @@ export function MatchHistoryPanelContent(props: { stores: SquadServerFrame.KeyPr
 									<Icons.Flag />
 								</div>
 							</TableHead>
-							<TableHead className="hidden min-[900px]:table-cell pr-0.5">
+							<TableHead className="hidden @[900px]:table-cell pr-0.5">
 								<span title="Set By">
 									<Icons.User />
 								</span>
@@ -279,19 +279,19 @@ export function MatchHistoryPanelContent(props: { stores: SquadServerFrame.KeyPr
 								<TableRow>
 									<TableCell
 										colSpan={8}
-										className="text-center text-muted-foreground py-8 hidden min-[900px]:table-cell"
+										className="text-center text-muted-foreground py-8 hidden @[900px]:table-cell"
 									>
 										No matches found
 									</TableCell>
 									<TableCell
 										colSpan={7}
-										className="text-center text-muted-foreground py-8 hidden min-[820px]:table-cell min-[900px]:hidden"
+										className="text-center text-muted-foreground py-8 hidden @[820px]:table-cell @[900px]:hidden"
 									>
 										No matches found
 									</TableCell>
 									<TableCell
 										colSpan={6}
-										className="text-center text-muted-foreground py-8 table-cell min-[820px]:hidden"
+										className="text-center text-muted-foreground py-8 table-cell @[820px]:hidden"
 									>
 										No matches found
 									</TableCell>
@@ -644,7 +644,7 @@ function MatchHistoryRow({
 								)}
 						</div>
 					</TableCell>
-					<TableCell className="text-xs hidden min-[820px]:table-cell pl-2 ">
+					<TableCell className="text-xs hidden @[820px]:table-cell pl-2 ">
 						{entry.isCurrentMatch && entry.startTime && entry.status === 'in-progress'
 							&& (
 								<span className="font-mono font-light">

--- a/src/components/primary-panel.tsx
+++ b/src/components/primary-panel.tsx
@@ -84,7 +84,7 @@ export default function PrimaryPanel(props: { stores: SquadServerFrame.KeyProp }
 	const headerRef = React.useRef<HTMLDivElement>(null)
 
 	return (
-		<Card className="flex flex-col flex-1 min-h-0">
+		<Card className="flex flex-col flex-1 min-h-0 @container">
 			<ScrollArea className="flex-1">
 				<MatchHistoryPanelContent stores={props.stores} />
 				<Separator />

--- a/src/components/server-dashboard.tsx
+++ b/src/components/server-dashboard.tsx
@@ -35,14 +35,15 @@ export default function ServerDashboard(props: { stores: SquadServerFrame.KeyPro
 			)}
 
 			{isDesktop && (
-				/* Desktop: Two column layout */
-				<div className="flex gap-2 h-full min-h-0 w-full justify-center">
-					{/* left column — grows into free space (capped) to give the teams grid more room */}
-					<div className="flex flex-col gap-2 shrink-0 min-w-0 grow max-w-[1250px]">
+				/* Desktop: two proportional columns. `minmax(0,...)` on both tracks lets them share the give, so
+				   the right column no longer absorbs all the shrink and starve (the left used to be grow+shrink-0,
+				   which greedily took the space and forced the right one to collapse). Capped and centered so
+				   ultrawide gutters rather than stretching the panels past a readable width. */
+				<div className="grid gap-2 h-full min-h-0 w-full max-w-[2050px] mx-auto grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
+					<div className="flex flex-col gap-2 min-h-0 min-w-0">
 						<PrimaryPanel stores={props.stores} />
 					</div>
-					{/* right column — explicit width matches SecondaryPanel max-w so justify-center works */}
-					<div className="flex min-h-0 min-w-0 w-[800px] shrink">
+					<div className="flex min-h-0 min-w-0">
 						<SecondaryPanel stores={props.stores} />
 					</div>
 				</div>

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -59,39 +59,29 @@ export const userIsActive$ = (function createPageActivityObservable(): Rx.Observ
 	)
 })()
 
-export function useIsDesktopSize() {
-	const [isDesktop, setIsDesktop] = React.useState(false)
+function useMediaQuery(query: string) {
+	// Lazy init off matchMedia so the first render already matches the viewport. A `useState(false)` seed
+	// paints the mobile layout for one frame on every desktop load, then snaps -- visible, and it churns any
+	// layout keyed off the result (the navbar's dashboard tab switcher mounts then unmounts).
+	const [matches, setMatches] = React.useState(() => isBrowser() && window.matchMedia(query).matches)
 
 	React.useEffect(() => {
-		const mediaQuery = window.matchMedia('(min-width: 1280px)')
-		setIsDesktop(mediaQuery.matches)
-
-		const handleChange = (e: MediaQueryListEvent) => {
-			setIsDesktop(e.matches)
-		}
-
+		const mediaQuery = window.matchMedia(query)
+		setMatches(mediaQuery.matches)
+		const handleChange = (e: MediaQueryListEvent) => setMatches(e.matches)
 		mediaQuery.addEventListener('change', handleChange)
 		return () => mediaQuery.removeEventListener('change', handleChange)
-	}, [])
-	return isDesktop
+	}, [query])
+	return matches
+}
+
+export function useIsDesktopSize() {
+	return useMediaQuery('(min-width: 1280px)')
 }
 
 // true below the Tailwind `sm` breakpoint (640px) -- the width at which the navbar collapses its links into a hamburger
 export function useIsSmallViewport() {
-	const [isSmall, setIsSmall] = React.useState(false)
-
-	React.useEffect(() => {
-		const mediaQuery = window.matchMedia('(max-width: 639.98px)')
-		setIsSmall(mediaQuery.matches)
-
-		const handleChange = (e: MediaQueryListEvent) => {
-			setIsSmall(e.matches)
-		}
-
-		mediaQuery.addEventListener('change', handleChange)
-		return () => mediaQuery.removeEventListener('change', handleChange)
-	}, [])
-	return isSmall
+	return useMediaQuery('(max-width: 639.98px)')
 }
 
 // The scrollable this wheel event is already going to move, if any: the first ancestor between the target and `root`


### PR DESCRIPTION
The dashboard's breakpoint/resize behavior had three concrete problems, verified live in Chrome across 1000 / 1290 / 1468 / 1900 px:

## Problems
1. **Flash of the wrong layout on every load.** `useIsDesktopSize`/`useIsSmallViewport` seeded `useState(false)` and only read `matchMedia` in a post-mount effect, so desktop loads painted the mobile/tab layout for a frame then snapped (also churned the navbar's dashboard tab switcher).
2. **Lopsided two-column split starved the right column.** Left was `grow shrink-0 max-w-[1250px]`, right a fixed `w-[800px] shrink`. Between ~1280 and ~2058px the right column (Stats + Server Activity) absorbed *all* the shrink and collapsed: the tick value clipped, entries wrapped to 3 lines, and the whole page grew a horizontal scrollbar.
3. **Match History table clipped in the narrower column.** Its responsive column-hiding was keyed to *viewport* width (`min-[820px]`, `min-[900px]`), so at e.g. 1290px all columns showed even though the column was only ~780px, clipping Team B with no way to scroll to it.

## Fixes
- **`browser.ts`** — both hooks share a `useMediaQuery` that inits synchronously from `matchMedia`, so first paint already matches the viewport.
- **`server-dashboard.tsx`** — desktop split is now a proportional `grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]`, capped and centered. Both tracks can shrink, so neither column starves and the page no longer overflows horizontally.
- **`match-history-panel.tsx` + `primary-panel.tsx`** — mark the panel as an `@container` and key the table's column-hiding to the *panel* width (`@[820px]`, `@[900px]`), so the table adapts to the space it actually has.
- **`CLAUDE.md`** — documented two worktree-setup gotchas (fresh worktree needs `pnpm install`; `?login=` must wait for the app port to be listening or it bounces to the real Discord oauth flow).

## Verification
Driven live via the worktree dev instance. Before: right column ~360px with clipped tick + page h-scroll at 1440px. After: right column ~550px at 1468px and ~700px at 1900px, no page h-scroll at any width, and the Match History table drops low-priority columns to fit the 1290px case cleanly.

## Not in scope (follow-up)
The navbar overflows/cramps in a narrow band below ~960px (full links + the dashboard tab switcher in one row). Pre-existing and separate; flagged for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)