### PR TITLE
Route rejected ops to the originator instead of broadcasting them

### DIFF
--- a/src/frame-partials/layer-queue.partial.ts
+++ b/src/frame-partials/layer-queue.partial.ts
@@ -147,9 +147,16 @@ export function initLayerQueue(args: Args) {
 						if (res.unknownOpIds.length > 0) console.warn(`received ack for unknown op ${update.opId}`)
 						if (res.session !== session) {
 							set({ rbSession: res.session })
-							if (!res.rejected) { for (const se of res.sideEffects) onSideEffect(se) }
+							if (res.rejected) console.error('acked queue op diverged from the server:', res.error.data)
+							else for (const se of res.sideEffects) onSideEffect(se)
 							for (const ackedOp of res.ackedOps) get().syncedOp$.next(ackedOp)
 						}
+						break
+					}
+					case 'rejected': {
+						// the server refused our op, so it will never be acked -- replay the local timeline without it
+						console.debug(`queue op ${update.opId} rejected by the server: ${update.reason}`)
+						set({ rbSession: ODSM.Client.dropPendingOps(get().rbSession, [update.opId], SLL.reducer) })
 						break
 					}
 					default:
@@ -160,7 +167,8 @@ export function initLayerQueue(args: Args) {
 			writeIncomingOperations(ops: SLL.Operation[]) {
 				const res = ODSM.Client.processIncomingOps(get().rbSession, ops, SLL.reducer)
 				set({ rbSession: res.session })
-				if (!res.rejected) { for (const se of res.sideEffects) onSideEffect(se) }
+				if (res.rejected) console.error('incoming queue op diverged from the server:', res.error.data)
+				else for (const se of res.sideEffects) onSideEffect(se)
 				for (const op of ops) {
 					get().syncedOp$.next(op)
 				}

--- a/src/frame-partials/teamswaps.partial.ts
+++ b/src/frame-partials/teamswaps.partial.ts
@@ -37,12 +37,12 @@ async function resolveDisplayName(source: TSW.Teamswap['source'] | undefined): P
 	}
 }
 
-// surfaces a rejected teamswap op to the user. called at dispatch time with the rejection the
-// reducer threw, so it already runs on the originating client -- no need to filter by user
-function toastOpError(error: TSW.OpError) {
+// surfaces a rejected teamswap op to the user. only ever reached on the originating client -- either from
+// its own optimistic dispatch or from the server's `rejected` message -- so there's no user to filter by
+function toastOpError(code: TSW.Rejection['code']) {
 	let title: string
 	let description: string | undefined
-	switch (error.code) {
+	switch (code) {
 		case 'err:currently-swapping':
 			title = 'Swap in progress'
 			description = 'Cannot modify swaps while a team swap is being executed.'
@@ -174,7 +174,8 @@ export function initTeamswaps(args: Args) {
 					case 'op': {
 						const res = ODSM.Client.processIncomingOps(get().session, update.ops, TSW.reducer)
 						set({ session: res.session })
-						if (!res.rejected) { for (const se of res.sideEffects) onSideEffect(se, presenceEvent$) }
+						if (res.rejected) console.error('incoming teamswap ops diverged from the server:', res.error.data)
+						else for (const se of res.sideEffects) onSideEffect(se, presenceEvent$)
 						break
 					}
 					case 'ack': {
@@ -184,8 +185,16 @@ export function initTeamswaps(args: Args) {
 						if (res.unknownOpIds.length > 0) console.warn('received ack for unknown teamswap ops', res.unknownOpIds)
 						if (res.session !== session) {
 							set({ session: res.session })
-							if (!res.rejected) { for (const se of res.sideEffects) onSideEffect(se, presenceEvent$) }
+							if (res.rejected) console.error('acked teamswap ops diverged from the server:', res.error.data)
+							else for (const se of res.sideEffects) onSideEffect(se, presenceEvent$)
 						}
+						break
+					}
+					case 'rejected': {
+						// the server refused our ops, so they will never be acked -- replay the local timeline without
+						// them. a 'noop' rejection changed nothing there and has nothing to report
+						if (update.reason !== 'noop') toastOpError(update.reason)
+						set({ session: ODSM.Client.dropPendingOps(get().session, update.opIds, TSW.reducer) })
 						break
 					}
 					default:
@@ -213,7 +222,7 @@ export namespace Actions {
 			// the op was rejected against local state; surface a real failure to the user and drop it
 			// without sending. a 'noop' rejection changed nothing and has nothing to report
 			const rejection = res.error.data as TSW.Rejection
-			if (rejection.code !== 'noop') toastOpError(rejection)
+			if (rejection.code !== 'noop') toastOpError(rejection.code)
 			return
 		}
 		slice.setState({ session: res.session })

--- a/src/lib/odsm.test.ts
+++ b/src/lib/odsm.test.ts
@@ -417,17 +417,25 @@ describe('RejectedError', () => {
 		expect(res.session.pendingOps).toEqual([op('a', 2)])
 	})
 
-	it('server keeps a rejected op in history as a state no-op and returns the rejection', () => {
+	it('server discards a rejected op entirely and returns the rejection', () => {
 		const session = Server.initSession<Op, State>([1])
-		const baseState = session.state
 		const res = Server.applyOps(session, [op('a', -5)], gatedReducer)
 		expect(res.rejected).toBe(true)
 		if (!res.rejected) throw new Error('expected rejection')
-		expect(res.session.state).toBe(baseState) // no state change, same reference
-		expect(res.session.ops).toEqual([op('a', -5)]) // still recorded so it broadcasts/acks coherently
+		expect(res.session).toBe(session) // neither state nor history moves, so it is never broadcast
 		expect((res.error.data as Rejection).code).toBe('would-empty')
 	})
 
+	it('lets a rejected opId be dispatched again, since it never entered server history', () => {
+		const session = Server.initSession<Op, State>([1])
+		const rejected = Server.applyOps(session, [op('a', -5)], gatedReducer)
+		const retried = Server.applyOps(rejected.session, [op('a', 2)], gatedReducer)
+		expect(retried.rejected).toBe(false)
+		expect(retried.session.state).toEqual([1, 2])
+	})
+
+	// the server only broadcasts what it accepted, so this is the divergence path: keep the op in history
+	// so op ids stay aligned, and leave synced state alone
 	it('leaves syncedState untouched on an incoming rejected op but still records it', () => {
 		let session = Client.initSession<Op, State>([1])
 		const base = session.syncedState
@@ -467,6 +475,6 @@ describe('RejectedError', () => {
 
 		const rejectedRes = Server.applyOps(accepted.session, [op('b', -1)], effectReducer)
 		expect(rejectedRes.rejected).toBe(true) // rejected branch has no `sideEffects` field at all
-		expect(rejectedRes.session.ops.map(o => o.opId)).toEqual(['a', 'b']) // op still recorded
+		expect(rejectedRes.session.ops.map(o => o.opId)).toEqual(['a']) // rejected op left no trace
 	})
 })

--- a/src/lib/odsm.ts
+++ b/src/lib/odsm.ts
@@ -12,12 +12,12 @@ export type BaseOp = {
 
 // thrown by a reducer to reject the batch of ops it was handed. the batch produces no state change,
 // and the typed `data` payload describes why -- callers surface it and react (show it to the user,
-// return it to an rpc caller, log it). how a caller reacts depends on where the batch came from: a
-// client-authored batch is dropped entirely (never queued or sent) and its rejection is returned to
-// the dispatcher, while a batch arriving over the wire (or applied on the server) keeps the ops in
-// history for coherence but leaves state untouched. because the same op is replayed against several
-// base states (optimistic local, synced, server), a batch can be rejected against one and applied
-// against another. ops passed together are dependent, so rejection is all-or-nothing for the batch.
+// return it to an rpc caller, log it). a rejected batch never enters a timeline: a client-authored
+// batch is dropped before it is queued or sent, and a batch the server rejects touches neither its
+// state nor its history, so no replica ever sees it -- the originating client is told instead, and
+// drops its optimistic copy via dropPendingOps. because the same op is replayed against several base
+// states (optimistic local, synced, server), a batch can be rejected against one and applied against
+// another. ops passed together are dependent, so rejection is all-or-nothing for the batch.
 export class RejectedError<T = unknown> extends Error {
 	readonly data: T
 	constructor(data: T, options?: ErrorOptions & { message?: string }) {
@@ -62,7 +62,7 @@ export type Reducer<O extends BaseOp, S, SE extends SideEffectBase = undefined> 
 
 // result of applying a batch of ops. side effects are only reachable on the non-rejected branch: a
 // rejected batch changed no state and its accumulated side effects are discarded. the session is
-// present on both branches -- even a rejected batch advances op history for coherence.
+// present on both branches, but on the rejected branch it is the caller's session unchanged.
 export type Applied<Sess, SE extends SideEffectBase> =
 	| { rejected: false; session: Sess; sideEffects: SE[] }
 	| { rejected: true; session: Sess; error: RejectedError }
@@ -106,9 +106,9 @@ export namespace Server {
 		return { state, ops: [] }
 	}
 
-	// applies ops on the authoritative server. a rejected batch leaves state untouched but the ops are
-	// still recorded in history and broadcast, so originators can reconcile (roll back their optimistic
-	// copy) and late joiners stay coherent. the rejection / side effects are returned for the dispatcher.
+	// applies ops on the authoritative server. a rejected batch is discarded whole: neither state nor
+	// history moves, so it is never broadcast and late joiners never see it. the dispatcher reports the
+	// rejection to the originating client (which drops its optimistic copy) and nobody else.
 	export function applyOps<O extends BaseOp, S, SE extends SideEffectBase = undefined>(
 		session: Session<O, S>,
 		ops: O[],
@@ -123,11 +123,8 @@ export namespace Server {
 			if (existingIds.has(id)) throw new Error(`Duplicate opId already in session: ${id}`)
 		}
 		const reduced = runReducer(reducer, session.state, ops, session.ops)
-		const newSession: Session<O, S> = {
-			state: reduced.rejected ? session.state : reduced.state,
-			ops: OpHistory.concat(session.ops, ops),
-		}
-		return tag(newSession, reduced)
+		if (reduced.rejected) return tag(session, reduced)
+		return tag({ state: reduced.state, ops: OpHistory.concat(session.ops, ops) }, reduced)
 	}
 
 	export function resetSession<O extends BaseOp, S>(
@@ -191,7 +188,9 @@ export namespace Client {
 		}
 
 		const prevSyncedOps = session.syncedOps
-		// a rejected batch leaves synced state untouched but is still recorded in history
+		// the server only broadcasts what it accepted, so a rejection here means this replica has diverged
+		// from the authoritative one. the ops still enter history so op ids stay aligned, but synced state is
+		// left untouched and the caller reports the divergence
 		const reduced = runReducer(reducer, session.syncedState, ops, prevSyncedOps)
 		const newSyncedState = reduced.rejected ? session.syncedState : reduced.state
 		const newSyncedOps = [...prevSyncedOps, ...ops]
@@ -218,7 +217,8 @@ export namespace Client {
 
 	// processes server acks for ops this client dispatched. the server only sends back opIds for the
 	// originator's own ops -- since ops are fully deterministic, we advance the synced history by
-	// replaying our own pending copies instead of receiving them over the wire again
+	// replaying our own pending copies instead of receiving them over the wire again. an ack means the
+	// server accepted the op, so a rejection replaying it is divergence (see processIncomingOps)
 	export function processAckedOps<O extends BaseOp, S, SE extends SideEffectBase>(
 		session: Session<O, S>,
 		opIds: OpId[],
@@ -276,8 +276,8 @@ export namespace Client {
 		return { rejected: false, session: applied.session, sideEffects: applied.sideEffects, ackedOps, unknownOpIds }
 	}
 
-	// drops ops the server refused (permission denied, an invalid op, a dispatch that never landed) and replays
-	// what is left of the local timeline. a pending op that is never acked is not merely a lost edit: until
+	// drops ops the server refused (a `rejected` message, permission denied, a dispatch that never landed) and
+	// replays what is left of the local timeline. a pending op that is never acked is not merely a lost edit: until
 	// pendingOps drains, processIncomingOps/processAckedOps refuse to adopt the synced state, so every later
 	// server update -- including the saves that clear mutation state -- stops reaching localState entirely.
 	export function dropPendingOps<O extends BaseOp, S, SE extends SideEffectBase>(

--- a/src/models/shared-layer-list.ts
+++ b/src/models/shared-layer-list.ts
@@ -346,6 +346,13 @@ export type Update =
 		code: 'ack'
 		opId: string
 	}
+	| {
+		// the server refused the originator's own op: it changed nothing there and reached no other
+		// client, so the originator drops its optimistic copy. only ever sent to the originator
+		code: 'rejected'
+		opId: string
+		reason: Rejection['code']
+	}
 
 // the sequence id of the base queue the session
 const QueueSequenceId = z.number()

--- a/src/models/teamswaps.models.ts
+++ b/src/models/teamswaps.models.ts
@@ -661,4 +661,10 @@ export type UpdateForClient = {
 	// replays its pending copies
 	code: 'ack'
 	opIds: string[]
+} | {
+	// the server refused the originator's own batch: it changed nothing there and reached no other
+	// client, so the originator drops its optimistic copies. only ever sent to the originator
+	code: 'rejected'
+	opIds: string[]
+	reason: Rejection['code']
 }

--- a/src/models/user-presence.ts
+++ b/src/models/user-presence.ts
@@ -885,6 +885,13 @@ export type PresenceUpdate =
 		code: 'ack'
 		opIds: string[]
 	}
+	| {
+		// the server refused the originator's own batch: it changed nothing there and reached no other
+		// client, so the originator drops its optimistic copies. only ever sent to the originator
+		code: 'rejected'
+		opIds: string[]
+		reason: Rejection['code']
+	}
 
 // no presence instances older than this should be displayed
 export const DISPLAYED_AWAY_PRESENCE_WINDOW = 1000 * 60 * 10

--- a/src/systems/layer-queue.server.ts
+++ b/src/systems/layer-queue.server.ts
@@ -58,9 +58,13 @@ export type LayerQueueSlice = {
 	update$: Rx.ReplaySubject<[SS.LQStateUpdate, C.Db & C.ServerId]>
 
 	session: ODSM.Server.Session<SLL.Operation, SLL.State>
-	op$: Rx.Subject<{ op: SLL.Operation; sourceWsClientId?: string }>
+	op$: Rx.Subject<DispatchedOp>
 	updateLayerMtx: MutexInterface
 }
+
+// a dispatched op on its way to the watchOps streams. a rejected op changed nothing and is routed to the
+// originating client alone, so it can drop its optimistic copy -- no other client ever hears about it.
+export type DispatchedOp = { op: SLL.Operation; sourceWsClientId?: string; rejection?: SLL.Rejection }
 
 const module = initModule('layer-queue')
 let log!: CS.Logger
@@ -77,7 +81,7 @@ export function initLayerQueueSlice(ctx: C.ServerSliceCleanup & C.ServerId, serv
 		update$: new IsolatedReplaySubject(1),
 
 		session: ODSM.Server.initSession<SLL.Operation, SLL.State>(sllState),
-		op$: new IsolatedSubject<{ op: SLL.Operation; sourceWsClientId?: string }>(),
+		op$: new IsolatedSubject<DispatchedOp>(),
 		updateLayerMtx: new Mutex(),
 	}
 
@@ -601,12 +605,13 @@ export const router = {
 					ops: ctx.layerQueue.session.ops,
 				}
 				const updateForClient$: Rx.Observable<SLL.Update> = ctx.layerQueue.op$.pipe(
-					// the originator already has the op in its pending set -- ack with just the id
-					Rx.map(({ op, sourceWsClientId }): SLL.Update =>
-						sourceWsClientId !== undefined && sourceWsClientId === context.wsClientId
-							? { code: 'ack' as const, opId: op.opId }
-							: { code: 'op' as const, op }
-					),
+					Rx.map(({ op, sourceWsClientId, rejection }): SLL.Update | null => {
+						// the originator already has the op in its pending set -- ack (or reject) with just the id
+						const isOriginator = sourceWsClientId !== undefined && sourceWsClientId === context.wsClientId
+						if (rejection) return isOriginator ? { code: 'rejected' as const, opId: op.opId, reason: rejection.code } : null
+						return isOriginator ? { code: 'ack' as const, opId: op.opId } : { code: 'op' as const, op }
+					}),
+					Rx.filter((update): update is SLL.Update => update !== null),
 					Rx.startWith(initial),
 					// if we don't do this then the orpcWs breaks
 					Rx.observeOn(Rx.asyncScheduler),
@@ -914,13 +919,14 @@ export const dispatchOp = C.spanOp(
 	) => {
 		const applied = ODSM.Server.applyOps(ctx.layerQueue.session, [op], SLL.reducer)
 		ctx.layerQueue.session = applied.session
-		ctx.layerQueue.op$.next({ op, sourceWsClientId: opts?.sourceWsClientId })
 		if (applied.rejected) {
 			const rejection = applied.error.data as SLL.Rejection
+			ctx.layerQueue.op$.next({ op, sourceWsClientId: opts?.sourceWsClientId, rejection })
 			if (rejection.code === 'op-skipped') log.debug('layer queue op skipped: %s', op.op)
 			else log.error(new Error('layer queue op produced invalid state', { cause: applied.error }))
 			return
 		}
+		ctx.layerQueue.op$.next({ op, sourceWsClientId: opts?.sourceWsClientId })
 		// all side effect processing happens here in an uninterrupted async context
 		for (const se of applied.sideEffects) {
 			await handleSideEffect(ctx, op, se)

--- a/src/systems/teamswaps.server.ts
+++ b/src/systems/teamswaps.server.ts
@@ -93,10 +93,14 @@ async function resolveSourceName(
 
 type Session = ODSM.Server.Session<TSW.Op, TSW.State>
 
+// a dispatched batch on its way to the watchUpdates streams. a rejected batch changed nothing and is routed
+// to the originating client alone, so it can drop its optimistic copies -- no other client hears about it.
+export type DispatchedOps = { ops: TSW.Op[]; sourceWsClientId?: string; rejection?: TSW.Rejection }
+
 export type TeamswapContext = {
 	session: Session
 	// outgoing operations
-	op$: IsolatedSubject<{ ops: TSW.Op[]; sourceWsClientId?: string }>
+	op$: IsolatedSubject<DispatchedOps>
 	dispatchMtx: MutexInterface
 	teamswapExecutedAt: number | null
 	haveReadSavedSwapsFromDb: boolean
@@ -108,7 +112,7 @@ export function setup() {
 export function initContext(ctx: C.SquadServer & C.Db & C.ServerSliceCleanup) {
 	const context: TeamswapContext = {
 		session: ODSM.Server.initSession(TSW.initState()),
-		op$: new IsolatedSubject<{ ops: TSW.Op[]; sourceWsClientId?: string }>(),
+		op$: new IsolatedSubject<DispatchedOps>(),
 		dispatchMtx: new Mutex(),
 		teamswapExecutedAt: null,
 		haveReadSavedSwapsFromDb: false,
@@ -373,12 +377,14 @@ export const orpcRouter = {
 				ops: ctx.teamswaps.session.ops,
 			}
 			return ctx.teamswaps.op$.pipe(
-				// the originator already has the ops in its pending set -- ack with just the ids
-				Rx.map(({ ops, sourceWsClientId }): TSW.UpdateForClient =>
-					sourceWsClientId !== undefined && sourceWsClientId === context.wsClientId
-						? { code: 'ack', opIds: ops.map(op => op.opId) }
-						: { code: 'op', ops }
-				),
+				Rx.map(({ ops, sourceWsClientId, rejection }): TSW.UpdateForClient | null => {
+					// the originator already has the ops in its pending set -- ack (or reject) with just the ids
+					const isOriginator = sourceWsClientId !== undefined && sourceWsClientId === context.wsClientId
+					const opIds = ops.map(op => op.opId)
+					if (rejection) return isOriginator ? { code: 'rejected', opIds, reason: rejection.code } : null
+					return isOriginator ? { code: 'ack', opIds } : { code: 'op', ops }
+				}),
+				Rx.filter((update): update is TSW.UpdateForClient => update !== null),
 				Rx.startWith(init),
 			)
 		}).pipe(withAbortSignal(signal!))
@@ -413,7 +419,6 @@ const dispatchOp = C.spanOp(
 	async (ctx: C.Teamswap & C.ServerSlice & C.Db, ops: TSW.Op[], opts?: { sourceWsClientId?: string }) => {
 		const applied = ODSM.Server.applyOps(ctx.teamswaps.session, ops, TSW.reducer)
 		ctx.teamswaps.session = applied.session
-		ctx.teamswaps.op$.next({ ops, sourceWsClientId: opts?.sourceWsClientId })
 
 		const opErrors = new Map<string, unknown[]>()
 		const addError = (opId: string, error: unknown) => {
@@ -426,6 +431,7 @@ const dispatchOp = C.spanOp(
 		// failure to the rpc caller via opErrors and log it; a 'noop' rejection has nothing to report
 		if (applied.rejected) {
 			const rejection = applied.error.data as TSW.Rejection
+			ctx.teamswaps.op$.next({ ops, sourceWsClientId: opts?.sourceWsClientId, rejection })
 			if (rejection.code !== 'noop') {
 				if (rejection.code === 'err:unexpected') {
 					log.error('op error while executing operation: %s op: %o', rejection.code, rejection.op)
@@ -438,6 +444,7 @@ const dispatchOp = C.spanOp(
 			}
 			return opErrors
 		}
+		ctx.teamswaps.op$.next({ ops, sourceWsClientId: opts?.sourceWsClientId })
 
 		const nextOps: TSW.Op[] = []
 		for (const se of applied.sideEffects) {

--- a/src/systems/user-presence.client.ts
+++ b/src/systems/user-presence.client.ts
@@ -258,12 +258,18 @@ function handleIncomingPresenceUpdate(update: UP.PresenceUpdate) {
 		// presence has no client-side side effects, so the returned sideEffects are ignored
 		const res = ODSM.Client.processIncomingOps(Store.getState().session, update.ops, UP.reducer)
 		Store.setState({ session: res.session })
+		if (res.rejected) console.error('incoming presence ops diverged from the server:', res.error.data)
 	} else if (update.code === 'ack') {
 		// ops are deterministic, so the server only sends back the ids -- replay our pending copies
 		const session = Store.getState().session
 		const res = ODSM.Client.processAcks(session, update.opIds, UP.reducer)
 		if (res.unknownOpIds.length > 0) console.warn('received ack for unknown presence ops', res.unknownOpIds)
 		if (res.session !== session) Store.setState({ session: res.session })
+		if (res.rejected) console.error('acked presence ops diverged from the server:', res.error.data)
+	} else if (update.code === 'rejected') {
+		// the server refused our ops, so they will never be acked -- replay the local timeline without them
+		if (update.reason !== 'noop') console.error('presence ops rejected by the server:', update.reason)
+		Store.setState({ session: ODSM.Client.dropPendingOps(Store.getState().session, update.opIds, UP.reducer) })
 	}
 }
 

--- a/src/systems/user-presence.server.ts
+++ b/src/systems/user-presence.server.ts
@@ -19,10 +19,16 @@ import { z } from 'zod'
 // the two shared drafts a client can hold an editing session on
 export type DraftScope = 'queue' | 'layer-requests'
 
+// a dispatched batch on its way to the watchUpdates streams. a rejected batch changed nothing and is routed
+// to the originating client alone, so it can drop its optimistic copies -- no other client hears about it.
+// `echoToSource` sends the originator the full ops instead of an ack, for when the server corrected them
+// and its copies are no longer what the client replayed optimistically
+export type DispatchedOps = { ops: UP.Op[]; sourceWsClientId?: string; echoToSource?: boolean; rejection?: UP.Rejection }
+
 export type UserPresenceContext = {
 	userPresence: {
 		session: ODSM.Server.Session<UP.Op, UP.State>
-		op$: IsolatedSubject<{ ops: UP.Op[]; sourceWsClientId?: string }>
+		op$: IsolatedSubject<DispatchedOps>
 		abandoned$: IsolatedSubject<{ serverId: string; scope: DraftScope }>
 	}
 }
@@ -51,12 +57,15 @@ export const orpcRouter = {
 			ops: Obj.deepClone(globalUserPresence.session.ops),
 		}
 		const update$ = globalUserPresence.op$.pipe(
-			// the originator already has the ops in its pending set -- ack with just the ids
-			Rx.map(({ ops, sourceWsClientId }): UP.PresenceUpdate =>
-				sourceWsClientId !== undefined && sourceWsClientId === context.wsClientId
-					? { code: 'ack', opIds: ops.map(op => op.opId) }
-					: { code: 'op', ops }
-			),
+			Rx.map(({ ops, sourceWsClientId, echoToSource, rejection }): UP.PresenceUpdate | null => {
+				// the originator already has the ops in its pending set -- ack (or reject) with just the ids
+				const isOriginator = sourceWsClientId !== undefined && sourceWsClientId === context.wsClientId
+				const opIds = ops.map(op => op.opId)
+				if (rejection) return isOriginator ? { code: 'rejected', opIds, reason: rejection.code } : null
+				if (isOriginator && !echoToSource) return { code: 'ack', opIds }
+				return { code: 'op', ops }
+			}),
+			Rx.filter((update): update is UP.PresenceUpdate => update !== null),
 			Rx.startWith(initial),
 			withAbortSignal(signal!),
 		)
@@ -88,23 +97,19 @@ export const orpcRouter = {
 					}
 				}
 
-				// there some clients where the op time is in the future because their clocks are fucked up, so we need to update it to the current time.
-				// We need to create a new opId as well so that the client and server don't fall out of sync
+				// some clients have fucked up clocks and stamp the op in the future, so we correct it here. the opId is
+				// kept so the originator can still recognize its own op in the echo below and drop the pending copy
 				if (op.time > Date.now()) {
-					op = {
-						...op,
-						time: Date.now(),
-						opId: UP.createOpId(),
-					}
+					op = { ...op, time: Date.now() }
 					opsRewritten = true
 				}
 
 				ops.push(op)
 			}
 
-			// ack-by-id has the originator replay its own pending copies, which only works if the server
-			// applied them verbatim -- if we rewrote any op, fall back to echoing the full ops
-			dispatchOp(ops, opsRewritten ? undefined : { sourceWsClientId: ctx.wsClientId }).catch((error) => log.error(error))
+			// ack-by-id has the originator replay its own pending copies, which only works if the server applied
+			// them verbatim -- if we rewrote any op, echo the corrected ops to the originator too
+			dispatchOp(ops, { sourceWsClientId: ctx.wsClientId, echoToSource: opsRewritten }).catch((error) => log.error(error))
 			return { code: 'ok' as const }
 		}),
 }
@@ -137,16 +142,17 @@ function endsEditingDeliberately(op: UP.Op) {
 const dispatchOp = C.spanOp(
 	'dispatchOp',
 	{ module, extraText: (ops) => ops.map(o => o.code + (o.code === 'update-activity' ? ` (${o.update.code})` : '')).join(',') },
-	async (ops: UP.Op[], opts?: { sourceWsClientId?: string }) => {
+	async (ops: UP.Op[], opts?: Omit<DispatchedOps, 'ops' | 'rejection'>) => {
 		const editorsBefore = countEditingClients(globalUserPresence.session.state)
 		const applied = ODSM.Server.applyOps(globalUserPresence.session, ops, UP.reducer)
 		globalUserPresence.session = applied.session
-		globalUserPresence.op$.next({ ops, sourceWsClientId: opts?.sourceWsClientId })
 		if (applied.rejected) {
 			const rejection = applied.error.data as UP.Rejection
+			globalUserPresence.op$.next({ ops, ...opts, rejection })
 			if (rejection.code === 'op-error') log.error(rejection.error, 'presence op errored')
 			return
 		}
+		globalUserPresence.op$.next({ ops, ...opts })
 		if (!ops.some(endsEditingDeliberately)) {
 			const editorsAfter = countEditingClients(globalUserPresence.session.state)
 			for (const scope of DRAFT_SCOPES) {
@@ -263,7 +269,7 @@ export function setup() {
 
 	globalUserPresence = {
 		session: ODSM.Server.initSession(UP.initState()),
-		op$: new IsolatedSubject<{ ops: UP.Op[]; sourceWsClientId?: string }>(),
+		op$: new IsolatedSubject<DispatchedOps>(),
 		abandoned$: new IsolatedSubject<{ serverId: string; scope: DraftScope }>(),
 	}
 	CleanupSys.register(() => {


### PR DESCRIPTION
## What

On the server, a batch the reducer rejects no longer goes out to every client. It changed nothing on the server, so:

- `ODSM.Server.applyOps` now discards a rejected batch whole: neither state nor op history moves. No replica ever sees it, and the opId is free to be dispatched again.
- The originating client (and only it) gets a new `rejected` update carrying the rejection code, and drops its optimistic copies via `dropPendingOps`. Everyone else gets nothing.
- Applied to all three ODSM systems: shared layer list, teamswaps, user presence.

Previously a rejected op was broadcast to everyone and kept in every history, and the originator was told `ack` for something the server had refused. Convergence relied on each client independently re-rejecting the op on replay.

## Fallout

- Because the server now only ships what it accepted, a rejection while replaying an *incoming* op or an *ack* means that replica has diverged. Each client logs that as an error instead of silently skipping side effects.
- Teamswaps surfaces a server-side rejection through the same toast its local dispatch already used (`toastOpError` now takes the rejection code, which is all it ever read).
- Presence no longer rewrites the `opId` when it corrects a client's future-dated op. Keeping the id lets the originator recognize its own op in the echo and drain the pending copy; before this, those ops stayed pending forever and pinned `localState` to the moment of the rewrite.
- The `QUEUE_UPDATED` app event lists the ops in the span since the last save, read off the server's op history. Ops the server refused are no longer in that history, so the audit event now lists exactly the ops that produced the saved list.

No persisted data structures or config change.

## Testing

- `pnpm run check`, `pnpm run lint` clean
- `pnpm run test` - 757 passed (odsm unit tests updated for the new server semantics)
- Full Playwright suite - 28 passed, including `collaboration.test.ts`
- Live on the dev instance: swap-factions dispatch/ack round-trip, then save through the warning gate, with no divergence logged. http://localhost:3201 (log in via http://localhost:3200/check-auth?login=grey275 first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)