### PR TITLE
Stamp the owning build into the db so restore names the image to pin

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -126,7 +126,8 @@ Backups happen for two reasons. One of them is not optional.
 **Before every migration**, always, the database is snapshotted into `BACKUPS_DIR` first. This happens whether
 the app applies migrations itself at boot (`DB_AUTOMIGRATE`, the default) or you run `pnpm db:migrate:prod`
 yourself, and it is what you restore from if an upgrade turns out to have been a mistake. Nothing is applied if
-the snapshot fails. These are named `slm-backup-db-pre-migration-20260713-134504.sqlite3.gz`, and the most
+the snapshot fails. These are named `slm-backup-db-pre-migration-a6047f44deb0-20260713-134504.sqlite3.gz` (the sha is the version being
+upgraded _from_, which is the one a rollback wants), and the most
 recent one is never deleted by retention, however old it gets: it is the only way back from the migration it
 was taken before.
 
@@ -169,15 +170,21 @@ A failed upload does not fail the backup. The local copy is still written, and t
 `restore.sh` stops the app, puts a backup back, and starts it again:
 
 ```sh
-./restore.sh --list                   # what backups there are
+./restore.sh --list                   # what backups there are, and the build each belongs to
 ./restore.sh --inspect --latest       # which build a backup belongs to, without restoring it
 ./restore.sh --pre-migration          # the snapshot taken before the last migration: undo a bad upgrade
 ./restore.sh --latest                 # the newest backup of any kind
-./restore.sh --from slm-backup-db-20260713-134504.sqlite3.gz    # a specific one
+./restore.sh --commit-sha commit-a6047f4    # the newest backup taken by a given build
+./restore.sh --from slm-backup-db-a6047f44deb0-20260713-134504.sqlite3.gz    # a specific one
 ```
 
 `--from` also takes a path, which is how you restore a backup fetched back off the SFTP target. Drop it in
 `data/backups` or pass the full path.
+
+Each backup's filename carries the short git sha of the build that owned the database when it was taken (e.g.
+`slm-backup-db-a6047f44deb0-...`), so `--list` shows the build and `--commit-sha` can pick the newest backup from a
+particular version. `--commit-sha` accepts a full sha, a short one, or a `commit-<sha>` image tag, and pairs with
+`--pre-migration` to restrict the search to pre-migration snapshots.
 
 `--inspect` pairs with a backup selector (`--latest`, `--pre-migration`, `--from`) and changes nothing: it unpacks
 the backup, reports which app build the database belongs to and which image tag to pin, and how far behind the

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -141,8 +141,30 @@ The two share a schedule and a retention window rather than running as separate 
 migrate counts as that interval's backup (it is uploaded and recorded like any other), so an upgrade doesn't
 produce two copies of the same database a minute apart, and the next periodic one is a full interval later.
 
-Backups are named after the database they came from, e.g. `slm-backup-db-20260713-134504.sqlite3.gz`.
-Each run is recorded in the audit log as a `BACKUP_CREATED` event.
+Backups are named after the database they came from, so two instances writing to one directory can't be confused
+and retention only ever prunes its own. The full format is:
+
+```
+slm-backup-<db>[-pre-migration]-<sha>-<yyyyMMdd>-<HHmmss>.sqlite3.gz
+```
+
+For example:
+
+```
+slm-backup-db-a6047f44deb0-20260713-134504.sqlite3.gz                 a periodic backup
+slm-backup-db-pre-migration-9c1f0a2b3d4e-20260713-134016.sqlite3.gz   taken before a migration
+```
+
+| segment               | meaning                                                                                                                                                                                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `slm-backup-`         | fixed prefix marking an SLM backup                                                                                                                                                                                                                              |
+| `<db>`                | the source database's filename without extension (`db` for `db.sqlite3`). Retention only deletes names matching this, so distinct db names keep two instances sharing a directory from pruning each other's backups                                             |
+| `-pre-migration`      | present only on the snapshot taken before a migration, absent on periodic backups. It is what lets retention pin the newest pre-migration backup and never age it out                                                                                           |
+| `<sha>`               | short git sha of the build that owned the database when the snapshot was taken (recorded inside it, see `_slm_meta`). For a pre-migration backup this is the version being upgraded _from_, the one to roll back to. `unknown` if the database carried no stamp |
+| `<yyyyMMdd>-<HHmmss>` | when it was taken, which sorts chronologically                                                                                                                                                                                                                  |
+| `.sqlite3.gz`         | a gzipped SQLite database                                                                                                                                                                                                                                       |
+
+Each run is also recorded in the audit log as a `BACKUP_CREATED` event.
 
 It's also possible to configure an SFTP destination for the backups. See below.
 
@@ -181,10 +203,10 @@ A failed upload does not fail the backup. The local copy is still written, and t
 `--from` also takes a path, which is how you restore a backup fetched back off the SFTP target. Drop it in
 `data/backups` or pass the full path.
 
-Each backup's filename carries the short git sha of the build that owned the database when it was taken (e.g.
-`slm-backup-db-a6047f44deb0-...`), so `--list` shows the build and `--commit-sha` can pick the newest backup from a
-particular version. `--commit-sha` accepts a full sha, a short one, or a `commit-<sha>` image tag, and pairs with
-`--pre-migration` to restrict the search to pre-migration snapshots.
+Because the filename carries the owning build's sha (see the breakdown above), `--list` shows the build and
+`--commit-sha` can pick the newest backup from a particular version without unpacking anything. `--commit-sha`
+accepts a full sha, a short one, or a `commit-<sha>` image tag, and pairs with `--pre-migration` to restrict the
+search to pre-migration snapshots.
 
 `--inspect` pairs with a backup selector (`--latest`, `--pre-migration`, `--from`) and changes nothing: it unpacks
 the backup, reports which app build the database belongs to and which image tag to pin, and how far behind the

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -169,14 +169,20 @@ A failed upload does not fail the backup. The local copy is still written, and t
 `restore.sh` stops the app, puts a backup back, and starts it again:
 
 ```sh
-./restore.sh --list             # what backups there are
-./restore.sh --pre-migration    # the snapshot taken before the last migration: undo a bad upgrade
-./restore.sh --latest           # the newest backup of any kind
+./restore.sh --list                   # what backups there are
+./restore.sh --inspect --latest       # which build a backup belongs to, without restoring it
+./restore.sh --pre-migration          # the snapshot taken before the last migration: undo a bad upgrade
+./restore.sh --latest                 # the newest backup of any kind
 ./restore.sh --from slm-backup-db-20260713-134504.sqlite3.gz    # a specific one
 ```
 
 `--from` also takes a path, which is how you restore a backup fetched back off the SFTP target. Drop it in
 `data/backups` or pass the full path.
+
+`--inspect` pairs with a backup selector (`--latest`, `--pre-migration`, `--from`) and changes nothing: it unpacks
+the backup, reports which app build the database belongs to and which image tag to pin, and how far behind the
+current build it is. Run it first when rolling back an upgrade, so you know which version to point
+`docker-compose.yaml` at before you start the app.
 
 The database being replaced is kept, renamed to `db.sqlite3.replaced-<timestamp>` next to it, because a restore
 is otherwise the one operation with no undo. Delete it once you are happy. The restore is checked
@@ -189,7 +195,9 @@ the app goes on writing to a database that is no longer at that path, and those 
 
 If you are rolling back a bad upgrade, roll the image back too. Restoring a pre-migration backup and then
 starting the same version just applies the same migration again (the restore says so if the database it put
-back is behind the build).
+back is behind the build). Each database is stamped with the git sha and branch of the app that last ran
+against it, so the restore (and `--inspect`) names the exact image tag to pin -- for a pre-migration snapshot
+that is the version you were upgrading _from_, which is the one to roll back to.
 
 #### 3.7. Event history retention
 

--- a/restore.sh
+++ b/restore.sh
@@ -2,6 +2,7 @@
 # Restore the database from a backup, stopping the app around it.
 #
 #   ./restore.sh --list                  what backups there are
+#   ./restore.sh --inspect --latest      which build a backup belongs to (which image to pin), without restoring it
 #   ./restore.sh --pre-migration         the snapshot taken before the last migration (undo a bad upgrade)
 #   ./restore.sh --latest                the newest backup of any kind
 #   ./restore.sh --from <file>           a specific one, e.g. one pulled back off the sftp target into ./data/backups
@@ -16,9 +17,9 @@ cd "$(dirname "$0")"
 command -v docker > /dev/null 2>&1 || { echo "error: docker is required" >&2; exit 1; }
 docker compose version > /dev/null 2>&1 || { echo "error: docker compose (v2) is required" >&2; exit 1; }
 
-# --list reads the backups directory and touches nothing, so it has no business stopping anybody's app
+# --list and --inspect touch neither the live database nor the app, so they have no business stopping anybody's app
 for arg in "$@"; do
-	if [[ $arg == --list ]]; then
+	if [[ $arg == --list || $arg == --inspect ]]; then
 		exec docker compose run --rm app pnpm db:restore:prod "$@"
 	fi
 done

--- a/restore.sh
+++ b/restore.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Restore the database from a backup, stopping the app around it.
 #
-#   ./restore.sh --list                  what backups there are
+#   ./restore.sh --list                  what backups there are (with the build each belongs to)
 #   ./restore.sh --inspect --latest      which build a backup belongs to (which image to pin), without restoring it
 #   ./restore.sh --pre-migration         the snapshot taken before the last migration (undo a bad upgrade)
 #   ./restore.sh --latest                the newest backup of any kind
+#   ./restore.sh --commit-sha <sha>      the newest backup taken by a given build (a git sha or commit-<sha> tag)
 #   ./restore.sh --from <file>           a specific one, e.g. one pulled back off the sftp target into ./data/backups
 #
 # The app must not be running: it would go on writing to the database being replaced and lose those writes, without

--- a/src/scripts/restore.ts
+++ b/src/scripts/restore.ts
@@ -1,5 +1,7 @@
+import { formatVersion } from '@/lib/versioning'
 import { tsMigrations } from '@/migrations/registry'
 import * as DbBackup from '@/server/db-backup'
+import * as DbMeta from '@/server/db-meta'
 import * as Env from '@/server/env'
 import * as Migrate from '@/server/migrate'
 import DatabaseConstructor, { type Database } from 'better-sqlite3'
@@ -22,6 +24,7 @@ import * as Zlib from 'node:zlib'
 const args = parseArgs({
 	options: {
 		list: { type: 'boolean', default: false },
+		inspect: { type: 'boolean', default: false },
 		'pre-migration': { type: 'boolean', default: false },
 		latest: { type: 'boolean', default: false },
 		from: { type: 'string' },
@@ -102,6 +105,28 @@ function fail(msg: string): never {
 	process.exit(1)
 }
 
+// Reports which build a backup belongs to and how far behind the current code it is, without replacing anything --
+// the answer to "which image do I pin?" before committing to the restore. Unpacks to a temp file next to the db and
+// removes it again, so it needs the disk space but neither stops the app nor touches the live database.
+async function inspect(backup: Candidate) {
+	console.log(`inspecting ${describe(backup)}\n`)
+	const tmpPath = `${DB_PATH}.inspect-${process.pid}.tmp`
+	rmDbFiles(tmpPath)
+	try {
+		await gunzipTo(backup.path, tmpPath)
+		assertIntact(tmpPath)
+		console.log(pinGuidance(buildStampOf(tmpPath)))
+		const pending = pendingAfterRestore(tmpPath)
+		console.log(
+			pending.length > 0
+				? `It is ${pending.length} migration(s) behind the current build (${pending.join(', ')}).`
+				: 'It is up to date with the current build.',
+		)
+	} finally {
+		rmDbFiles(tmpPath)
+	}
+}
+
 async function gunzipTo(sourcePath: string, destPath: string) {
 	await Stream.pipeline(fs.createReadStream(sourcePath), Zlib.createGunzip(), fs.createWriteStream(destPath))
 }
@@ -130,6 +155,35 @@ function pendingAfterRestore(dbPath: string) {
 	} finally {
 		db.close()
 	}
+}
+
+// the build a backup belongs to, stamped into the db by the app that last ran against it. null for a backup taken
+// before stamping existed, or one pulled off a database that never booted the app.
+function buildStampOf(dbPath: string): DbMeta.BuildStamp | null {
+	const db = new DatabaseConstructor(dbPath, { readonly: true })
+	try {
+		return DbMeta.readBuildStamp(db)
+	} finally {
+		db.close()
+	}
+}
+
+// CI publishes every commit as `commit-<first 7 of sha>` (see .github/workflows/docker-ci.yml). null when the stamp
+// isn't a git sha we can turn into a tag (e.g. an "unknown" build with no GIT_SHA baked in).
+function imageTagFor(sha: string): string | null {
+	return /^[0-9a-f]{7,40}$/i.test(sha) ? `commit-${sha.slice(0, 7)}` : null
+}
+
+// the line(s) telling the operator which image this backup belongs to, so they can pin it before starting the app.
+function pinGuidance(stamp: DbMeta.BuildStamp | null): string {
+	if (!stamp) {
+		return 'This backup carries no build stamp (it predates version stamping); use the migration gap reported here to work out which image to pin.'
+	}
+	const tag = imageTagFor(stamp.gitSha)
+	const version = formatVersion(stamp.gitBranch, stamp.gitSha)
+	return tag
+		? `This backup belongs to build ${version}. Pin the \`${tag}\` image tag in docker-compose.yaml before starting the app.`
+		: `This backup belongs to build ${version}, which has no published image tag; match the image to it before starting the app.`
 }
 
 async function confirm(question: string) {
@@ -180,6 +234,12 @@ if (!args.values.from && !args.values['pre-migration'] && !args.values.latest) {
 }
 
 const backup = pick()
+
+if (args.values.inspect) {
+	await inspect(backup)
+	process.exit(0)
+}
+
 const existing = lockExisting()
 try {
 	console.log(`restoring ${describe(backup)}\n     -> ${ENV.DB_PATH}\n`)
@@ -194,6 +254,7 @@ try {
 	assertIntact(tmpPath)
 
 	const pending = pendingAfterRestore(tmpPath)
+	const stamp = buildStampOf(tmpPath)
 
 	// An archive holds one file, so a -wal next to the unpacked copy can only be the empty one sqlite made for the
 	// read-only connections just above, which they aren't allowed to tidy up on close. Left there they would follow
@@ -218,12 +279,13 @@ try {
 
 	fs.renameSync(tmpPath, DB_PATH)
 	console.log(`restored ${ENV.DB_PATH} from ${backup.fileName}`)
+	console.log(pinGuidance(stamp))
 
 	if (pending.length > 0) {
 		console.log(
 			`\nnote: this database is ${pending.length} migration(s) behind this build (${pending.join(', ')}).\n`
-				+ 'Starting this version of the app applies them again, undoing the restore -- so roll the image back to the version\n'
-				+ 'this database belongs to before starting it (or set DB_AUTOMIGRATE=0 if you know what you are doing).',
+				+ 'Starting this version of the app applies them again, undoing the restore -- so roll the image back before\n'
+				+ 'starting it (or set DB_AUTOMIGRATE=0 if you know what you are doing).',
 		)
 		process.exit(EXIT_RESTORED_BEHIND_BUILD)
 	}

--- a/src/scripts/restore.ts
+++ b/src/scripts/restore.ts
@@ -27,6 +27,7 @@ const args = parseArgs({
 		inspect: { type: 'boolean', default: false },
 		'pre-migration': { type: 'boolean', default: false },
 		latest: { type: 'boolean', default: false },
+		'commit-sha': { type: 'string' },
 		from: { type: 'string' },
 		yes: { type: 'boolean', short: 'y', default: false },
 	},
@@ -42,22 +43,23 @@ const DB_PATH = path.resolve(ENV.DB_PATH)
 // undo the whole exercise. Its own exit code so the wrapper can decline to restart the app rather than walk into that.
 const EXIT_RESTORED_BEHIND_BUILD = 2
 
-type Candidate = { fileName: string; path: string; kind: DbBackup.BackupKind; takenAt: Date; sizeBytes: number }
+type Candidate = { fileName: string; path: string; kind: DbBackup.BackupKind; sha: string | null; takenAt: Date; sizeBytes: number }
 
 // every backup of this database, newest first, whatever kind
 function candidates(): Candidate[] {
 	if (!fs.existsSync(ENV.BACKUPS_DIR)) return []
 	const names = fs.readdirSync(ENV.BACKUPS_DIR)
-	return DbBackup.backupFiles(names, ENV.DB_PATH).map(({ name, kind }) => {
+	return DbBackup.backupFiles(names, ENV.DB_PATH).map(({ name, kind, sha }) => {
 		const p = path.join(ENV.BACKUPS_DIR, name)
 		const stat = fs.statSync(p)
-		return { fileName: name, path: p, kind, takenAt: stat.mtime, sizeBytes: stat.size }
+		return { fileName: name, path: p, kind, sha, takenAt: stat.mtime, sizeBytes: stat.size }
 	})
 }
 
 function describe(c: Candidate) {
 	const size = `${(c.sizeBytes / 1024 / 1024).toFixed(1)} MB`
-	return `${c.fileName}\n    ${c.kind}, taken ${DateFns.format(c.takenAt, 'yyyy-MM-dd HH:mm:ss')}, ${size}`
+	const build = c.sha && c.sha !== 'unknown' ? `commit-${c.sha.slice(0, 7)}` : 'build unknown'
+	return `${c.fileName}\n    ${c.kind}, ${build}, taken ${DateFns.format(c.takenAt, 'yyyy-MM-dd HH:mm:ss')}, ${size}`
 }
 
 function list() {
@@ -79,23 +81,25 @@ function pick(): Candidate {
 		const resolved = fs.existsSync(p) ? p : fs.existsSync(fallback) ? fallback : null
 		if (!resolved) fail(`no such backup: ${args.values.from}`)
 		const stat = fs.statSync(resolved)
+		const parsed = DbBackup.parseBackupFile(path.basename(resolved), ENV.DB_PATH)
 		return {
 			fileName: path.basename(resolved),
 			path: resolved,
-			kind: DbBackup.kindOf(path.basename(resolved), ENV.DB_PATH) ?? 'periodic',
+			kind: parsed?.kind ?? 'periodic',
+			sha: parsed?.sha ?? null,
 			takenAt: stat.mtime,
 			sizeBytes: stat.size,
 		}
 	}
 
-	const all = candidates()
-	const wanted = args.values['pre-migration'] ? all.filter(c => c.kind === 'pre-migration') : all
+	const commitSha = args.values['commit-sha']
+	const db = path.basename(ENV.DB_PATH)
+	let wanted = candidates()
+	if (args.values['pre-migration']) wanted = wanted.filter(c => c.kind === 'pre-migration')
+	if (commitSha) wanted = wanted.filter(c => DbBackup.shaMatchesRequest(c.sha, commitSha))
 	if (wanted.length === 0) {
-		fail(
-			args.values['pre-migration']
-				? `no pre-migration backups of ${path.basename(ENV.DB_PATH)} in ${ENV.BACKUPS_DIR}`
-				: `no backups of ${path.basename(ENV.DB_PATH)} in ${ENV.BACKUPS_DIR}`,
-		)
+		const scope = [args.values['pre-migration'] ? 'pre-migration ' : '', `backups of ${db}`, commitSha ? ` from commit ${commitSha}` : '']
+		fail(`no ${scope.join('')} in ${ENV.BACKUPS_DIR}`)
 	}
 	return wanted[0]
 }
@@ -227,9 +231,9 @@ if (args.values.list) {
 	list()
 	process.exit(0)
 }
-if (!args.values.from && !args.values['pre-migration'] && !args.values.latest) {
+if (!args.values.from && !args.values['pre-migration'] && !args.values.latest && !args.values['commit-sha']) {
 	console.error('pick a backup: --latest (newest of any kind), --pre-migration (newest taken before a migration),')
-	console.error('or --from <file>. `--list` shows what there is.')
+	console.error('--commit-sha <sha> (newest from a given build), or --from <file>. `--list` shows what there is.')
 	process.exit(1)
 }
 

--- a/src/server/db-backup.test.ts
+++ b/src/server/db-backup.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 
 const DB_PATH = './data/db.sqlite3'
 
+// the sha-less form: how backups were named before the sha segment existed. Still has to parse and prune correctly.
 const periodic = (stamp: string) => `slm-backup-db-${stamp}.sqlite3.gz`
 const preMigration = (stamp: string) => `slm-backup-db-pre-migration-${stamp}.sqlite3.gz`
 
@@ -42,11 +43,45 @@ describe('backupFiles', () => {
 		expect(DbBackup.kindOf('slm-backup-otherdb-20260101-000000.sqlite3.gz', DB_PATH)).toBeNull()
 	})
 
-	test('names a backup so it parses back', () => {
+	test('names a backup with its build sha so it parses back', () => {
 		for (const kind of DbBackup.BACKUP_KINDS) {
-			const name = DbBackup.fileName(DB_PATH, kind, new Date(2026, 6, 16, 13, 40, 16))
-			expect(DbBackup.parseBackupFile(name, DB_PATH)).toEqual({ name, kind, stamp: '20260716134016' })
+			const name = DbBackup.fileName(DB_PATH, kind, 'a6047f44deb0cafe', new Date(2026, 6, 16, 13, 40, 16))
+			expect(DbBackup.parseBackupFile(name, DB_PATH)).toEqual({ name, kind, stamp: '20260716134016', sha: 'a6047f44deb0' })
 		}
+	})
+
+	test('still parses names written before the sha segment existed, with a null sha', () => {
+		for (const [name, kind] of [[periodic('20260716-134016'), 'periodic'], [preMigration('20260716-134016'), 'pre-migration']] as const) {
+			expect(DbBackup.parseBackupFile(name, DB_PATH)).toEqual({ name, kind, stamp: '20260716134016', sha: null })
+		}
+	})
+
+	test('a fully-numeric short sha is not mistaken for the timestamp', () => {
+		const name = DbBackup.fileName(DB_PATH, 'periodic', '1234567', new Date(2026, 6, 16, 13, 40, 16))
+		expect(DbBackup.parseBackupFile(name, DB_PATH)).toEqual({ name, kind: 'periodic', stamp: '20260716134016', sha: '1234567' })
+	})
+
+	test('falls back to `unknown` when the database carries no stamp', () => {
+		const name = DbBackup.fileName(DB_PATH, 'periodic', null, new Date(2026, 6, 16, 13, 40, 16))
+		expect(name).toContain('-unknown-')
+		expect(DbBackup.parseBackupFile(name, DB_PATH)).toEqual({ name, kind: 'periodic', stamp: '20260716134016', sha: 'unknown' })
+	})
+})
+
+describe('shaMatchesRequest', () => {
+	test('matches a full sha, a short sha, and a commit- tag against the stored token', () => {
+		const stored = 'a6047f44deb0'
+		expect(DbBackup.shaMatchesRequest(stored, 'a6047f44deb0cafebabe')).toBe(true)
+		expect(DbBackup.shaMatchesRequest(stored, 'a6047f4')).toBe(true)
+		expect(DbBackup.shaMatchesRequest(stored, 'commit-a6047f4')).toBe(true)
+		expect(DbBackup.shaMatchesRequest(stored, 'A6047F4')).toBe(true)
+	})
+
+	test('does not match a different build, or a stampless backup', () => {
+		expect(DbBackup.shaMatchesRequest('a6047f44deb0', 'deadbeef')).toBe(false)
+		expect(DbBackup.shaMatchesRequest('unknown', 'a6047f4')).toBe(false)
+		expect(DbBackup.shaMatchesRequest(null, 'a6047f4')).toBe(false)
+		expect(DbBackup.shaMatchesRequest('a6047f44deb0', '')).toBe(false)
 	})
 })
 

--- a/src/server/db-backup.ts
+++ b/src/server/db-backup.ts
@@ -8,11 +8,15 @@ import * as Zlib from 'node:zlib'
 // backup loop (backups.server.ts) and the pre-migration snapshot (migrate.ts). This module deliberately knows
 // nothing about env, logging or the driver -- the pre-migration path runs before any of that is set up.
 //
-// Backups are named slm-backup-<db filename>[-pre-migration]-<yyyyMMdd>-<HHmmss>.sqlite3.gz, e.g.
-// slm-backup-db-20260713-134016.sqlite3.gz for the default ./data/db.sqlite3. Naming them after the source db
-// means backups of different databases (two SLM instances pointed at one sftp directory, say) can't be mistaken
-// for each other -- which matters because retention deletes everything matching the prefix. Restore with
+// Backups are named slm-backup-<db filename>[-pre-migration]-<sha>-<yyyyMMdd>-<HHmmss>.sqlite3.gz, e.g.
+// slm-backup-db-a6047f44deb0-20260713-134016.sqlite3.gz for the default ./data/db.sqlite3. Naming them after the
+// source db means backups of different databases (two SLM instances pointed at one sftp directory, say) can't be
+// mistaken for each other -- which matters because retention deletes everything matching the prefix. Restore with
 // `gunzip -c <backup> > db.sqlite3`.
+//
+// <sha> is the short git sha of the build that owned the database when the snapshot was taken (see db-meta.ts). It
+// rides in the name so a backup can be selected and listed by version without unpacking it. Backups written before
+// this segment existed simply have no sha, and still parse (with sha null) -- the parser makes it optional.
 export const BACKUP_FILE_EXT = '.sqlite3.gz'
 
 // why a backup was taken. It is in the file name so that a pre-migration snapshot can be found (and restored) as
@@ -25,29 +29,51 @@ function filePrefix(dbPath: string, kind: BackupKind) {
 	return kind === 'pre-migration' ? `slm-backup-${db}-pre-migration` : `slm-backup-${db}`
 }
 
+// the sha is optional in the pattern so backups written before the sha segment existed still parse. It can't be
+// confused with the timestamp that follows: the timestamp is two fixed-width all-digit groups, and even a fully
+// numeric short sha only matches the optional group when a second `-<8 digits>-<6 digits>` still follows it.
 function filePattern(dbPath: string, kind: BackupKind) {
-	return new RegExp(`^${escapeRegExp(filePrefix(dbPath, kind))}-(\\d{8})-(\\d{6})${escapeRegExp(BACKUP_FILE_EXT)}$`)
+	return new RegExp(
+		`^${escapeRegExp(filePrefix(dbPath, kind))}-(?:([0-9a-f]{7,40}|unknown)-)?(\\d{8})-(\\d{6})${escapeRegExp(BACKUP_FILE_EXT)}$`,
+	)
 }
 
-export function fileName(dbPath: string, kind: BackupKind, at = new Date()) {
-	return `${filePrefix(dbPath, kind)}-${DateFns.format(at, 'yyyyMMdd-HHmmss')}${BACKUP_FILE_EXT}`
+// A filename-safe token for the owning build: a lowercased hex prefix of the git sha (see db-meta.ts), or `unknown`
+// for a database that carries no stamp. Trimmed to 12 chars -- long enough to be unambiguous, short enough to read.
+export function shaToken(sha: string | null | undefined): string {
+	const hex = /^[0-9a-f]+/i.exec((sha ?? '').trim())?.[0]
+	return hex && hex.length >= 7 ? hex.slice(0, 12).toLowerCase() : 'unknown'
+}
+
+export function fileName(dbPath: string, kind: BackupKind, sha: string | null | undefined, at = new Date()) {
+	return `${filePrefix(dbPath, kind)}-${shaToken(sha)}-${DateFns.format(at, 'yyyyMMdd-HHmmss')}${BACKUP_FILE_EXT}`
+}
+
+// Whether a backup's sha token satisfies a `--commit-sha` request. The request may be a full sha, a short one, or a
+// `commit-<sha>` image tag; a match is either being a prefix of the other, so 7-, 12- and 40-char forms all line up.
+// A backup with no stamp (`unknown`, or an older name with no sha at all) never matches.
+export function shaMatchesRequest(fileSha: string | null, requested: string): boolean {
+	if (!fileSha || fileSha === 'unknown') return false
+	const req = requested.trim().toLowerCase().replace(/^commit-/, '')
+	return req.length > 0 && (fileSha.startsWith(req) || req.startsWith(fileSha))
 }
 
 // `stamp` is the file's yyyyMMddHHmmss, which sorts chronologically. The whole NAME does not: `-pre-migration`
 // sits between the db name and the timestamp, so sorting on that orders every pre-migration backup after every
 // periodic one, whatever their dates -- which, once the two share a retention window, silently means retention
 // keeps the wrong files.
-export type BackupFile = { name: string; kind: BackupKind; stamp: string }
+export type BackupFile = { name: string; kind: BackupKind; stamp: string; sha: string | null }
 
 // null when the file isn't a backup of this database at all. Anything that returns null is left alone forever:
-// retention only ever deletes files we wrote ourselves.
+// retention only ever deletes files we wrote ourselves. `sha` is the owning build's short sha, or null for a backup
+// named before the sha segment existed.
 export function parseBackupFile(fileName: string, dbPath: string): BackupFile | null {
 	// pre-migration first: the periodic pattern requires the timestamp immediately after the db name, so the two
 	// can't both match, but trying the more specific one first makes that a property of this function rather than
 	// of the regexes.
 	for (const kind of ['pre-migration', 'periodic'] as const) {
 		const match = filePattern(dbPath, kind).exec(fileName)
-		if (match) return { name: fileName, kind, stamp: match[1] + match[2] }
+		if (match) return { name: fileName, kind, stamp: match[2] + match[3], sha: match[1] ?? null }
 	}
 	return null
 }

--- a/src/server/db-meta.test.ts
+++ b/src/server/db-meta.test.ts
@@ -1,0 +1,30 @@
+import DatabaseConstructor from 'better-sqlite3'
+import { describe, expect, test } from 'vitest'
+import * as DbMeta from './db-meta'
+
+describe('db-meta build stamp', () => {
+	test('round-trips a stamp', () => {
+		const db = new DatabaseConstructor(':memory:')
+		DbMeta.writeBuildStamp(db, { gitSha: 'abc1234def', gitBranch: 'main' })
+		expect(DbMeta.readBuildStamp(db)).toEqual({ gitSha: 'abc1234def', gitBranch: 'main' })
+	})
+
+	test('reads null from a database that was never stamped', () => {
+		const db = new DatabaseConstructor(':memory:')
+		expect(DbMeta.readBuildStamp(db)).toBeNull()
+	})
+
+	test('overwrites on the next stamp rather than appending', () => {
+		const db = new DatabaseConstructor(':memory:')
+		DbMeta.writeBuildStamp(db, { gitSha: 'old', gitBranch: 'main' })
+		DbMeta.writeBuildStamp(db, { gitSha: 'new', gitBranch: 'release' })
+		expect(DbMeta.readBuildStamp(db)).toEqual({ gitSha: 'new', gitBranch: 'release' })
+	})
+
+	test('reads null when the table exists but a key is missing', () => {
+		const db = new DatabaseConstructor(':memory:')
+		db.exec(`CREATE TABLE "_slm_meta" (key TEXT PRIMARY KEY, value TEXT NOT NULL)`)
+		db.prepare(`INSERT INTO "_slm_meta" (key, value) VALUES ('git_sha', 'abc')`).run()
+		expect(DbMeta.readBuildStamp(db)).toBeNull()
+	})
+})

--- a/src/server/db-meta.ts
+++ b/src/server/db-meta.ts
@@ -1,0 +1,35 @@
+import type { Database } from 'better-sqlite3'
+
+// A tiny key/value table recording which build a database belongs to: the git sha and branch of the app that last
+// ran against it. It rides inside the database file, so every snapshot -- periodic or pre-migration -- carries it for
+// free, and `restore.sh` can read it back out of a backup to tell you which image to pin before starting the app.
+//
+// Deliberately outside the migration sequence, like `_slm_migrations`: it is infrastructure metadata, not schema, and
+// an old database that predates it is fine (reads treat a missing table as "unknown"). Driver-only, no env import, so
+// the restore path can read it before the rest of the app is set up.
+const TABLE = '_slm_meta'
+
+export type BuildStamp = { gitSha: string; gitBranch: string }
+
+// Records the running build against the database. Called on every boot: the value is the build that owns the database
+// from now on, which for a periodic backup is exactly the version to restore to. A pre-migration snapshot is taken
+// before this runs, so it keeps the PREVIOUS build's stamp -- the one a bad upgrade rolls back to.
+export function writeBuildStamp(driver: Database, stamp: BuildStamp): void {
+	driver.exec(`CREATE TABLE IF NOT EXISTS "${TABLE}" (key TEXT PRIMARY KEY, value TEXT NOT NULL)`)
+	const upsert = driver.prepare(`INSERT INTO "${TABLE}" (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`)
+	upsert.run('git_sha', stamp.gitSha)
+	upsert.run('git_branch', stamp.gitBranch)
+}
+
+// null when the database carries no stamp: it predates this table, or was created by something that never booted the
+// app (a fresh clone, say). Never writes -- a missing table is "unknown", not an error.
+export function readBuildStamp(driver: Database): BuildStamp | null {
+	const exists = driver.prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='${TABLE}'`).get()
+	if (!exists) return null
+	const rows = driver.prepare(`SELECT key, value FROM "${TABLE}"`).all() as { key: string; value: string }[]
+	const byKey = new Map(rows.map((r) => [r.key, r.value]))
+	const gitSha = byKey.get('git_sha')
+	const gitBranch = byKey.get('git_branch')
+	if (gitSha === undefined || gitBranch === undefined) return null
+	return { gitSha, gitBranch }
+}

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -10,6 +10,7 @@ import { highlight } from 'sql-highlight'
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import type * as C from './context.ts'
+import * as DbMeta from './db-meta.ts'
 import * as Env from './env.ts'
 import * as Migrate from './migrate.ts'
 
@@ -73,6 +74,11 @@ export async function setup(opts?: { skipMigrationCheck?: boolean }) {
 				)
 			}
 		}
+
+		// stamp the database with the build now taking ownership of it, so a backup of it can later say which image to
+		// restore to. After migrations on purpose: a pre-migration snapshot is already on disk carrying the previous
+		// build's stamp, which is the one a rollback wants.
+		DbMeta.writeBuildStamp(driver, { gitSha: ENV.PUBLIC_GIT_SHA, gitBranch: ENV.PUBLIC_GIT_BRANCH })
 	}
 
 	// mysql enforced the schema's FK cascades; sqlite only does so with this pragma (per-connection).

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -112,6 +112,12 @@ export async function backupTo(destPath: string) {
 	return await driver.backup(destPath)
 }
 
+// the build that owns this database, stamped on boot (see db-meta.ts). null only if setup() hasn't run or the db
+// predates stamping. Used to name a periodic backup after the version it belongs to.
+export function readBuildStamp() {
+	return DbMeta.readBuildStamp(driver)
+}
+
 // try to use the getter instead of passing the db instance around by itself. that way the logger is always up-to-date. not expensive.
 export function addPooledDb<T extends object>(ctx: T) {
 	if ('db' in ctx) return ctx as T & C.Db

--- a/src/server/migrate.ts
+++ b/src/server/migrate.ts
@@ -2,6 +2,7 @@ import type { Database } from 'better-sqlite3'
 import fs from 'node:fs'
 import path from 'node:path'
 import * as DbBackup from './db-backup.ts'
+import * as DbMeta from './db-meta.ts'
 
 // Custom migration runner that applies both generated `.sql` schema migrations
 // (authored via `drizzle-kit generate`) and hand-written `.ts` data migrations in
@@ -107,7 +108,9 @@ export async function applyPendingMigrations(
 }
 
 async function takePreMigrationBackup(driver: MigrationDriver, backup: BackupConfig, log: (msg: string) => void) {
-	const name = DbBackup.fileName(backup.dbPath, 'pre-migration')
+	// the stamp still on the db is the build being upgraded FROM: this backup is named after the version a rollback
+	// wants, not the one about to apply the migrations.
+	const name = DbBackup.fileName(backup.dbPath, 'pre-migration', DbMeta.readBuildStamp(driver)?.gitSha)
 	const destPath = path.join(backup.dir, name)
 	const { sizeBytes } = await DbBackup.writeBackup({ destPath, snapshot: (dest) => driver.backup(dest) })
 	log(`wrote pre-migration backup ${destPath} (${sizeBytes} bytes)`)

--- a/src/systems/backups.server.ts
+++ b/src/systems/backups.server.ts
@@ -176,7 +176,7 @@ export const runBackup = C.spanOp('runBackup', { module }, async (ctx: C.Db & CS
 	const startedAt = Date.now()
 	const pruned = await pruneEventHistory(ctx)
 
-	const fileName = DbBackup.fileName(ENV.DB_PATH, 'periodic')
+	const fileName = DbBackup.fileName(ENV.DB_PATH, 'periodic', DB.readBuildStamp()?.gitSha)
 	const destPath = path.join(ENV.BACKUPS_DIR, fileName)
 	const { sizeBytes, snapshotBytes } = await DbBackup.writeBackup({
 		destPath,


### PR DESCRIPTION
## Problem

Our backup/restore system reliably tells you **that** you must pin an older image before restoring, but gave almost no help figuring out **which one**. Backup filenames carried only the db name, kind, and a timestamp. `restore.sh` detects the mismatch (diffs the restored db's `_slm_migrations` against the build, exits 2, refuses to restart) and says "Point docker-compose.yaml at the version this database belongs to" -- but identifying that version was manual git archaeology: pending migration names -> the commit before they landed -> that commit's `commit-<sha>` tag. Prod runs `:latest`, so even "which image was running when this backup was taken" was recorded nowhere.

## Approach

**1. Stamp the owning build inside the database.** A small `_slm_meta` key/value table (`src/server/db-meta.ts`) storing `git_sha` + `git_branch`, written on every boot in `db.ts setup()` after migrations. Outside the migration sequence, like `_slm_migrations`; created on demand. Stamping *after* migrations is deliberate: a pre-migration snapshot keeps the *previous* build's stamp -- exactly the version a rollback wants.

**2. Embed the owner's short sha in the backup filename** (`slm-backup-db-<sha>-<stamp>.gz`), so a backup's version can be listed and selected **without unpacking** the archive. Both writers name the file after the db's owner stamp: the periodic loop uses the running build; the pre-migration snapshot uses the stamp still on the db (the build being upgraded *from*). `parseBackupFile` reads the sha back and is backward-compatible -- names written before the sha segment existed still parse (sha `null`) and prune correctly.

**3. Surface it in restore (`src/scripts/restore.ts`):**
- Reads the stamp out of the restored db and prints the concrete `commit-<short>` tag to pin.
- **`--inspect`** (pairs with `--latest`/`--pre-migration`/`--from`/`--commit-sha`): reports the build + migration gap **without** touching the live db -- answers "which image do I pin?" before committing to the restore.
- **`--commit-sha <sha>`**: selects the newest backup taken by a given build (accepts a full sha, short sha, or `commit-<sha>` tag; pairs with `--pre-migration`).
- **`--list`** now shows the build each backup belongs to.
- Old, unstamped backups fall back to a migration-gap hint.

## Verification

Exercised end-to-end against a dev instance with the real CLI (stamp -> sqlite online-backup -> gzip -> restore CLI):

- `--list` renders `periodic, commit-a6047f4, taken ...` per backup.
- `--inspect --commit-sha 1111111` and `--inspect --commit-sha commit-a6047f4` each select the right build and print the exact tag to pin.
- `--commit-sha deadbeef` -> `no backups of db.sqlite3 from commit deadbeef` (exit 1).
- Confirmed the unstamped-backup fallback message.

`pnpm run check` / `lint:fix` clean. Unit tests: `db-meta` round-trip/null cases, `db-backup` sha naming + backward-compatible parse (incl. fully-numeric short sha vs timestamp) + `shaMatchesRequest`, plus existing `migrate`/`db` suites -- 24 passing.

## Compatibility

- `_slm_meta`: additive, created on demand, no migration. Old databases are stamped on their next boot.
- **Backup filename format** now includes the owner short sha. Backward compatible: old names still parse and prune, so no migration or manual step is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)