### PR TITLE
Fix filter builder overflow: wrap comparison rows, ShortLayerName for layer ids

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -717,7 +717,7 @@ IMMEDIATE`/`COMMIT`/`ROLLBACK`. Re-entrant: an inner transaction joins the outer
 rolls back the outer. Therefore, all transactions may wait for others to complete asyncronously,
 but are always executed syncronously once the lock is acquired.
 
-Because that lock is process-wide, **a `runTransaction` callback must never await anything but a query.**(This isn't 
+Because that lock is process-wide, **a `runTransaction` callback must never await anything but a query.**(This isn't
 great, and there's probably a better way to do this while still using drizzle.) Queries
 resolve immediately (the driver is synchronous), so a transaction that only queries holds the lock for microseconds.
 Awaiting rcon, discord, sftp, or any other network call inside one instead stalls every write in the process for the

--- a/src/components/combo-box/combo-box-multi.tsx
+++ b/src/components/combo-box/combo-box-multi.tsx
@@ -27,6 +27,9 @@ export type ComboBoxMultiProps<T extends string | null = string | null> = {
 	onSelect?: React.Dispatch<React.SetStateAction<T[]>>
 	ref?: React.ForwardedRef<ComboBoxHandle>
 	restrictValueSize?: boolean
+	// render the selection as wrapping chips in the trigger instead of one ellipsis-clipped line. with
+	// restrictValueSize the chip area caps its height and scrolls; otherwise it grows with the selection.
+	chipDisplay?: boolean
 	selectOnClose?: boolean
 	reset?: boolean | T[]
 	confirm?: boolean | string
@@ -150,8 +153,10 @@ export default function ComboBoxMulti<T extends string | null>(props: ComboBoxMu
 		|| displayValues.some(v => !confirmedSet.has(v))
 	)
 
+	const chipDisplay = props.chipDisplay ?? false
 	let valuesDisplay = ''
-	if (!props.children) {
+	// chip mode renders each selection as its own node, so only the empty-state text is precomputed here
+	if (!props.children && !(chipDisplay && displayValues.length > 0)) {
 		if (displayValues.length > 0) {
 			const displayText = displayValues
 				.map((value) => {
@@ -166,6 +171,7 @@ export default function ComboBoxMulti<T extends string | null>(props: ComboBoxMu
 			valuesDisplay = props.emptyLabel ?? 'Select...'
 		}
 	}
+	const showChips = chipDisplay && displayValues.length > 0
 	const trigger = (
 		<PopoverTrigger asChild>
 			{props.children ?? (
@@ -181,12 +187,43 @@ export default function ComboBoxMulti<T extends string | null>(props: ComboBoxMu
 					// push out of a flex container instead of truncating inside it.
 					// props.className goes last so a caller's width can beat these defaults -- cn merges
 					// tailwind conflicts last-wins, so the old ordering silently dropped them
-					className={cn(restrictValueSize ? 'max-w-[400px]' : 'max-w-full', 'min-w-0 justify-between font-mono', props.className)}
+					// chip mode grows multiline as the selection wraps, so let the button size to its content
+					// (h-auto) and top-align the chevron; the parent decides how much room it gets
+					className={cn(
+						restrictValueSize ? 'max-w-[400px]' : 'max-w-full',
+						'min-w-0 justify-between font-mono',
+						showChips && 'h-auto min-h-9 items-start py-1',
+						props.className,
+					)}
 				>
-					<span className="grow overflow-hidden text-ellipsis">
-						{valuesDisplay}
-					</span>
-					<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+					{showChips
+						? (
+							<span className="flex grow flex-wrap items-center gap-1">
+								{displayValues.map((value) => {
+									const option = optionsByValue.get(value)
+									const label = option ? (option.label ?? option.value) : value
+									return (
+										<span
+											key={value === null ? NULL.current : value}
+											className="inline-flex items-center rounded bg-secondary px-1.5 py-0.5 text-xs font-normal"
+										>
+											{label === null ? DisplayHelpers.NULL_DISPLAY : label}
+										</span>
+									)
+								})}
+								{selectionLimit && (
+									<span className="self-center text-xs text-muted-foreground">
+										({displayValues.length}/{selectionLimit})
+									</span>
+								)}
+							</span>
+						)
+						: (
+							<span className="grow overflow-hidden text-ellipsis">
+								{valuesDisplay}
+							</span>
+						)}
+					<ChevronsUpDown className={cn('ml-2 h-4 w-4 shrink-0 opacity-50', showChips && 'mt-1 self-start')} />
 				</Button>
 			)}
 		</PopoverTrigger>

--- a/src/components/filter-card.tsx
+++ b/src/components/filter-card.tsx
@@ -1,7 +1,6 @@
 import * as EditFrame from '@/frames/filter-editor.frame.ts'
 import type * as SquadServerFrame from '@/frames/squad-server.frame.ts'
 import * as Arr from '@/lib/array.ts'
-import * as DH from '@/lib/display-helpers'
 import * as Obj from '@/lib/object.ts'
 import type { Clearable, Focusable } from '@/lib/react'
 import { eltToFocusable } from '@/lib/react'
@@ -29,6 +28,7 @@ import { FilterEntityLabel } from './filter-entity-select.tsx'
 import type { FilterTextEditorHandle } from './filter-text-editor.types'
 import { NodePortal, StoredParentNode } from './node-map.tsx'
 import SelectLayersDialog from './select-layers-dialog.tsx'
+import ShortLayerName from './short-layer-name.tsx'
 import { Button, buttonVariants } from './ui/button'
 import { ButtonGroup } from './ui/button-group'
 import { Input } from './ui/input'
@@ -111,7 +111,7 @@ export default function FilterCard(props: FilterCardProps & { children: React.Re
 
 	const rendered = (
 		<div defaultValue="builder" className="w-full space-x-2 flex">
-			<div className="flex-1">
+			<div className="flex-1 min-w-0 overflow-x-auto">
 				<div className={activeTab === 'builder' ? '' : 'hidden'}>
 					<StoredParentNode nodeId={rootNodeId} store={nodeStore} />
 				</div>
@@ -384,7 +384,7 @@ const NodeWrapper = (
 					>
 						<Icons.GripVertical />
 					</button>
-					<div className={className}>
+					<div className={cn('min-w-0', className)}>
 						{children}
 					</div>
 				</>
@@ -416,7 +416,7 @@ export function LeafFilterNode(props: NodeProps) {
 
 	if (F.isCompNode(node)) {
 		return (
-			<NodeWrapper path={nodePath} className="flex items-center space-x-1" nodeId={props.nodeId}>
+			<NodeWrapper path={nodePath} className="flex flex-wrap items-center gap-1" nodeId={props.nodeId}>
 				<CompNodeConfig nodeId={props.nodeId} stores={props.stores} node={node} />
 				{opCluster}
 			</NodeWrapper>
@@ -424,7 +424,7 @@ export function LeafFilterNode(props: NodeProps) {
 	}
 	if (F.isMatchupNode(node)) {
 		return (
-			<NodeWrapper path={nodePath} className="flex items-center space-x-1" nodeId={props.nodeId}>
+			<NodeWrapper path={nodePath} className="flex flex-wrap items-center gap-1" nodeId={props.nodeId}>
 				<MatchupNodeConfig nodeId={props.nodeId} stores={props.stores} node={node} />
 				{opCluster}
 			</NodeWrapper>
@@ -432,7 +432,7 @@ export function LeafFilterNode(props: NodeProps) {
 	}
 	if (F.isApplyFilterNode(node)) {
 		return (
-			<NodeWrapper path={nodePath} className="flex items-center space-x-1" nodeId={props.nodeId}>
+			<NodeWrapper path={nodePath} className="flex flex-wrap items-center gap-1" nodeId={props.nodeId}>
 				<ComboBox
 					allowEmpty={false}
 					title="mode"
@@ -1150,7 +1150,7 @@ function MatchupNodeConfig(props: { nodeId: string; stores: EditFrame.KeyProp; n
 	// between those very labels, so reusing them here would read as driving it.
 	const [leftLabel, rightLabel] = node.locked ? ['Team 1', 'Team 2'] : ['One side', 'Other side']
 	return (
-		<div className="flex items-center space-x-2">
+		<div className="flex flex-wrap items-center gap-2">
 			<ComboBox
 				allowEmpty={false}
 				className="w-min"
@@ -1227,7 +1227,7 @@ function InListConfig(
 	const addableColumns = props.comparableColumns.filter((o) => !columns.some((c) => c.column === o.value))
 
 	return (
-		<div className={cn(props.className, 'flex items-center space-x-1')}>
+		<div className={cn(props.className, 'flex flex-wrap items-center gap-1')}>
 			<StringInConfig
 				ref={props.ref}
 				column={props.column}
@@ -1276,16 +1276,16 @@ function LayersInConfig(
 	return (
 		<div className={cn(props.className, 'space-y-2')}>
 			{filteredValues.length > 0 && (
-				<ul className="flex items-center space-x-1">
+				<ul className="flex flex-wrap items-center gap-1">
 					{filteredValues.map((layerId) => (
-						<li key={layerId} className="flex items-center justify-between px-2 py-1 bg-secondary rounded-md">
-							<span className="text-sm">{DH.displayLayer(layerId)}</span>
+						<li key={layerId} className="flex min-w-0 items-center justify-between gap-1 px-2 py-1 bg-secondary rounded-md">
+							<ShortLayerName layerId={layerId} allowShowInfo={false} className="text-sm" />
 							<Button
 								size="sm"
 								variant="ghost"
 								onClick={() =>
 									removeValue(layerId)}
-								className="h-6 w-6 p-0 hover:bg-destructive/20 hover:text-destructive"
+								className="h-6 w-6 shrink-0 p-0 hover:bg-destructive/20 hover:text-destructive"
 							>
 								<Minus className="h-3 w-3" />
 							</Button>
@@ -1322,10 +1322,10 @@ export function LayerEqConfig(
 	const [open, setOpen] = React.useState(false)
 
 	return (
-		<div className="flex space-x-2 items-center">
-			<Button className="flex items-center space-x-1" variant="ghost" onClick={() => setOpen(true)}>
-				{props.value !== null && DH.displayLayer(props.value)}
-				<Icons.Edit />
+		<div className="flex min-w-0 flex-wrap space-x-2 items-center">
+			<Button className="flex h-auto min-w-0 flex-wrap items-center gap-1" variant="ghost" onClick={() => setOpen(true)}>
+				{props.value !== null && <ShortLayerName layerId={props.value} allowShowInfo={false} />}
+				<Icons.Edit className="shrink-0" />
 			</Button>
 			<EditLayerDialog
 				open={open}

--- a/src/components/filter-card.tsx
+++ b/src/components/filter-card.tsx
@@ -1101,6 +1101,7 @@ function StringInConfig(
 			onSelect={props.setValues}
 			className={props.className}
 			restrictValueSize={props.restrictValueSize}
+			chipDisplay
 		/>
 	)
 }
@@ -1279,7 +1280,7 @@ function LayersInConfig(
 				<ul className="flex flex-wrap items-center gap-1">
 					{filteredValues.map((layerId) => (
 						<li key={layerId} className="flex min-w-0 items-center justify-between gap-1 px-2 py-1 bg-secondary rounded-md">
-							<ShortLayerName layerId={layerId} allowShowInfo={false} className="text-sm" />
+							<ShortLayerName layerId={layerId} className="text-sm" />
 							<Button
 								size="sm"
 								variant="ghost"
@@ -1322,9 +1323,9 @@ export function LayerEqConfig(
 	const [open, setOpen] = React.useState(false)
 
 	return (
-		<div className="flex min-w-0 flex-wrap space-x-2 items-center">
-			<Button className="flex h-auto min-w-0 flex-wrap items-center gap-1" variant="ghost" onClick={() => setOpen(true)}>
-				{props.value !== null && <ShortLayerName layerId={props.value} allowShowInfo={false} />}
+		<div className="flex min-w-0 flex-wrap items-center gap-1">
+			{props.value !== null && <ShortLayerName layerId={props.value} />}
+			<Button size="icon" variant="ghost" aria-label="Change layer" onClick={() => setOpen(true)}>
 				<Icons.Edit className="shrink-0" />
 			</Button>
 			<EditLayerDialog


### PR DESCRIPTION
## Problem

Long value lists in the filter builder overflowed the builder column horizontally and got clipped by an ancestor `overflow-hidden` (chips cut off at the right edge). Reproduces with a big `id in` layer list, `Map`/faction `in` selections, and matchup team specs at narrow widths.

## Changes

### Overflow (`filter-card.tsx`)
- **Wrap comparison rows**: comp / matchup / apply-filter leaf rows now use `flex-wrap` + `gap` instead of a single non-wrapping `space-x` line.
- **Constrain the builder column**: gave the builder column `min-w-0` so the wrap is bounded by the available width (a `flex-1` child defaults to `min-width:auto` and expands past its container), plus `overflow-x-auto` as a fallback so any single unbreakable row scrolls within the column rather than being clipped by the page.
- **Wrap chip lists**: the `id in` layer chip list and the `in`-list column-reference chips now wrap.

### Layer id rendering (`filter-card.tsx`)
- Hardcoded layer ids (`id eq` value, `id in` chips) render with `ShortLayerName` (wraps internally, shows the map + faction breakdown) instead of the flat `displayLayer` string.
- **Click a layer to open its details window**: `ShortLayerName`'s default click-to-open behavior is kept. `LayerEqConfig` renders the layer name outside the edit button (a separate pencil opens the layer picker) so the name stays clickable without nesting buttons; the `id in` chips no longer suppress it.

### Chip-style multi-select trigger (`combo-box-multi.tsx`)
- New opt-in `chipDisplay` prop renders the selection as wrapping chips in the trigger instead of one ellipsis-clipped line. It grows multiline as the selection wraps, so the parent decides how much vertical room it gets. Enabled for the filter's `StringInConfig` (Map/faction `in`, matchup team specs).

## Verification

Drove the running dev instance and measured the DOM:
- `id in` with 14 layers wraps within the builder column at 1900px, 820px, and a forced 700px container; `pageOverflowX == 0` and every chip stays within bounds (before the fix the list was 1020px inside a 768px column and clipped).
- Clicking a layer chip opens the layer-details draggable window.
- `Map in` with all 24 maps selected renders as wrapping chips (2 rows), grows multiline, stays within the viewport, `pageOverflowX == 0`.
- Matchup block wraps its fixed-width team-spec boxes at narrow widths.

Clean-merged onto latest `main` (which independently fixed the `id in` layer-select trigger); both changes coexist.

**Dev server (this worktree):** http://localhost:3121/filters/anti-main-pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)