### PR TITLE
Fix: allow clearing filter alert/description text

### DIFF
--- a/src/components/filter-edit.tsx
+++ b/src/components/filter-edit.tsx
@@ -344,7 +344,7 @@ export function FilterEdit(
 																placeholder={label}
 																defaultValue={field.state.value ?? ''}
 																onBlur={field.handleBlur}
-																onChange={(e) => field.setValue(e.target.value.trim() ?? null)}
+																onChange={(e) => field.setValue(e.target.value.trim() || null)}
 																rows={3}
 															/>
 															{field.state.meta.errors.length > 0 && (
@@ -401,7 +401,7 @@ export function FilterEdit(
 																placeholder={label}
 																defaultValue={field.state.value ?? ''}
 																onBlur={field.handleBlur}
-																onChange={(e) => field.setValue(e.target.value.trim() ?? null)}
+																onChange={(e) => field.setValue(e.target.value.trim() || null)}
 																rows={3}
 															/>
 															{field.state.meta.errors.length > 0 && (
@@ -434,7 +434,7 @@ export function FilterEdit(
 														placeholder={label}
 														defaultValue={field.state.value ?? ''}
 														onBlur={field.handleBlur}
-														onChange={(e) => field.handleChange(e.target.value?.trim() ?? null)}
+														onChange={(e) => field.handleChange(e.target.value?.trim() || null)}
 														rows={15}
 														className="font-mono text-sm grow"
 													/>


### PR DESCRIPTION
## Problem

Once an **Alert Message** (the indicator warning text) was set on a filter entity, it was impossible to remove it. Clearing the textarea and saving did nothing.

## Cause

In `filter-edit.tsx` the Alert Message / Miss-Indicator Alert Message / Description textareas set their value with `e.target.value.trim() ?? null`. `String.prototype.trim()` always returns a string, so emptying the field produced `''`, never `null`. The field validators are `AlertMessageSchema.nullable()` / `DescriptionSchema.nullable()` (each `min(3)`), so `''` fails validation and the form is stuck invalid and unsaveable.

## Fix

Use `|| null` so an emptied field coerces to `null`, which the nullable validators accept and the submit handler already passes through as `null`.

Applied to all three affected fields (Alert Message, Miss Indicator Alert Message, Description) since they shared the identical defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)