### PR TITLE
Show a layer request's owner as their discord avatar

### DIFF
--- a/src/components/backburner-panel.tsx
+++ b/src/components/backburner-panel.tsx
@@ -46,6 +46,7 @@ import { FilterEntityLabel } from './filter-entity-select.tsx'
 import { ListEditor } from './list-editor.tsx'
 import SelectLayersDialog from './select-layers-dialog.tsx'
 import { ButtonGroup } from './ui/button-group'
+import { UserAvatar } from './user-avatar.tsx'
 
 type StoresProp = { stores: SquadServerFrame.KeyProp }
 
@@ -480,7 +481,7 @@ function BackburnerRow(
 				</Tooltip>
 			)}
 			<TemplateDisplay filter={item.filter} className="min-w-0 flex-1 truncate" />
-			<OwnerName source={item.source} />
+			<RequestOwner source={item.source} />
 			{(canEdit || props.canRequest) && (
 				<span className="flex items-center">
 					{props.canRequest && (
@@ -520,10 +521,11 @@ function BackburnerRow(
 	)
 }
 
-function OwnerName(props: { source: BB.BackburnerItem['source'] }) {
-	const { data: userRes } = UsersClient.useUser(props.source.discordId, { enabled: props.source.discordId !== undefined })
-	const name = (userRes?.code === 'ok' ? userRes.user.displayName : undefined)
-		?? (props.source.steamId ? `steam:${props.source.steamId}` : 'unknown')
+// who asked for the layer. A request made in chat by a player with no linked discord account can only be
+// named by their steam id, so that falls back to text rather than an avatar.
+function RequestOwner(props: { source: BB.BackburnerItem['source'] }) {
+	if (props.source.discordId !== undefined) return <UserAvatar userId={props.source.discordId} label="Requested By" />
+	const name = props.source.steamId ? `steam:${props.source.steamId}` : 'unknown'
 	return <span className="max-w-32 truncate text-xs text-muted-foreground" title={name}>{name}</span>
 }
 

--- a/src/components/layer-source-display.tsx
+++ b/src/components/layer-source-display.tsx
@@ -1,68 +1,29 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { assertNever } from '@/lib/type-guards'
 import type * as LL from '@/models/layer-list.models'
-import * as USR from '@/models/users.models'
-import * as PartsSys from '@/systems/parts.client'
-import * as UsersClient from '@/systems/users.client'
 import * as Icons from 'lucide-react'
-import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+import { Avatar } from './ui/avatar'
+import { UserAvatar } from './user-avatar'
 
 export default function LayerSourceDisplay(props: { source: LL.Source }) {
-	const loggedInUser = UsersClient.useLoggedInUser()
-	const userId = props.source.type === 'manual' ? props.source.userId : undefined
-	const userPartial = userId ? PartsSys.findUser(userId) : undefined
-	const isMe = userId && userId === loggedInUser?.discordId
-	const userRes = UsersClient.useUser(userId, { enabled: !!userId && !userPartial && !isMe })
-	const user: USR.User | undefined = (userRes.data?.code === 'ok' ? userRes.data.user : undefined) ?? userPartial ?? loggedInUser
-	const username = user?.displayName ?? 'Unknown'
-
-	const renderAvatar = (
-		displayName: string,
-		initials: string,
-		backgroundColor?: string,
-		avatar?: string | React.ReactNode,
-		isUser = false,
-	) => {
-		let inner: React.ReactNode
-		if (!avatar || typeof avatar === 'string') {
-			inner = (
-				<Avatar
-					style={{ backgroundColor: backgroundColor ?? undefined }}
-					className="h-6 w-6"
-				>
-					{typeof avatar === 'string' && <AvatarImage src={avatar} crossOrigin="anonymous" />}
-					<AvatarFallback className="text-xs">
-						{initials}
-					</AvatarFallback>
-				</Avatar>
-			)
-		} else {
-			inner = avatar
-		}
-
-		return (
-			<Tooltip delayDuration={0}>
-				<TooltipTrigger>
-					{inner}
-				</TooltipTrigger>
-				<TooltipContent className="bg-secondary text-secondary-foreground">
-					{isUser ? 'Set By' : undefined} {displayName}
-				</TooltipContent>
-			</Tooltip>
-		)
-	}
+	const renderIcon = (displayName: string, backgroundColor: string, icon: React.ReactNode) => (
+		<Tooltip delayDuration={0}>
+			<TooltipTrigger>
+				<Avatar style={{ backgroundColor }} className="h-6 w-6">{icon}</Avatar>
+			</TooltipTrigger>
+			<TooltipContent className="bg-secondary text-secondary-foreground">{displayName}</TooltipContent>
+		</Tooltip>
+	)
 
 	switch (props.source.type) {
 		case 'gameserver':
-			return renderAvatar('Game Server', 'GS', '#6366f1', <Icons.Server />)
+			return renderIcon('Game Server', '#6366f1', <Icons.Server />)
 		case 'unknown':
-			return renderAvatar('Unknown', '?', '#64748b', <Icons.MessageCircleQuestion />)
+			return renderIcon('Unknown', '#64748b', <Icons.MessageCircleQuestion />)
 		case 'generated':
-			return renderAvatar('Generated', 'G', '#059669', <Icons.Dices />)
-		case 'manual': {
-			if (!user) return null
-			return renderAvatar(username, USR.getUserInitials(user), user.displayHexColor ?? undefined, user.avatarUrl, true)
-		}
+			return renderIcon('Generated', '#059669', <Icons.Dices />)
+		case 'manual':
+			return <UserAvatar userId={props.source.userId} label="Set By" />
 		default:
 			assertNever(props.source)
 	}

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -1,0 +1,32 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import type * as USR from '@/models/users.models'
+import { getUserInitials } from '@/models/users.models'
+import * as PartsSys from '@/systems/parts.client'
+import * as UsersClient from '@/systems/users.client'
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+
+// A discord user rendered as their avatar, with their name on hover. `label` prefixes the tooltip ("Set By").
+// Renders nothing while the user is unresolved, so a caller can fall back to whatever identity it does have.
+export function UserAvatar(props: { userId: USR.UserId; label?: string; className?: string }) {
+	const loggedInUser = UsersClient.useLoggedInUser()
+	const partial = PartsSys.findUser(props.userId)
+	const isMe = props.userId === loggedInUser?.discordId
+	const res = UsersClient.useUser(props.userId, { enabled: !partial && !isMe })
+	const user = (res.data?.code === 'ok' ? res.data.user : undefined) ?? partial ?? (isMe ? loggedInUser : undefined)
+	if (!user) return null
+
+	return (
+		<Tooltip delayDuration={0}>
+			<TooltipTrigger>
+				<Avatar style={{ backgroundColor: user.displayHexColor ?? undefined }} className={cn('h-6 w-6', props.className)}>
+					<AvatarImage src={user.avatarUrl} crossOrigin="anonymous" />
+					<AvatarFallback className="text-xs">{getUserInitials(user)}</AvatarFallback>
+				</Avatar>
+			</TooltipTrigger>
+			<TooltipContent className="bg-secondary text-secondary-foreground">
+				{props.label} {user.displayName}
+			</TooltipContent>
+		</Tooltip>
+	)
+}


### PR DESCRIPTION
A layer request's owner now renders as the requester's discord avatar, the same way a queue item shows who set it, instead of a truncated display name.

A request made in chat by a player with no linked discord account has nothing to resolve, so that still falls back to their steam id as text.

## One implementation of "user → avatar"

`UserAvatar` is extracted out of `layer-source-display` into its own component and used by both. The layer-item path keeps its icon avatars for the non-user sources (game server / generated / unknown) locally, since those are just an icon and a tooltip.

That extraction also fixes a flicker in the layer-item path: the fallback chain ended in `?? loggedInUser` unconditionally, so while another user's fetch was in flight the queue showed *your* avatar as the setter of *their* item. It now only falls back to the logged-in user when the id actually is theirs — which is what the `enabled: … && !isMe` on the query already assumed.

## Verification

`pnpm run check`, `pnpm run lint`, `pnpm run test` (747), and the backburner + queue-editing e2e (7) pass. Checked by hand on the dev instance: a GUI request shows the avatar with a "Requested By <name>" tooltip, and the queue's own source avatars are unchanged.

## Dev instance

Worktree slot 9. Hit the app port first so the auth-bypass cookie is set, then browse from either:

    http://localhost:3190/?login=<username>

Client (vite, HMR): http://localhost:3191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sb6WJJ7nYTXWN1UDZcrYf1
