### PR TITLE
Graceful websocket recovery when returning to an idle tab

### DIFF
--- a/src/orpc.client.ts
+++ b/src/orpc.client.ts
@@ -18,7 +18,15 @@ import { formatVersion } from './lib/versioning'
 
 const wsHostname = window.location.origin.replace(/^http/, 'ws').replace(/\/$/, '')
 const wsUrl = `${wsHostname}${AR.route('/orpc')}`
-const websocket = new WebSocket(wsUrl)
+
+// On reconnect, tell the server the id we last held so it reclaims that exact presence entry (activity +
+// locks) and evicts our stale socket, instead of minting a fresh id and leaving a ghost that reads as an
+// "other active session". partysocket re-invokes this per connect; empty on the first connect (no id yet).
+function resolveWsUrl(): string {
+	const priorClientId = ConfigClient.getConfig()?.wsClientId
+	return priorClientId ? `${wsUrl}?prior=${encodeURIComponent(priorClientId)}` : wsUrl
+}
+const websocket = new WebSocket(resolveWsUrl)
 
 // read off the socket rather than connectStatus$, because a close event fails the in-flight calls and moves the status
 // in an order we don't control: readyState is already CLOSING/CLOSED by the time those rejections land.

--- a/src/orpc.client.ts
+++ b/src/orpc.client.ts
@@ -97,12 +97,40 @@ connectStatus$.pipe(
 	Rx.distinctUntilChanged(),
 ).subscribe(online => onlineManager.setOnline(online))
 
+// A backgrounded tab's socket is dropped externally (OS suspension, network sleep, a proxy idle-timeout) while nothing
+// on either side keeps it alive. partysocket has no liveness detection, so the dead socket only surfaces as a close
+// event around the moment the tab is refocused, and its first reconnect attempt then waits minReconnectionDelay (1-5s).
+// On refocus we force an immediate reconnect (resets partysocket's retry backoff to 0), so recovery is near-instant.
+let becameVisibleAt = document.hidden ? 0 : Date.now()
+document.addEventListener('visibilitychange', () => {
+	if (document.hidden) return
+	becameVisibleAt = Date.now()
+	if (!transportOpen()) websocket.reconnect()
+})
+
+// A disconnect discovered at or just after refocus is the expected idle-drop, and it recovers on its own within a
+// second or two, so warning about it is just noise. This grace window suppresses the toast for that case while still
+// reporting a genuine outage that happens (or persists) while the user is actively looking at the tab.
+const REFOCUS_GRACE_MS = 3_000
+const shouldWarnDisconnected$ = Rx.combineLatest([
+	connectStatus$,
+	Rx.fromEvent(document, 'visibilitychange').pipe(Rx.startWith(null)),
+]).pipe(
+	Rx.switchMap(([status]) => {
+		if (status !== 'closed' || document.hidden) return Rx.of(false)
+		const remaining = REFOCUS_GRACE_MS - (Date.now() - becameVisibleAt)
+		if (remaining <= 0) return Rx.of(true)
+		return Rx.concat(Rx.of(false), Rx.of(true).pipe(Rx.delay(remaining)))
+	}),
+	Rx.distinctUntilChanged(),
+)
+
 // one toast for the whole outage, replaced in place by its own resolution. Keyed so repeated close events can't stack
 // copies of it, and unclearable because dismissing it wouldn't make the app usable again.
 const RECONNECT_TOAST_ID = 'ws-reconnect'
 let reconnectToastShown = false
-connectStatus$.subscribe(status => {
-	if (status === 'closed' && !reconnectToastShown) {
+shouldWarnDisconnected$.subscribe(warn => {
+	if (warn && !reconnectToastShown) {
 		reconnectToastShown = true
 		// the whole state is in the title: updating a toast by id merges into the existing one, so a description set
 		// here would survive into the success toast that replaces it
@@ -111,9 +139,15 @@ connectStatus$.subscribe(status => {
 			duration: Infinity,
 			dismissible: false,
 		})
-	} else if (status === 'open' && reconnectToastShown) {
+	} else if (!warn && reconnectToastShown) {
 		reconnectToastShown = false
-		toast.success('Reconnected to the server', { id: RECONNECT_TOAST_ID, duration: 3_000, dismissible: true })
+		// resolved because we reconnected -> tell the user; resolved because the tab went hidden while still down ->
+		// just drop the toast, there is nothing to celebrate and no one watching
+		if (transportOpen()) {
+			toast.success('Reconnected to the server', { id: RECONNECT_TOAST_ID, duration: 3_000, dismissible: true })
+		} else {
+			toast.dismiss(RECONNECT_TOAST_ID)
+		}
 	}
 })
 

--- a/src/systems/fastify.server.ts
+++ b/src/systems/fastify.server.ts
@@ -344,9 +344,12 @@ export function createOrpcSessionBase(
 	ctx: C.FastifyRequestFull & C.AuthedUser,
 	websocket: WebSocket,
 ): C.OrpcBase {
-	// reuse the id of an interrupted session for this user if there is one, so the reconnecting socket
-	// picks up its held presence (activity + locks) with no visible break; otherwise mint a fresh id
-	const wsClientId = UserPresenceSys.reclaimInterruptedClientId(ctx.user.discordId) ?? createId(32)
+	// reconnecting clients send the id they last held as `?prior=`, so the socket picks up its held presence
+	// (activity + locks) in place with no visible break and leaves no ghost "other session"; otherwise mint a fresh id
+	const priorClientId = typeof (ctx.req.query as { prior?: unknown })?.prior === 'string'
+		? (ctx.req.query as { prior: string }).prior
+		: undefined
+	const wsClientId = UserPresenceSys.reclaimClientId(ctx.user.discordId, priorClientId) ?? createId(32)
 
 	const wsCtx: C.OrpcBase = {
 		wsClientId,

--- a/src/systems/user-presence.client.ts
+++ b/src/systems/user-presence.client.ts
@@ -532,10 +532,9 @@ export async function setup() {
 		handleIncomingPresenceUpdate(update)
 	})
 
-	// Presence after a websocket reconnect is re-established server-side: an abnormal socket close
-	// leaves our prior presence in 'connection-interrupted' with its activity intact, and when our new
-	// connection registers the server steals that activity onto the fresh wsClientId (see
-	// user-presence.server.ts). So there's nothing to replay from the client here.
+	// Presence after a websocket reconnect is re-established server-side: our new socket sends the id we
+	// last held as `?prior=`, and the server reclaims that same wsClientId with its activity and locks
+	// intact (see reclaimClientId in user-presence.server.ts). So there's nothing to replay from the client here.
 
 	const settingsModified$ = Rx.combineLatest([
 		ZusUtils.toObservable(SquadServerClient.SelectedServerStore, true).pipe(Rx.map(([s]) => s.selectedServerId)),

--- a/src/systems/user-presence.server.ts
+++ b/src/systems/user-presence.server.ts
@@ -132,10 +132,22 @@ const dispatchOp = C.spanOp(
 		}
 	},
 )
-// Called at connection time (see createOrpcSessionBase): if this user has a client whose socket was
-// interrupted, hand the new connection that same wsClientId so its held activity and locks carry over
-// untouched, and mark it live again. Returns the reclaimed id, or undefined to mint a fresh one.
-export function reclaimInterruptedClientId(userId: bigint): string | undefined {
+// Called at connection time (see createOrpcSessionBase): hand the new connection the wsClientId it is
+// reconnecting into, so its held presence (activity + locks) carries over untouched and no ghost entry is
+// left behind. Returns the reclaimed id, or undefined to mint a fresh one.
+export function reclaimClientId(userId: bigint, priorClientId?: string): string | undefined {
+	// The reconnecting client told us the id it last held. Reclaim that exact entry whether it is still
+	// `connected` (its old socket half-open, close not yet detected -- the common reconnect case) or already
+	// `connection-interrupted`, and evict any stale socket still parked on it. Scoped to this user's own ids.
+	if (priorClientId !== undefined) {
+		const presence = globalUserPresence.session.state.presence.get(priorClientId)
+		if (presence && presence.userId === userId && presence.connectionState !== 'disconnected') {
+			WSSessionSys.evictStaleSocket(priorClientId)
+			return markReclaimed(priorClientId)
+		}
+	}
+
+	// Fallback for a client that supplied no usable prior id: reclaim its most-recently-seen interrupted entry.
 	let reclaimedId: string | undefined
 	let bestSeen = -Infinity
 	for (const [clientId, presence] of globalUserPresence.session.state.presence) {
@@ -148,11 +160,15 @@ export function reclaimInterruptedClientId(userId: bigint): string | undefined {
 		}
 	}
 	if (reclaimedId === undefined) return undefined
-	// the reconnecting socket owns this id now; cancel the pending disconnect and mark it live
-	clearPendingDisconnect(reclaimedId)
-	dispatchOp([{ code: 'connection-restored', clientId: reclaimedId, opId: UP.createOpId(), time: Date.now() }])
+	return markReclaimed(reclaimedId)
+}
+
+// the reconnecting socket owns this id now; cancel any pending disconnect and mark it live
+function markReclaimed(clientId: string): string {
+	clearPendingDisconnect(clientId)
+	dispatchOp([{ code: 'connection-restored', clientId, opId: UP.createOpId(), time: Date.now() }])
 		.catch((error) => log.error(error))
-	return reclaimedId
+	return clientId
 }
 
 // the users currently editing the given server's layer queue, minus `exclude` (typically the user whose save is

--- a/src/systems/ws-session.server.ts
+++ b/src/systems/ws-session.server.ts
@@ -20,6 +20,14 @@ const CLEAN_CLOSE_CODES = new Set([1000, 1001])
 const module = initModule('ws-session')
 let log!: CS.Logger
 
+// Without an application-level ping the server cannot tell a live-but-quiet socket from a half-open one
+// (a client whose network dropped or machine slept): the OS keeps the dead connection around for its own
+// keepalive window (~2h), so presence counts a ghost as `connected` the whole time. Pinging on an interval
+// and terminating anything that misses the next round's pong (browsers answer ping frames automatically)
+// bounds that to one interval -- the `ws` library's documented liveness pattern.
+const PING_INTERVAL = 30_000
+const socketAlive = new WeakMap<C.OrpcSessionBase['ws'], boolean>()
+
 const meter = metrics.getMeter('ws-session')
 meter.createObservableGauge(ATTRS.WebSocket.CONNECTED_CLIENTS, {
 	description: 'Number of currently connected WebSocket clients',
@@ -74,6 +82,33 @@ function instrumentSocketIo(ws: C.OrpcSessionBase['ws']) {
 
 export function setup() {
 	log = module.getLogger()
+	setInterval(() => {
+		for (const ctx of wsSessions.values()) {
+			if (socketAlive.get(ctx.ws) === false) {
+				// missed the previous round's pong: the socket is half-open. Terminating it runs the close path
+				// (abnormal -> interrupted), so presence stops counting it as connected.
+				log.info('%s (%s) missed keepalive pong, terminating', ctx.user.username, ctx.wsClientId)
+				ctx.ws.terminate()
+				continue
+			}
+			socketAlive.set(ctx.ws, false)
+			try {
+				ctx.ws.ping()
+			} catch { /* socket already closing */ }
+		}
+	}, PING_INTERVAL).unref()
+}
+
+// A reconnecting client is reclaiming this id (see reclaimClientId): if a stale socket is still parked on it
+// -- its close not yet detected, e.g. a half-open connection -- drop it from tracking and terminate it so the
+// reclaiming socket can register the id cleanly. The stale socket's later close is a no-op (see registerClient).
+export function evictStaleSocket(wsClientId: string) {
+	const stale = wsSessions.get(wsClientId)
+	if (!stale) return
+	wsSessions.delete(wsClientId)
+	try {
+		stale.ws.terminate()
+	} catch { /* already dead */ }
 }
 
 export function registerClient(ctx: C.OrpcSessionBase) {
@@ -83,9 +118,14 @@ export function registerClient(ctx: C.OrpcSessionBase) {
 	}
 
 	wsSessions.set(ctx.wsClientId, ctx)
+	socketAlive.set(ctx.ws, true)
+	ctx.ws.on('pong', () => socketAlive.set(ctx.ws, true))
 	connectionCounter.add(1)
 	instrumentSocketIo(ctx.ws)
 	ctx.ws.on('close', (code) => {
+		// A stale socket whose id was reclaimed by a reconnect must not tear down the live session now holding
+		// that id: only act if we're still the registered owner.
+		if (wsSessions.get(ctx.wsClientId) !== ctx) return
 		const interrupted = !CLEAN_CLOSE_CODES.has(code)
 		log.info('%s has disconnected (%s) code=%d interrupted=%s', ctx.user.username, ctx.wsClientId, code, interrupted)
 		disconnect$.next({ ctx, interrupted })


### PR DESCRIPTION
Two related fixes for how the app behaves around websocket reconnects after a tab has been idle/backgrounded.

## 1. Graceful reconnect UX (returning to an idle tab)

Returning to a backgrounded SLM tab reliably flashed a "Lost connection... reconnecting" toast even though recovery was fine. Neither partysocket nor our code proactively disconnects on tab-hidden; the socket is dropped externally while backgrounded, surfaces as a `close` around refocus, and partysocket then waits `minReconnectionDelay` (1-5s) before its first retry -- always past the 750ms grace window.

- On `visibilitychange` -> visible, force an immediate `websocket.reconnect()` (resets partysocket's backoff to 0) so recovery is near-instant.
- Gate the disconnect toast behind tab visibility + a short refocus grace window: the expected idle-drop stays silent, a genuine outage during active use is still reported, and if the tab goes hidden before recovery the toast is dismissed rather than left claiming a reconnect that didn't happen.

## 2. Reclaim the wsClientId in place + keepalive ping

A reconnect could also leave a stale duplicate presence entry, firing a false "Other sessions active" toast against the *same* client. Root cause: with no app-level keepalive the server can't distinguish a live-but-quiet socket from a half-open one, so a socket dropped while backgrounded lingers as `connected` (up to the OS keepalive window, ~2h). The reconnecting socket couldn't reclaim it (reclaim only matched `connection-interrupted` entries), minted a fresh id, and the stale `connected` ghost read as a second session.

- Client sends the id it last held as `?prior=` on every (re)connect.
- `reclaimClientId(userId, priorClientId)` reclaims that exact entry whether it is still `connected` or already `interrupted` (scoped to the user's own ids) and evicts any stale socket parked on it.
- `registerClient`'s close handler is now identity-aware: a superseded stale socket's later close no longer tears down the live session holding its id.
- Keepalive ping every 30s terminates sockets that miss a pong, bounding a half-open ghost's lifetime to one interval (backstop for clients that never reconnect).

### Verification

Fix #2 verified end-to-end against a dev instance (server logs + browser): a reconnect reuses the same wsClientId, the stale socket is evicted (`close 1006`), no spurious disconnect fires for the reclaimed id, and no false toast appears. Fix #1 verified: app boots/connects cleanly on the new url-provider, single-session shows no toast.

No persisted data / config / schema changes.

## Dev server

- App/login: http://localhost:3100/?login=<username> (any user in the cloned db; hit :3100 first to set the cookie), then the client at http://localhost:3101

🤖 Generated with [Claude Code](https://claude.com/claude-code)