### PR TITLE
feat(flags): refresh BM data on flag dialogs + player details window

### DIFF
--- a/src/components/bm-flag-workflows.tsx
+++ b/src/components/bm-flag-workflows.tsx
@@ -73,13 +73,15 @@ function FlagRow(props: {
 }
 
 export function ManageFlagsDialogContent(props: {
-	currentFlagIds: string[]
+	playerId: string
 	addRef: React.MutableRefObject<string[]>
 	removeRef: React.MutableRefObject<string[]>
 	reasonsRef: React.MutableRefObject<Record<string, string>>
 }) {
 	const orgFlags = BattlemetricsClient.useOrgFlags()
 	const requiringNote = ZusUtils.useStore(SettingsClient.PublicSettingsStore, (s) => s?.playerFlagsRequiringNote ?? [])
+	// read live so the refresh kicked off when the dialog opened lands here without reopening it
+	const currentFlagIds = BattlemetricsClient.usePlayerFlagIds(props.playerId) ?? []
 	// staged rather than applied on click: a misclick on a destructive action stays undoable while the dialog is open
 	const [staged, setStaged] = React.useState<string[]>(() => props.removeRef.current)
 	const [pending, setPending] = React.useState<string[]>(() => props.addRef.current)
@@ -87,7 +89,7 @@ export function ManageFlagsDialogContent(props: {
 	const [picking, setPicking] = React.useState(false)
 
 	const addable = (orgFlags ?? []).map((f) => f.id)
-		.filter((id) => !props.currentFlagIds.includes(id) && !pending.includes(id))
+		.filter((id) => !currentFlagIds.includes(id) && !pending.includes(id))
 
 	function toggleStaged(id: string) {
 		const next = staged.includes(id) ? staged.filter((f) => f !== id) : [...staged, id]
@@ -111,11 +113,9 @@ export function ManageFlagsDialogContent(props: {
 	return (
 		<div className="grid gap-2">
 			<Label>Flags</Label>
-			{props.currentFlagIds.length === 0 && pending.length === 0 && (
-				<p className="text-xs text-muted-foreground">This player has no flags.</p>
-			)}
+			{currentFlagIds.length === 0 && pending.length === 0 && <p className="text-xs text-muted-foreground">This player has no flags.</p>}
 			<ul className="grid gap-1">
-				{props.currentFlagIds.map((id) => (
+				{currentFlagIds.map((id) => (
 					<FlagRow
 						key={id}
 						id={id}
@@ -261,6 +261,7 @@ function useManageFlagsAction(playerId: string) {
 	const denied = RbacClient.usePermsCheck(RBAC.perm('battlemetrics:write-flags'))
 	const openDialog = useAlertDialog()
 	const currentFlagIds = BattlemetricsClient.usePlayerFlagIds(playerId)
+	const refresh = BattlemetricsClient.useRefreshPlayerBmData()
 	const mutation = useMutation(RPC.orpc.battlemetrics.updateFlags.mutationOptions())
 	const addRef = React.useRef<string[]>([])
 	const removeRef = React.useRef<string[]>([])
@@ -271,12 +272,14 @@ function useManageFlagsAction(playerId: string) {
 		addRef.current = []
 		removeRef.current = []
 		reasonsRef.current = {}
+		// pull fresh flags in case they moved since this player's data was last polled; the dialog reads them live
+		void refresh.mutateAsync({ playerIds: [playerId] })
 		const result = await openDialog({
 			title: 'Manage Flags',
 			description: "Add or remove BattleMetrics flags on this player's profile.",
 			content: (
 				<ManageFlagsDialogContent
-					currentFlagIds={currentFlagIds}
+					playerId={playerId}
 					addRef={addRef}
 					removeRef={removeRef}
 					reasonsRef={reasonsRef}
@@ -327,6 +330,7 @@ export function PlayerFlagsMenuItem(props: { slots: MenuSlots; playerId: string;
 function useAddFlagsAction(playerIds: string[], targetDescription: string) {
 	const denied = RbacClient.usePermsCheck(RBAC.perm('battlemetrics:write-flags'))
 	const openDialog = useAlertDialog()
+	const refresh = BattlemetricsClient.useRefreshPlayerBmData()
 	const mutation = useMutation(RPC.orpc.battlemetrics.addFlags.mutationOptions())
 	const addRef = React.useRef<string[]>([])
 	const reasonsRef = React.useRef<Record<string, string>>({})
@@ -335,6 +339,8 @@ function useAddFlagsAction(playerIds: string[], targetDescription: string) {
 		if (playerIds.length === 0) return
 		addRef.current = []
 		reasonsRef.current = {}
+		// the server re-diffs against live flags per player; refreshing keeps its skip-already-flagged decision current
+		void refresh.mutateAsync({ playerIds })
 		const result = await openDialog({
 			title: 'Add Flags',
 			description: `Add BattleMetrics flags to ${targetDescription}.`,

--- a/src/components/player-details-window.tsx
+++ b/src/components/player-details-window.tsx
@@ -15,7 +15,7 @@ import * as BM from '@/models/battlemetrics.models'
 import * as CHAT from '@/models/chat.models'
 import { WINDOW_ID } from '@/models/draggable-windows.models'
 import * as RPC from '@/orpc.client'
-import { useOrgFlags, usePlayerGroupColor } from '@/systems/battlemetrics.client'
+import { useOrgFlags, usePlayerGroupColor, useRefreshPlayerBmData } from '@/systems/battlemetrics.client'
 import { DraggableWindowStore } from '@/systems/draggable-window.client'
 import * as MatchHistoryClient from '@/systems/match-history.client'
 import * as TimeoutsClient from '@/systems/timeouts.client'
@@ -143,6 +143,7 @@ function PlayerDetailsWindow({ playerId, stores }: PlayerDetailsWindowProps) {
 						)
 				)}
 				{flags && flags.length > 0 && <PlayerFlagsList flags={flags} />}
+				<PlayerBmRefreshButton playerId={playerId} />
 				<PlayerFlagsButton playerId={playerId} />
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>
@@ -268,6 +269,25 @@ function PlayerDetailsWindow({ playerId, stores }: PlayerDetailsWindowProps) {
 				</div>
 			)}
 		</div>
+	)
+}
+
+// on-demand bust of this player's cached BM data; the fresh flags/profile arrive over the watch stream
+function PlayerBmRefreshButton({ playerId }: { playerId: string }) {
+	const refresh = useRefreshPlayerBmData()
+	return (
+		<button
+			type="button"
+			disabled={refresh.isPending}
+			onClick={async () => {
+				const res = await refresh.mutateAsync({ playerIds: [playerId] })
+				if (res.failed.length > 0) toast.error('Failed to refresh BattleMetrics data')
+			}}
+			className="inline-flex items-center rounded p-0.5 text-muted-foreground hover:text-foreground transition-colors shrink-0 disabled:pointer-events-none"
+			title="Refresh BattleMetrics data"
+		>
+			<Icons.RefreshCw className={`h-3 w-3 ${refresh.isPending ? 'animate-spin' : ''}`} />
+		</button>
 	)
 }
 

--- a/src/systems/battlemetrics.client.ts
+++ b/src/systems/battlemetrics.client.ts
@@ -4,7 +4,7 @@ import * as PG from '@/models/player-groupings.models'
 import * as RPC from '@/orpc.client'
 import * as SettingsClient from '@/systems/settings.client'
 import * as ReactRx from '@react-rxjs/core'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import * as Rx from 'rxjs'
 import * as Zus from 'zustand'
 
@@ -41,6 +41,11 @@ export const [usePlayerBmData, playerBmData$] = ReactRx.bind<BM.PublicPlayerBmDa
 export function useOrgFlags(): BM.PlayerFlag[] | undefined {
 	const { data } = useQuery(RPC.orpc.battlemetrics.listOrgFlags.queryOptions({ staleTime: Infinity }))
 	return data ?? undefined
+}
+
+// busts the server's BM cache for these players and refetches; fresh data arrives over the watch stream
+export function useRefreshPlayerBmData() {
+	return useMutation(RPC.orpc.battlemetrics.refreshPlayerBmData.mutationOptions())
 }
 
 export function usePlayerFlagIds(playerId: string): string[] | null {

--- a/src/systems/battlemetrics.server.ts
+++ b/src/systems/battlemetrics.server.ts
@@ -634,6 +634,21 @@ export const router = {
 		return fetchSinglePlayerBmData(ctx, SM.PlayerIds.queryFromPlayerId(input.playerId))
 	}),
 
+	// on-demand cache bust: drops each player's cached BM data and refetches, pushing the fresh result down the watch
+	// stream. A player whose refetch fails is left with whatever was cached rather than failing the batch.
+	refreshPlayerBmData: orpcBase.meta({ type: 'mutation' }).input(z.object({
+		playerIds: z.array(z.string()).min(1),
+	})).handler(async ({ input, context: ctx }) => {
+		const failed: string[] = []
+		for (const playerId of input.playerIds) {
+			await refreshPlayerFlags(ctx, playerId, SM.PlayerIds.queryFromPlayerId(playerId)).catch((err) => {
+				log.warn({ err, playerId }, 'failed to refresh player bm data')
+				failed.push(playerId)
+			})
+		}
+		return { code: 'ok' as const, refreshedCount: input.playerIds.length - failed.length, failed }
+	}),
+
 	watchPlayerBmData: orpcBase.meta({ logLevel: 'trace' }).handler(async function*({ signal, context: _ctx }) {
 		const initial$ = Rx.from(
 			[...playerFlagsAndProfileCache.entries()]


### PR DESCRIPTION
Follow-up to #56 (stacked on it). Two enhancements to the BattleMetrics flag flows:

## Invalidate on dialog open
Opening **Add Flags** (bulk selection / squad) or **Manage Flags** (single player) now busts and refetches each target player's cached BM data, so the dialog reflects current flags rather than whatever was last polled (cache TTL is 30 min).

- `ManageFlagsDialogContent` now reads the player's flags **live** from the store (takes `playerId` instead of a `currentFlagIds` snapshot), so the refresh kicked off on open lands in the already-open dialog.
- `AddFlagsDialogContent` doesn't display per-player flags, but the refresh keeps the server's per-player "skip already-flagged" diff current.

## Refresh icon on the player details window
A refresh icon (↻) in the details-window top bar does an on-demand cache bust for that player. Spins while pending, toasts on failure.

## Server
New `battlemetrics.refreshPlayerBmData` mutation: accepts many player ids, drops each from the cache and refetches (pushing the fresh result down the existing watch stream), and skips per-player failures rather than failing the batch. Reuses the existing `refreshPlayerFlags` helper. Ungated, matching the other BM read procedures.

No persisted-data or config changes.

## Verification
On the slot-2 dev instance: the refresh icon renders and clicks cleanly (no console error, no error toast), and Manage Flags opens showing the player's current flags read live after the refactor. Server side reuses the `refreshPlayerFlags` path already verified end-to-end in #56.

`pnpm run check` and `pnpm run lint:fix` clean.

Dev server (with these changes): http://localhost:3121 (same-host only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)