### PR TITLE
Add-only flag dialog for bulk selection and squads

### DIFF
--- a/src/components/bm-flag-workflows.tsx
+++ b/src/components/bm-flag-workflows.tsx
@@ -173,6 +173,84 @@ export function ManageFlagsDialogContent(props: {
 	)
 }
 
+// add-only variant of the flag dialog: no current flags, no removals -- just the set of flags to apply to every
+// target, each with its own reason. Shared by the bulk-selection and squad menus, where the targets' existing flags
+// differ and there's nothing to diff against.
+export function AddFlagsDialogContent(props: {
+	addRef: React.MutableRefObject<string[]>
+	reasonsRef: React.MutableRefObject<Record<string, string>>
+}) {
+	const orgFlags = BattlemetricsClient.useOrgFlags()
+	const requiringNote = ZusUtils.useStore(SettingsClient.PublicSettingsStore, (s) => s?.playerFlagsRequiringNote ?? [])
+	const [pending, setPending] = React.useState<string[]>(() => props.addRef.current)
+	// while true the add button is replaced by the picker it summoned
+	const [picking, setPicking] = React.useState(false)
+
+	const addable = (orgFlags ?? []).map((f) => f.id).filter((id) => !pending.includes(id))
+
+	function dropPending(id: string) {
+		const next = pending.filter((f) => f !== id)
+		setPending(next)
+		props.addRef.current = next
+	}
+
+	function addPending(id: string) {
+		const next = [...pending, id]
+		setPending(next)
+		props.addRef.current = next
+		setPicking(false)
+	}
+
+	return (
+		<div className="grid gap-2">
+			<Label>Flags to add</Label>
+			{pending.length === 0 && <p className="text-xs text-muted-foreground">No flags selected yet.</p>}
+			<ul className="grid gap-1">
+				{pending.map((id) => (
+					<FlagRow
+						key={id}
+						id={id}
+						change="adding"
+						requiresReason={requiringNote.includes(id)}
+						orgFlags={orgFlags}
+						reasonsRef={props.reasonsRef}
+						onToggle={() => dropPending(id)}
+					/>
+				))}
+			</ul>
+			{picking
+				? (
+					<BmFlagSelect
+						value={undefined}
+						only={addable}
+						autoOpen
+						placeholder="Select a flag..."
+						onOpenChange={(open) => {
+							if (!open) setPicking(false)
+						}}
+						onChange={addPending}
+					/>
+				)
+				: (
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="justify-self-start"
+						disabled={addable.length === 0}
+						onClick={() => setPicking(true)}
+					>
+						<Icons.Plus className="mr-1 h-3 w-3" />
+						Add flag
+					</Button>
+				)}
+			<span className="text-xs text-muted-foreground">
+				Each reason is posted to every selected player's BattleMetrics profile as its own note.
+			</span>
+		</div>
+	)
+}
+
 // only the flags actually being changed: a row's text survives in the ref after its row goes away, so it can be
 // restored if the flag comes back, but it must never be submitted for a flag that isn't changing
 function readFlagChanges(flagIds: string[], reasonsRef: React.MutableRefObject<Record<string, string>>): BM.FlagChange[] {
@@ -242,6 +320,57 @@ export function PlayerFlagsMenuItem(props: { slots: MenuSlots; playerId: string;
 	return (
 		<PermissionDeniedTooltip denied={denied}>
 			<Item onClick={manageFlags} disabled={disabled}>{props.label ?? 'Manage Flags...'}</Item>
+		</PermissionDeniedTooltip>
+	)
+}
+
+function useAddFlagsAction(playerIds: string[], targetDescription: string) {
+	const denied = RbacClient.usePermsCheck(RBAC.perm('battlemetrics:write-flags'))
+	const openDialog = useAlertDialog()
+	const mutation = useMutation(RPC.orpc.battlemetrics.addFlags.mutationOptions())
+	const addRef = React.useRef<string[]>([])
+	const reasonsRef = React.useRef<Record<string, string>>({})
+
+	async function addFlags() {
+		if (playerIds.length === 0) return
+		addRef.current = []
+		reasonsRef.current = {}
+		const result = await openDialog({
+			title: 'Add Flags',
+			description: `Add BattleMetrics flags to ${targetDescription}.`,
+			content: <AddFlagsDialogContent addRef={addRef} reasonsRef={reasonsRef} />,
+			buttons: [{ id: 'confirm', label: 'Apply' }],
+		})
+		if (result !== 'confirm') return
+		const add = readFlagChanges(addRef.current, reasonsRef)
+		if (add.length === 0) {
+			toast.error('No flags to add')
+			return
+		}
+		const res = await mutation.mutateAsync({ playerIds, add })
+		if (res.code === 'err:reason-required') {
+			toast.error('Reason required', { description: `These flags require a reason: ${res.flags.join(', ')}` })
+			return
+		}
+		if (res.code !== 'ok') {
+			toast.error('Failed to add flags', { description: res.code })
+			return
+		}
+		toast(`Flagged ${res.flaggedCount} of ${res.playerCount} players`, {
+			description: res.noteAdded ? undefined : 'The flags were added, but a BattleMetrics note failed to post.',
+		})
+	}
+
+	return { addFlags, denied, disabled: !!denied || playerIds.length === 0 }
+}
+
+// bulk-selection and squad menu entry: add-only flags across every target
+export function AddPlayerFlagsMenuItem(props: { slots: MenuSlots; playerIds: string[]; targetDescription: string; label?: string }) {
+	const { Item } = props.slots
+	const { addFlags, denied, disabled } = useAddFlagsAction(props.playerIds, props.targetDescription)
+	return (
+		<PermissionDeniedTooltip denied={denied}>
+			<Item onClick={addFlags} disabled={disabled}>{props.label ?? 'Add Flags...'}</Item>
 		</PermissionDeniedTooltip>
 	)
 }

--- a/src/components/player-bulk-context-menu-options.tsx
+++ b/src/components/player-bulk-context-menu-options.tsx
@@ -15,6 +15,7 @@ import * as TimeoutsClient from '@/systems/timeouts.client'
 import * as UPClient from '@/systems/user-presence.client'
 import * as WarnChat from '@/systems/warn-chat.client'
 import React from 'react'
+import { AddPlayerFlagsMenuItem } from './bm-flag-workflows'
 import { PermissionDeniedTooltip } from './permission-denied-tooltip'
 import { contextMenuSlots, PlayerCopyIdsSub, PlayerOpenLinksSub, TimeoutDialogContent } from './player-context-menu-options'
 import { ContextMenuItem, ContextMenuLabel, ContextMenuSeparator, ContextMenuShortcut } from './ui/context-menu'
@@ -369,6 +370,11 @@ export default function PlayerBulkContextMenuOptions(
 				label={fullSquad ? 'Warn Squad' : 'Warn'}
 				onCustom={warn}
 				onPreset={warnPreset}
+			/>
+			<AddPlayerFlagsMenuItem
+				slots={contextMenuSlots}
+				playerIds={playerIds}
+				targetDescription={fullSquad ? `squad "${fullSquad.squadName}"` : `these ${playerIds.length} players`}
 			/>
 			<PermissionDeniedTooltip denied={manageDenied}>
 				<ContextMenuItem onClick={removeFromSquad} disabled={!!manageDenied}>Remove from Squad</ContextMenuItem>

--- a/src/components/squad-context-menu-options.tsx
+++ b/src/components/squad-context-menu-options.tsx
@@ -15,6 +15,7 @@ import * as TimeoutsClient from '@/systems/timeouts.client'
 import * as UPClient from '@/systems/user-presence.client'
 import * as WarnChat from '@/systems/warn-chat.client'
 import React from 'react'
+import { AddPlayerFlagsMenuItem } from './bm-flag-workflows'
 import { PermissionDeniedTooltip } from './permission-denied-tooltip'
 import { type MenuSlots, TimeoutDialogContent } from './player-context-menu-options'
 import { ContextMenuItem, ContextMenuSeparator, ContextMenuShortcut, ContextMenuSub, ContextMenuSubContent, ContextMenuSubTrigger } from './ui/context-menu'
@@ -366,6 +367,12 @@ export function SquadMenuItems(
 					/>
 				</>
 			)}
+			<AddPlayerFlagsMenuItem
+				slots={slots}
+				playerIds={squadPlayerIds}
+				targetDescription={`squad ${squadLabel}`}
+				label="Add Flags to Squad..."
+			/>
 			<Separator />
 			<PermissionDeniedTooltip denied={manageDenied}>
 				<Item onClick={disbandSquad} disabled={!!manageDenied || !squadExists}>

--- a/src/systems/battlemetrics.server.ts
+++ b/src/systems/battlemetrics.server.ts
@@ -690,6 +690,47 @@ export const router = {
 
 		return { code: 'ok' as const, data: updated, noteAdded: noteResults.every(Boolean), added, removed }
 	}),
+
+	// add-only, applied across many players (bulk selection / squad): one flag set with per-flag reasons, added to
+	// every target that doesn't already have it. Each player lands its own PLAYER_FLAGS_UPDATED event and BM notes,
+	// so the audit trail reads the same as if each had been flagged singly. A player already carrying a flag is left
+	// untouched rather than failing the batch.
+	addFlags: orpcBase.meta({ type: 'mutation' }).input(z.object({
+		playerIds: z.array(z.string()).min(1),
+		add: z.array(BM.FlagChangeSchema).min(1),
+	})).handler(async ({ input, context: ctx }) => {
+		const denyRes = await Rbac.tryDenyPermissionsForUser(ctx, RBAC.perm('battlemetrics:write-flags'))
+		if (denyRes) return denyRes
+
+		const orgFlags = await getOrgFlags(ctx)
+		const missing = BM.flagsMissingRequiredNote(input.add, Settings.GLOBAL_SETTINGS.playerFlagsRequiringNote)
+		if (missing.length > 0) {
+			return { code: 'err:reason-required' as const, flags: BM.resolveFlags(missing, orgFlags).map((f) => f.name) }
+		}
+
+		let flaggedCount = 0
+		let allNotesAdded = true
+		for (const playerId of input.playerIds) {
+			const playerIds = SM.PlayerIds.queryFromPlayerId(playerId)
+			const current = await fetchSinglePlayerBmData(ctx, playerIds)
+			if (!current) continue
+			const toAdd = input.add.filter((f) => !current.flagIds.includes(f.id))
+			if (toAdd.length === 0) continue
+
+			const addRes = await addPlayerFlags(ctx, current.bmPlayerId, toAdd.map((f) => f.id))
+			if (addRes.code === 'player-already-has-flag') continue
+
+			const added = resolveFlagChanges(toAdd, orgFlags)
+			const noteAdded = await postFlagChangeNotes(ctx, current.bmPlayerId, 'added', added, actorLabel(ctx))
+			if (!noteAdded) allNotesAdded = false
+
+			await refreshPlayerFlags(ctx, playerId, playerIds)
+			await persistFlagsUpdatedEvent(ctx, { playerId, added, removed: [] })
+			flaggedCount++
+		}
+
+		return { code: 'ok' as const, flaggedCount, playerCount: input.playerIds.length, noteAdded: allNotesAdded }
+	}),
 }
 
 type ResolvedFlagChange = { id: string; name: string; reason?: string }


### PR DESCRIPTION
## What

Adds an **Add Flags...** action to the player **bulk-selection** and **squad** context menus. It mirrors the existing single-player *Manage Flags* dialog but is add-only (no removals), since the targets' existing flags differ and there's nothing to diff against.

- **Bulk menu**: `Add Flags...`, targeting the current selection (or `squad "X"` when the selection is exactly one full squad).
- **Squad menu**: `Add Flags to Squad...`, targeting all live squad members.
- **Component** (`bm-flag-workflows.tsx`): new `AddFlagsDialogContent` (picker + per-flag reason rows, reusing `FlagRow`), `useAddFlagsAction`, and the shared `AddPlayerFlagsMenuItem` menu entry.
- **Server** (`battlemetrics.server.ts`): new add-only `battlemetrics.addFlags` bulk procedure. One flag set with per-flag reasons is applied to every target that doesn't already have it; each player lands its own `PLAYER_FLAGS_UPDATED` event and BM notes, so the audit trail reads the same as flagging each singly. Required-note enforcement is re-checked server-side. A player already carrying a flag is skipped rather than failing the batch.

No data-structure or config changes.

## Verification

Driven end-to-end on a worktree dev instance (emulated squad + BM stub):

- Selected two players, opened **Add Flags...**, staged *Watchlist* with a reason, applied.
- Toast: `Flagged 2 of 2 players`.
- BM stub received one correctly-formatted note per player.
- Two `PLAYER_FLAGS_UPDATED` app events persisted, one per player, each snapshotting the reason.

`pnpm run check` and `pnpm run lint:fix` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)