### PR TITLE
Defer match-history user enrichment out of the sync transaction

### DIFF
--- a/src/systems/match-history.server.ts
+++ b/src/systems/match-history.server.ts
@@ -131,16 +131,25 @@ export const loadState = C.spanOp(
 			...m,
 			isCurrentMatch: m.historyEntryId === currentMatchId,
 		}))
+		const userRows = new Map<bigint, Schema.User>()
 		for (const row of rows) {
 			const isCurrentMatch = row.recent_matches.id === currentMatchId!
 			// @ts-expect-error idgaf
 			const details = MH.matchHistoryEntryToMatchDetails(unsuperjsonify(Schema.matchHistory, row.recent_matches), isCurrentMatch)
 			state.recentMatches.push(details)
 
-			if (row.users) {
-				const user = await UsersClient.buildUser(row.users)
-				Arr.upsertOn(state.parts.users, user, 'discordId')
-			}
+			if (row.users) userRows.set(row.users.discordId, row.users)
+		}
+
+		// buildUser reaches the Discord REST API, which yields to the event loop. Enriching here would hold the
+		// process-wide transaction lock across a network round trip, so defer it: recentMatches reference users by
+		// setByUserId, not by embedding, and parts.users is display-only, so it can fill in after commit.
+		if (userRows.size > 0) {
+			addReleaseTask(async () => {
+				const users = await UsersClient.buildUsers([...userRows.values()])
+				for (const user of users) Arr.upsertOn(state.parts.users, user, 'discordId')
+				state.dispatchUpdate()
+			})
 		}
 
 		for (const row of balanceTriggerRows) {


### PR DESCRIPTION
## Problem

Prod logs repeated errors on `RCON_CONNECTED`:

```
syncWithCurrentLayer : error: transaction callback yielded to the event loop: only queries may be awaited inside runTransaction...
onNewGameDuringSync  : error: transaction callback yielded to the event loop...
```

Root cause: `MatchHistory.loadState` called `UsersClient.buildUser(row.users)` **inline inside** `syncWithCurrentLayer`'s `runTransaction`. `buildUser` reaches the Discord REST API (`guild.members.fetch`), so on a cold member cache (exactly the RCON-reconnect path) it yields to the event loop while holding the **process-wide** transaction lock, stalling every other write behind the network round trip. The `db.ts` async-tx guard correctly flags it (a real latency bug, not a false positive).

## Fix

Collect the `setBy` user rows during the db read and enrich them in a **release task that runs after commit** (the same `addReleaseTask` mechanism the callers already use for `dispatchUpdate`). This keeps every db read inside the transaction and moves only the Discord call out. `recentMatches` reference users by `setByUserId` (not by embedding), and `parts.users` is display-only, so it can fill in a beat later; the release task dispatches a follow-up update once names resolve.

## Scope check

Swept every `runTransaction` call site for awaited non-query work inside the callback. This was the only offender: layer-queue defers its RCON calls via `unlockTasks`, and sessions / filter-entity already hoist `buildUser` before the tx (with comments noting "the tx lock is global"). backups even yields *between* batch transactions via `setImmediate`, never inside.

## Testing

- `pnpm run check` clean
- `pnpm run test` for pending-events + db guard: 88 passed

No data-structure or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)