### PR TITLE
Reset queue mutation state on every save path

### DIFF
--- a/src/frame-partials/layer-queue.partial.ts
+++ b/src/frame-partials/layer-queue.partial.ts
@@ -16,6 +16,7 @@ import * as RbacClient from '@/systems/rbac.client'
 import * as UPClient from '@/systems/user-presence.client'
 import * as UsersClient from '@/systems/users.client'
 import * as Rx from 'rxjs'
+import type * as Zus from 'zustand'
 
 export type Store = {
 	queue: State
@@ -363,13 +364,26 @@ export namespace Actions {
 			else UPClient.Actions.ensureEditingQueue(serverId)
 		}
 
-		const res = await RPC.orpc.layerQueue.dispatchOp.call({ serverId, op })
-		if (res.code === 'err:permission-denied') {
-			RbacClient.handlePermissionDenied(res)
+		let res: Awaited<ReturnType<typeof RPC.orpc.layerQueue.dispatchOp.call>>
+		try {
+			res = await RPC.orpc.layerQueue.dispatchOp.call({ serverId, op })
+		} catch (error) {
+			// the op will never be acked, so it must leave the pending set -- see dropPendingOps
+			rollbackOp(slice, op.opId)
+			console.error('layer queue op dispatch failed:', error)
+			toast.error('Failed to apply queue operation')
 			return
-		} else if (res.code !== 'ok') {
-			toast.error('msg' in res ? res.msg : res.code)
 		}
+		if (res.code === 'ok') return
+		rollbackOp(slice, op.opId)
+		if (res.code === 'err:permission-denied') RbacClient.handlePermissionDenied(res)
+		else toast.error('msg' in res ? res.msg : res.code)
+	}
+
+	// a refused op stays applied to the local state until we replay the timeline without it. leaving it pending
+	// also pins localState to the moment of refusal, so the queue would stop reflecting the server entirely.
+	function rollbackOp(slice: Zus.StoreApi<State>, opId: string) {
+		slice.setState({ rbSession: ODSM.Client.dropPendingOps(slice.getState().rbSession, [opId], SLL.reducer) })
 	}
 
 	export function dispatchItemOp(stores: KeyProp, itemId: string, newItemOp: SLL.NewContextItemOperation) {

--- a/src/lib/odsm.test.ts
+++ b/src/lib/odsm.test.ts
@@ -264,6 +264,44 @@ describe('processAcks', () => {
 	})
 })
 
+describe('dropPendingOps', () => {
+	it('replays the local timeline without the dropped op', () => {
+		let session = Client.initSession<Op, State>([])
+		session = Client.processOutgoingOps(session, [op('a', 1)], reducer).session
+		session = Client.processOutgoingOps(session, [op('b', 2)], reducer).session
+
+		session = Client.dropPendingOps(session, ['a'], reducer)
+		expect(session.pendingOps).toEqual([op('b', 2)])
+		expect(session.localState).toEqual([2])
+	})
+
+	it('returns to the synced state when the last pending op is dropped', () => {
+		let session = Client.initSession<Op, State>([9])
+		session = Client.processOutgoingOps(session, [op('a', 1)], reducer).session
+		session = Client.dropPendingOps(session, ['a'], reducer)
+		expect(session.pendingOps).toEqual([])
+		expect(session.localState).toEqual([9])
+		expect(session.localState).toBe(session.syncedState)
+	})
+
+	// a pending op that is never acked blocks incoming server ops from reaching localState
+	it('lets server updates withheld while the op was pending reach the local state', () => {
+		let session = Client.initSession<Op, State>([])
+		session = Client.processOutgoingOps(session, [op('a', 1)], reducer).session
+		session = Client.processIncomingOps(session, [op('server', 7)], reducer).session
+		expect(session.localState).toEqual([1])
+
+		session = Client.dropPendingOps(session, ['a'], reducer)
+		expect(session.localState).toEqual([7])
+	})
+
+	it('is a no-op for ids that are not pending', () => {
+		let session = Client.initSession<Op, State>([])
+		session = Client.processOutgoingOps(session, [op('a', 1)], reducer).session
+		expect(Client.dropPendingOps(session, ['ghost'], reducer)).toBe(session)
+	})
+})
+
 describe('processInit', () => {
 	it('adopts the snapshot when nothing is pending', () => {
 		let session = Client.initSession<Op, State>([])

--- a/src/lib/odsm.ts
+++ b/src/lib/odsm.ts
@@ -276,6 +276,27 @@ export namespace Client {
 		return { rejected: false, session: applied.session, sideEffects: applied.sideEffects, ackedOps, unknownOpIds }
 	}
 
+	// drops ops the server refused (permission denied, an invalid op, a dispatch that never landed) and replays
+	// what is left of the local timeline. a pending op that is never acked is not merely a lost edit: until
+	// pendingOps drains, processIncomingOps/processAckedOps refuse to adopt the synced state, so every later
+	// server update -- including the saves that clear mutation state -- stops reaching localState entirely.
+	export function dropPendingOps<O extends BaseOp, S, SE extends SideEffectBase>(
+		session: Session<O, S>,
+		opIds: OpId[],
+		reducer: Reducer<O, S, SE>,
+	): Session<O, S> {
+		const droppedIds = new Set(opIds)
+		const pendingOps = session.pendingOps.filter(op => !droppedIds.has(op.opId))
+		if (pendingOps.length === session.pendingOps.length) return session
+		if (pendingOps.length === 0) return { ...session, localState: session.syncedState, pendingOps }
+		const reduced = runReducer(reducer, session.syncedState, pendingOps, session.syncedOps)
+		return {
+			...session,
+			localState: reduced.rejected ? session.syncedState : reduced.state,
+			pendingOps,
+		}
+	}
+
 	export function localOps<O extends BaseOp, S>(session: Session<O, S>): O[] {
 		return [...session.syncedOps, ...session.pendingOps]
 	}

--- a/src/models/shared-layer-list.test.ts
+++ b/src/models/shared-layer-list.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest'
 
 const USER = 5n
 const OTHER_USER = 6n
+const OTHER_LAYER_ID = L.swapFactionsInId(L.DEFAULT_LAYER_ID)
 
 let counter = 0
 function bbItem(id: string, owner: bigint = USER, map: string = 'Gorodok'): BB.BackburnerItem {
@@ -174,6 +175,84 @@ describe('generation consumption', () => {
 		})
 		expect(ids(state.savedBackburner)).toEqual(['b'])
 		expect(backburnerSaves(sideEffects)).toHaveLength(0)
+	})
+})
+
+describe('queue saves reset mutation state', () => {
+	function manualItem(layerId: L.LayerId = L.DEFAULT_LAYER_ID) {
+		return LL.createItem({ type: 'single-list-item', layerId }, { type: 'manual', userId: USER })
+	}
+
+	function queueProps(state: SLL.State) {
+		return { opId: `op-${counter++}`, userId: USER, editWindowSeqId: state.editWindowSeqId }
+	}
+
+	function editWindowClosures(sideEffects: SLL.SideEffect[]) {
+		return sideEffects.filter(se => se.code === 'edit-window-closed')
+	}
+
+	it('clears mutations when the save writes a changed list', () => {
+		const [first, second] = [manualItem(), manualItem()]
+		const initial = SLL.createNewState([first, second])
+		const edited = apply(initial, { op: 'delete', itemId: second.itemId, ...queueProps(initial) }).state
+		expect(edited.mutations.removed.has(second.itemId)).toBe(true)
+
+		const { state, sideEffects } = apply(edited, { op: 'save', ...queueProps(edited) })
+		expect(SLL.hasMutations(state)).toBe(false)
+		expect(listSaves(sideEffects)).toHaveLength(1)
+	})
+
+	// edits that cancel each other out leave the list identical to the saved one, so there is nothing to write --
+	// but the edit window still closed, and a deliberate finish-editing suppresses the abandoned-draft discard,
+	// so nothing else would ever clear the leftover mutations
+	it('clears mutations when the edits net out to no list change', () => {
+		const item = manualItem()
+		const initial = SLL.createNewState([item])
+		const there = apply(initial, { op: 'edit-layer', itemId: item.itemId, newLayerId: OTHER_LAYER_ID, ...queueProps(initial) }).state
+		const back = apply(there, { op: 'edit-layer', itemId: item.itemId, newLayerId: item.layerId, ...queueProps(there) }).state
+		expect(back.list).toEqual(back.savedList)
+		expect(SLL.hasMutations(back)).toBe(true)
+
+		const { state, sideEffects } = apply(back, { op: 'save', ...queueProps(back) })
+		expect(SLL.hasMutations(state)).toBe(false)
+		expect(state.editWindowSeqId).toBe(back.editWindowSeqId + 1)
+		expect(listSaves(sideEffects)).toHaveLength(0)
+		expect(editWindowClosures(sideEffects)).toHaveLength(1)
+	})
+
+	it('clears mutations when the save empties the queue and waits on generation', () => {
+		const item = manualItem()
+		const initial = SLL.createNewState([item])
+		const cleared = apply(initial, { op: 'clear', itemIds: [item.itemId], ...queueProps(initial) }).state
+
+		const { state, sideEffects } = apply(cleared, { op: 'save', ...queueProps(cleared) })
+		expect(sideEffects.some(se => se.code === 'request-queue-item-generation')).toBe(true)
+		expect(SLL.hasMutations(state)).toBe(false)
+
+		const generated = apply(state, { op: 'queue-item-generated', opId: 'gen', item: queueItem() }).state
+		expect(SLL.hasMutations(generated)).toBe(false)
+		expect(generated.list).toHaveLength(1)
+	})
+
+	it('clears mutations when a roll saves the list out from under an editor', () => {
+		const [first, second] = [manualItem(), manualItem()]
+		const initial = SLL.createNewState([first, second])
+		const edited = apply(initial, { op: 'edit-layer', itemId: second.itemId, newLayerId: OTHER_LAYER_ID, ...queueProps(initial) }).state
+		expect(SLL.hasMutations(edited)).toBe(true)
+
+		const { state } = apply(edited, { op: 'shift-first-saved-layer', opId: 'roll' })
+		expect(SLL.hasMutations(state)).toBe(false)
+	})
+
+	it('skips a queue op authored against the first edit window once it has closed', () => {
+		const [first, second] = [manualItem(), manualItem()]
+		const initial = SLL.createNewState([first, second])
+		expect(initial.editWindowSeqId).toBe(0)
+		const staleOp: SLL.Operation = { op: 'delete', itemId: second.itemId, ...queueProps(initial) }
+
+		const reset = apply(initial, { op: 'reset-to-saved', ...queueProps(initial) }).state
+		expect(reset.editWindowSeqId).toBe(1)
+		expect(() => apply(reset, staleOp)).toThrowError()
 	})
 })
 

--- a/src/models/shared-layer-list.ts
+++ b/src/models/shared-layer-list.ts
@@ -314,6 +314,11 @@ export type SideEffect =
 		layerId?: string | null
 	}
 	| {
+		// the save had nothing to write, but the edit window still closed -- editors are done and the draft
+		// state was reset, so this is the no-write counterpart of 'request-list-save'
+		code: 'edit-window-closed'
+	}
+	| {
 		// success is false when the op was skipped (stale edit window, pending generation)
 		code: 'op-outcome'
 		op: Operation
@@ -383,7 +388,7 @@ export const reducer: ODSM.Reducer<Operation, State, SideEffect> = (oldState, op
 export function applyOperation(session: State, newOp: Operation, onSideEffect?: ODSM.OnSideEffect<SideEffect>): boolean {
 	const opWindowSeqId = (newOp as { editWindowSeqId?: number })?.editWindowSeqId
 	const currentWindowSeqId = isBackburnerOp(newOp) ? session.backburnerEditWindowSeqId : session.editWindowSeqId
-	if (opWindowSeqId && opWindowSeqId !== currentWindowSeqId) {
+	if (opWindowSeqId !== undefined && opWindowSeqId !== currentWindowSeqId) {
 		return false
 	}
 	if (newOp.op === 'queue-item-generated') {
@@ -542,11 +547,19 @@ export function applyOperation(session: State, newOp: Operation, onSideEffect?: 
 			break
 
 		case 'save': {
-			// a save with no net changes shouldn't request a DB write or emit a QUEUE_UPDATED. this guard lives here
-			// (not in saveList) because in-place system ops -- rolls, vote results -- mutate savedList before saving,
-			// so they can't be compared inside saveList; they always save.
+			// a save with no net changes shouldn't request a DB write or emit a QUEUE_UPDATED, but it still closes
+			// the edit window: mutations that cancelled each other out (moved back, edited back) would otherwise
+			// outlive the save that acknowledged them, and nothing else clears them -- a deliberate finish-editing
+			// suppresses the abandoned-draft discard. this guard lives here (not in saveList) because in-place
+			// system ops -- rolls, vote results -- mutate savedList before saving, so they can't be compared
+			// inside saveList; they always save.
 			const queueChanged = !Obj.deepEqual(session.list, session.savedList)
-			if (queueChanged) saveList(session, newOp, session.list, onSideEffect)
+			if (queueChanged) {
+				saveList(session, newOp, session.list, onSideEffect)
+			} else {
+				closeEditWindow(session)
+				onSideEffect?.({ code: 'edit-window-closed' })
+			}
 			break
 		}
 
@@ -560,8 +573,7 @@ export function applyOperation(session: State, newOp: Operation, onSideEffect?: 
 		case 'reset-to-saved':
 		case 'discard-abandoned-queue-edits': {
 			session.list = Obj.deepClone(session.savedList)
-			session.mutations = ItemMut.initMutations()
-			session.editWindowSeqId++
+			closeEditWindow(session)
 			break
 		}
 
@@ -732,6 +744,9 @@ function saveList(
 	prevList: LL.List = session.savedList,
 ) {
 	session.saving = true
+	// before the empty-list bail-out: the draft this save consumed is gone either way, and leaving mutations
+	// behind for the generated item to clear strands them if generation never lands
+	closeEditWindow(session)
 	if (list.length === 0) {
 		session.requestingGeneratedQueueItem = true
 		onSideEffect?.({ code: 'request-queue-item-generation' })
@@ -739,9 +754,14 @@ function saveList(
 	}
 	session.list = list === session.list && list !== session.savedList ? list : Obj.deepClone(list)
 	session.savedList = list === session.savedList && list !== session.list ? list : Obj.deepClone(list)
+	onSideEffect?.({ code: 'request-list-save', list: session.savedList, prevList, opId: op.opId, lastSaveOpId: session.lastSaveOpId })
+}
+
+// every save path ends the edit window it committed: the draft's mutation highlights are spent, and latent ops
+// authored against the old window must be discarded rather than applied on top of the saved list
+function closeEditWindow(session: State) {
 	session.mutations = ItemMut.initMutations()
 	session.editWindowSeqId++
-	onSideEffect?.({ code: 'request-list-save', list: session.savedList, prevList, opId: op.opId, lastSaveOpId: session.lastSaveOpId })
 }
 
 export function mergeMutations(base: ItemMut.Mutations, additions: ItemMut.Mutations): ItemMut.Mutations {

--- a/src/systems/layer-queue.server.ts
+++ b/src/systems/layer-queue.server.ts
@@ -944,6 +944,10 @@ const handleSideEffect = C.spanOp(
 			case 'complete':
 			case 'op-outcome':
 				break
+			case 'edit-window-closed': {
+				UserPresenceSys.dispatchEndAllLayerQueueEditing(ctx.serverId)
+				break
+			}
 			case 'request-queue-item-generation': {
 				const serverState = await SquadServer.getServerState(ctx)
 				const allConstraints = SETTINGS.getSettingsConstraints(serverState.settings, { generatingLayers: true })


### PR DESCRIPTION
The queue could sit showing mutation badges (and count as "modified") with nobody editing and nothing left to save.

## What was wrong

**1. A save with no net list change never closed the edit window.** `case 'save'` skips `saveList` when `list` deep-equals `savedList` (correctly: no DB write, no `QUEUE_UPDATED`) but it also skipped the mutation reset and the window bump. Edits that cancel out still leave mutations behind: move an item and move it back, swap factions twice, edit a layer and edit it back. Nothing else clears them either, because `endsEditingDeliberately` treats a finish-editing as deliberate and suppresses the abandoned-draft discard, and no side effect fired so `dispatchEndAllLayerQueueEditing` never ran.

**2. A save that empties the queue bailed out before resetting.** `saveList` returns early to wait on generation, leaving the mutations for the generated item to clear later, which strands them if generation never lands.

**3. A refused client op was never removed from `pendingOps`.** `dispatchOp` has several refusal paths (permission denied, `err:invalid-user`, the out-of-pool force-write check, server not loaded) that return without dispatching, so no ack ever comes back. That is worse than a lost edit: `processIncomingOps`/`processAckedOps` will not adopt the synced state until `pendingOps` drains, so a single refused op pins `localState` forever and every later server update -- including the saves that clear mutation state -- stops reaching the UI.

Also: the edit-window guard read `if (opWindowSeqId && ...)`, so ops authored in window `0` were never discarded as stale.

## What changed

- All save paths funnel through `closeEditWindow` (mutations reset + window bump), including the no-op save and the empty-queue bail-out.
- New `edit-window-closed` side effect for the no-op save, so the server still ends everyone's editing session.
- `ODSM.Client.dropPendingOps` replays the local timeline without ops the server refused; the layer-queue dispatcher calls it on a refusal or a failed call.
- Stale-window check treats `0` as a real window id.

## Verification

- `src/models/shared-layer-list.test.ts`: four save paths (changed list, net-zero edits, emptied queue, roll) assert the mutation reset; the net-zero and empty-queue cases fail on `main`.
- `src/lib/odsm.test.ts`: `dropPendingOps` restores the local state and unblocks withheld server updates.
- Full suite: 756 pass. `pnpm run check` and `pnpm run lint:fix` clean.
- End to end on a dev instance (`http://localhost:3201/servers/tt-scrim-2`, worktree slot 10): swapped factions twice on an item already attributed to me so the list matched the saved list, then finished editing. Server logged `save -> Side Effect edit-window-closed` and `sll:end-all-editing`, no `request-list-save`; the client went to `mutations: []`, `isModified: false`, `editWindowSeqId 0 -> 1`, and the badges cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)