### PR TITLE
fix(squad): stop name-substring collision collapsing distinct players

### DIFF
--- a/src/models/squad.models.test.ts
+++ b/src/models/squad.models.test.ts
@@ -583,6 +583,25 @@ describe('PlayerIds.findByUsernameLoose', () => {
 	})
 })
 
+describe('PlayerIds.match', () => {
+	it('matches two records that share a hard id', () => {
+		expect(SM.PlayerIds.match({ eos: 'a', username: 'Quincy' }, { eos: 'a', username: 'Someone Else' })).toBe(true)
+	})
+
+	it('matches on username substring when neither side has a hard id', () => {
+		expect(SM.PlayerIds.match({ username: 'Quincy' }, { usernameNoTag: '『tag』 Quincy' })).toBe(true)
+	})
+
+	// prod: player "Quincy" (00021f...) was resolved to a distinct impostor "REAL Quincy" (000275...) every
+	// roster poll because "REAL Quincy".includes("Quincy"), producing a storm of spurious promote/team-change events.
+	it('does not collapse two players with differing hard ids just because one name is a substring of the other', () => {
+		const quincy = { eos: '00021f', username: 'Quincy' }
+		const impostor = { eos: '000275', username: 'REAL Quincy', usernameNoTag: 'REAL Quincy' }
+		expect(SM.PlayerIds.match(quincy, impostor)).toBe(false)
+		expect(SM.PlayerIds.match(impostor, quincy)).toBe(false)
+	})
+})
+
 describe('toRecentPlayer', () => {
 	// A player persisted before adminGroups existed reaches the reducer with the field simply absent (the schema
 	// leaves it optional). Spreading that threw "adminGroups is not iterable" and took the whole chat feed down on

--- a/src/models/squad.models.ts
+++ b/src/models/squad.models.ts
@@ -290,6 +290,12 @@ export namespace PlayerIds {
 		for (const prop of LOOKUP_PROPS) {
 			if (aNorm[prop] && bNorm[prop] && aNorm[prop] === bNorm[prop]) return true
 		}
+		// Two records that both carry a differing hard id are provably distinct players, so the loose
+		// username-substring fallback below must not override that (a player named "Quincy" would otherwise
+		// collide with a distinct "REAL Quincy").
+		for (const prop of UNIQUE_PROPS) {
+			if (aNorm[prop] && bNorm[prop] && aNorm[prop] !== bNorm[prop]) return false
+		}
 		if (aNorm.username && bNorm.usernameNoTag?.includes(aNorm.username)) return true
 		if (bNorm.username && aNorm.usernameNoTag?.includes(bNorm.username)) return true
 		return false


### PR DESCRIPTION
## Problem

In prod, player **Quincy** (`00021f…`) was caught in a loop, appearing to be promoted to squad leader and changed to the opposite team many times per second (~5.16s = the RCON roster-poll interval). 96 spurious `PLAYER_PROMOTED_TO_LEADER` events in a single match.

## Root cause

A second player (`000275…`) was impersonating him, renaming to **"REAL Quincy"** / **"NOT Quincy"**.

`PlayerIds.match` (`src/models/squad.models.ts`) falls back to a username-**substring** test after the exact-id checks:

```js
if (aNorm.username && bNorm.usernameNoTag?.includes(aNorm.username)) return true
```

`"REAL Quincy".includes("Quincy")` is `true`, so the two distinct EOS ids were treated as the same player. The roster reconciler resolves every player through `find`/`indexOf` → `match`, so lookups for the real Quincy returned the impostor's record. The per-poll diff (`reconcileTeamsUpdate`) therefore saw a different squad / not-leader / different team every time and re-emitted `PLAYER_JOINED_SQUAD` + `PLAYER_PROMOTED_TO_LEADER` + `PLAYER_CHANGED_TEAM`, and the fold-back (`applyEventTeamMutations`) wrote onto the wrong record, so it never converged.

SLM issues no RCON here — these events are purely derived from roster snapshots, so the fix is entirely in the matcher.

## Fix

Gate the substring fallback: if both records carry a differing hard id (`steam`/`eos`/`epic`) they are provably distinct players and can never match by name. The loose name match still applies when at least one side lacks a unique id (e.g. a log line carrying only a display name).

## Tests

Added a `PlayerIds.match` regression block covering the exact Quincy/"REAL Quincy" collision plus the still-valid cases (shared hard id; substring match when neither side has an id). Full `squad.models`, `pending-events.models`, and `chat.models` suites pass; `pnpm run check` clean.

No data-structure/config/schema changes; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)