### PR TITLE
Label the secondary filter lists as one "Secondary Filters" section

### DIFF
--- a/src/components/pool-config-panels.tsx
+++ b/src/components/pool-config-panels.tsx
@@ -360,8 +360,21 @@ export function PoolFiltersPanel({ api }: { api: PoolConfigApi }) {
 	return (
 		<div className="space-y-4">
 			<PoolFilterSection api={api} />
-			<div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-				{SECONDARY_LISTS.map((config) => <SecondaryFilterList key={config.key} api={api} config={config} />)}
+			<div className="space-y-3">
+				<span className="flex items-center gap-1">
+					<h4 className={cn(Typography.H4, 'text-sm font-medium text-muted-foreground')}>Secondary Filters</h4>
+					<HelpTooltip label="About secondary filters">
+						<p>
+							Secondary filters never decide what is in the pool; they add behavior on top of it: displaying match or miss indicators on
+							layers, being offered during layer selection, warning when a matching layer is queued or about to be played, and further
+							constraining autogeneration.
+						</p>
+						<p>A filter can appear in several of these lists at once.</p>
+					</HelpTooltip>
+				</span>
+				<div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+					{SECONDARY_LISTS.map((config) => <SecondaryFilterList key={config.key} api={api} config={config} />)}
+				</div>
 			</div>
 		</div>
 	)


### PR DESCRIPTION
## Summary

Follow-up to #63: the five lists after the pool filter (indicate matches/misses, default selectable, warn for, constrain generation) are now grouped under a single "Secondary Filters" heading, styled like the Pool Filter heading, with a `?` help tooltip explaining that secondary filters add behavior on top of the pool without ever deciding membership, and that a filter can appear in several lists at once.

UI-only, no model or behavior changes.

Dev instance with the change up (worktree slot 3): http://localhost:3131/servers/tt-scrim-2?login=grey275 (open the gear next to Start Editing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhmwZAQDUu4E3r7Mu53Sfz