### PR TITLE
Extend category selection to the admin cam icon

### DIFF
--- a/src/components/player-context-menu-options.tsx
+++ b/src/components/player-context-menu-options.tsx
@@ -258,6 +258,7 @@ export function PlayerMenuItems(
 				isCommander: player.isLeader && squad?.squadName === 'Command Squad',
 				isLeader: player.isLeader,
 				isAdmin: player.isAdmin,
+				inAdminCam: ChatPrt.Sel.chatState(chatStore).adminCamPlayerIds.includes(playerId),
 			}
 		},
 	)
@@ -613,6 +614,16 @@ export function PlayerMenuItems(
 				>
 					Admins
 					<ContextMenuShortcut>{sc('⇧+click admin badge', '⇧+Ctrl+click admin badge')}</ContextMenuShortcut>
+				</Item>
+				<Item
+					disabled={!playerInfo?.inAdminCam || teamMissing}
+					onClick={() => {
+						TSWClient.Actions.ensureViewingTeams(serverId)
+						SquadServerFrame.Actions.selectAllInAdminCam(stores, teamId)
+					}}
+				>
+					In Admin Cam
+					<ContextMenuShortcut>{sc('⇧+click camera icon', '⇧+Ctrl+click camera icon')}</ContextMenuShortcut>
 				</Item>
 				<Item
 					disabled={!isOnServer || teamMissing}

--- a/src/components/teams-panel.tsx
+++ b/src/components/teams-panel.tsx
@@ -767,7 +767,15 @@ function nameColumn<T extends TeamsPanelModels.EnrichedPlayer>(helper: ColumnHel
 				<span onClick={e => e.stopPropagation()} className="inline-flex items-center gap-1">
 					<PlayerDisplay stores={meta.stores} player={row.original} matchId={meta.matchId} disableContextMenu />
 					{row.original.inAdminCam && (
-						<span title="In admin camera">
+						<span
+							title="In admin camera. Shift+click: select this team's players in admin cam. Shift+Ctrl+click: both teams"
+							onClickCapture={e => {
+								if (!e.shiftKey) return
+								e.preventDefault()
+								e.stopPropagation()
+								SquadServerFrame.Actions.selectAllInAdminCam(meta.stores, e.ctrlKey ? undefined : row.original.teamId ?? undefined)
+							}}
+						>
 							<Icons.Camera className="h-3 w-3 text-purple-500 shrink-0" />
 						</span>
 					)}

--- a/src/frames/squad-server.frame.ts
+++ b/src/frames/squad-server.frame.ts
@@ -243,6 +243,16 @@ export namespace Actions {
 		)
 	}
 
+	export function selectAllInAdminCam(stores: KeyProp, teamId?: SM.TeamId) {
+		const chatState = ChatPrt.Sel.chatState(ZusUtils.getState(stores.squadServer!))
+		selectPlayers(
+			stores,
+			chatState.players
+				.filter(p => chatState.adminCamPlayerIds.includes(SM.PlayerIds.getPlayerId(p.ids)) && (teamId == null || p.teamId === teamId))
+				.map(p => SM.PlayerIds.getPlayerId(p.ids)),
+		)
+	}
+
 	export function selectAllWithRole(stores: KeyProp, role: string, teamId?: SM.TeamId) {
 		const players = ChatPrt.Sel.chatState(ZusUtils.getState(stores.squadServer!)).players
 		selectPlayers(


### PR DESCRIPTION
Extends the shift+click / ctrl+shift+click category-selection pattern (as on the admin badge) to the admin cam camera icon in the teams panel, and adds a matching context menu entry.

- New `SquadServerFrame.Actions.selectAllInAdminCam(stores, teamId?)` filtering players against `adminCamPlayerIds`
- Camera icon in the teams-panel name cell: shift+click selects that team's players in admin cam, shift+ctrl+click selects across both teams (title text updated to advertise it)
- Player context menu > Select from Team / Select All: new **In Admin Cam** item, disabled when the clicked player isn't in admin cam, with the shortcut hint

Verified in a worktree dev instance against the emulator: put Alice (team 1) and Bob (team 2) in admin cam via `emuctl cam`, confirmed shift+click selects only the clicked team's cam players, shift+ctrl+click selects both, and the context menu entry selects correctly and disables for players not in cam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)