### PR TITLE
chore(hooks): run pre-push checks on every branch

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -12,7 +12,7 @@ Disable with:
 pnpm remove:hooks
 ```
 
-`pre-push` runs the full suite (format, typecheck, lint, unit, integration, e2e) when pushing to `main`, and
-nothing on any other branch. See [CONTRIBUTING.md](../CONTRIBUTING.md#the-pre-push-hook) for the details.
+`pre-push` runs the full suite (format, typecheck, lint, unit, integration, e2e) on every branch. Branch
+deletions are skipped. See [CONTRIBUTING.md](../CONTRIBUTING.md#the-pre-push-hook) for the details.
 
 **Bypass:** `git push --no-verify`

--- a/.githooks/pre-push.js
+++ b/.githooks/pre-push.js
@@ -12,27 +12,18 @@ process.stdin.on('data', (chunk) => {
 })
 
 process.stdin.on('end', () => {
-	// Parse push information to detect if pushing to main
-	const lines = input.trim().split('\n')
+	// <local ref> <local sha> <remote ref> <remote sha>, one per ref being pushed
+	const refs = input.trim().split('\n')
+		.map((line) => line.split(' '))
+		.filter((parts) => parts.length >= 4)
 
-	let isPushingToMain = false
+	const hasCommitsToPush = refs.some(([, localSha]) => !/^0+$/.test(localSha))
 
-	for (const line of lines) {
-		const parts = line.split(' ')
-		if (parts.length >= 4) {
-			const refName = parts[2]
-			if (refName === 'refs/heads/main') {
-				isPushingToMain = true
-				break
-			}
-		}
-	}
-
-	if (!isPushingToMain) {
+	if (!hasCommitsToPush) {
 		process.exit(0)
 	}
 
-	console.log('🔍 Pushing to main - running checks...\n')
+	console.log('🔍 Running checks...\n')
 
 	try {
 		console.log('📋 Checking format...')


### PR DESCRIPTION
The pre-push hook only ran the suite when a ref named `refs/heads/main` was in the push, so every feature-branch push sailed through unchecked, even though CONTRIBUTING describes the hook as running before every push.

Now it runs on any push that carries commits. Branch deletions (all-zero local sha) still exit early, and `git push --no-verify` still bypasses.

Verified by feeding the hook the git stdin format directly: deletion lines and empty input exit 0 silently, a non-main ref starts the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)