### PR TITLE
Render the layer-select trigger for id `in` filters

### DIFF
--- a/src/components/filter-card.tsx
+++ b/src/components/filter-card.tsx
@@ -1294,6 +1294,10 @@ function LayersInConfig(
 				</ul>
 			)}
 			<div className="w-max">
+				<Button size="sm" variant="outline" onClick={() => setOpen(true)} className="w-full">
+					<Icons.Edit className="h-4 w-4 mr-2" />
+					{filteredValues.length === 0 ? 'Select Layers' : 'Edit Layers'}
+				</Button>
 				<SelectLayersDialog
 					open={open}
 					onOpenChange={setOpen}
@@ -1301,12 +1305,7 @@ function LayersInConfig(
 					pinMode="layers"
 					defaultSelected={filteredValues}
 					selectQueueItems={items => props.setValues(values => Arr.union(values, items.map(items => items.layerId!)))}
-				>
-					<Button size="sm" variant="outline" onClick={() => setOpen(true)} className="w-full">
-						<Icons.Edit className="h-4 w-4 mr-2" />
-						{filteredValues.length === 0 ? 'Select Layers' : 'Edit Layers'}
-					</Button>
-				</SelectLayersDialog>
+				/>
 			</div>
 		</div>
 	)

--- a/src/components/select-layers-dialog.tsx
+++ b/src/components/select-layers-dialog.tsx
@@ -34,7 +34,6 @@ type SelectLayersDialogProps = {
 	open: boolean
 	onOpenChange: (isOpen: boolean) => void
 	footerAdditions?: React.ReactNode
-	children?: React.ReactNode
 	cursor?: LL.Cursor
 }
 


### PR DESCRIPTION
## Problem
On the filter editor (`/filters/new`), a comparison with the **ID** column and the **in** operator rendered no value editor: there was no button to open the layer picker, so you couldn't select any layer ids. (Reported: "I'm not able to open the dialog.")

## Cause
`LayersInConfig` passed its trigger `<Button>` as a **child** of `SelectLayersDialog`:

```tsx
<SelectLayersDialog open={open} onOpenChange={setOpen} ...>
  <Button onClick={() => setOpen(true)}>Select Layers</Button>
</SelectLayersDialog>
```

But `SelectLayersDialog` renders only `HeadlessDialog` + its content and **never renders `props.children`**, so the trigger was silently dropped. The dialog is controlled purely via `open`/`onOpenChange`, and the other two call sites (`nav-bar.tsx`, `layer-list.tsx`) already supply their own external trigger.

## Fix
- Render the trigger `<Button>` as a **sibling** of the dialog (matching the established pattern), so it always shows and controls `open`.
- Drop the unused `children` prop from `SelectLayersDialogProps` so this footgun can't recur.

id + `eq` (single layer, `EditLayerDialog`) is unchanged.

## Verification
Ran a worktree dev instance and drove `/filters/new`:
- ID + `in` now shows a **Select Layers** button that opens the multi-select layer menu.
- Selected two layers ("2 selected"), submitted, and both flowed back as removable chips; the table filtered to those two layers.

Typecheck (`pnpm run check`) and lint (`pnpm run lint:fix`) pass; diff is limited to the two components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)